### PR TITLE
Don't fail when encoding is missing

### DIFF
--- a/src/finders.js
+++ b/src/finders.js
@@ -73,12 +73,17 @@ function getDependencies(filename, basedir) {
           localFilesToProcess.push(resolved);
           return;
         } catch (e) {
-          throw new Error(`Could not find "${moduleName}" module in file: ${filename.replace(
-            path.dirname(basedir),
-            ""
-          )}. 
-          
-Please ensure "${moduleName}" is installed in the project.`);
+          if (moduleName === "encoding") { // node-fetch has an undeclared peer dependency on encoding
+            // We add an exception for this one module because it is very popular and people complain about it
+            debug(`WARNING missing optional dependency: ${moduleName}`);
+          } else {
+            throw new Error(`Could not find "${moduleName}" module in file: ${filename.replace(
+              path.dirname(basedir),
+              ""
+            )}.
+
+  Please ensure "${moduleName}" is installed in the project.`);
+          }
         }
       }
       throw e;


### PR DESCRIPTION
Node-fetch is a very popular module, yet it uses undeclared peer dependencies.  This breaks some of our assumptions about whether or not we can safely skip peer and optional dependencies automatically.  If a module does something weird, it breaks that assumption (e.g. node-fetch not declaring peer deps).

Since this has been the number one complaint since we launched bundled deps, wee can add a single exception for this.