### PR TITLE
Simplify Ava configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,11 +7,6 @@
     "files": [
       "src/**/*.test.js"
     ],
-    "cache": true,
-    "concurrency": 5,
-    "failFast": false,
-    "failWithoutAssertions": false,
-    "tap": false,
     "compileEnhancements": false,
     "babel": false
   },


### PR DESCRIPTION
**- Summary**

Most of our Ava configuration is not needed, as the values are the same as the default values with Ava.

Also the `concurrency` is set to `5` but this might be too much on some machines and too little on others (like mine). The default value (`os.cpus().length`) is more appropriate.

**- Description for the changelog**

Simplify the Ava configuration.