### PR TITLE
Allow running "serveFunctions" without package.json

### DIFF
--- a/src/finders.js
+++ b/src/finders.js
@@ -157,17 +157,27 @@ Please ensure "${moduleName}" is installed in the project.`);
   return Array.from(filePaths);
 }
 
-function findModuleDir(dir) {
-  let basedir = dir;
-  while (!fs.existsSync(path.join(basedir, "package.json"))) {
-    const newBasedir = path.dirname(basedir);
-    if (newBasedir === basedir) {
-      return null;
+function getAscendingFinder(name) {
+  const cache = {};
+  return function(dir) {
+    if (cache[dir]) {
+      return cache[dir];
     }
-    basedir = newBasedir;
-  }
-  return basedir;
+    let basedir = dir;
+    while (!fs.existsSync(path.join(basedir, name))) {
+      const newBasedir = path.dirname(basedir);
+      if (newBasedir === basedir) {
+        return null;
+      }
+      basedir = newBasedir;
+    }
+    cache[dir] = basedir;
+    return basedir;
+  };
 }
+
+const findModuleDir = getAscendingFinder("package.json");
+const findGitDir = getAscendingFinder(".git");
 
 function findHandler(functionPath) {
   if (fs.lstatSync(functionPath).isFile()) {
@@ -184,4 +194,4 @@ function findHandler(functionPath) {
   return handlerPath;
 }
 
-module.exports = { getDependencies, findModuleDir, findHandler };
+module.exports = { getDependencies, findModuleDir, findGitDir, findHandler };

--- a/src/serve.js
+++ b/src/serve.js
@@ -6,7 +6,7 @@ const queryString = require("querystring");
 const path = require("path");
 const getPort = require("get-port");
 const chokidar = require("chokidar");
-const { findModuleDir, findHandler } = require("./finders");
+const { findModuleDir, findGitDir, findHandler } = require("./finders");
 
 const defaultPort = 30001;
 
@@ -60,6 +60,12 @@ function getHandlerPath(functionPath) {
   return path.join(functionPath, `${path.basename(functionPath)}.js`);
 }
 
+function getFunctionModuleDir(functionPath) {
+  return (
+    findModuleDir(functionPath) || findGitDir(functionPath) || process.cwd()
+  );
+}
+
 function createHandler(dir, options) {
   const functions = {};
   fs.readdirSync(dir).forEach(file => {
@@ -74,12 +80,12 @@ function createHandler(dir, options) {
     if (path.extname(functionPath) === ".js") {
       functions[file.replace(/\.js$/, "")] = {
         functionPath,
-        moduleDir: findModuleDir(functionPath)
+        moduleDir: getFunctionModuleDir(functionPath)
       };
     } else if (fs.lstatSync(functionPath).isDirectory()) {
       functions[file] = {
         functionPath: handlerPath,
-        moduleDir: findModuleDir(functionPath)
+        moduleDir: getFunctionModuleDir(functionPath)
       };
     }
   });


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

Uses as the function "moduleDir" the first .git directory found by ascending the folder structure if "findModuleDirectory" returns false. If that still fails, uses "process.cwd()". Uses a shared memoized implementation for ascending directory finders.

This PR completes the work necessary in this repo to close #15.

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**

Manually tested.

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**

Allow running "serveFunctions" without a package.json
