### PR TITLE
Group `require()` statements

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,7 +25,8 @@
         "args": "none",
         "ignoreRestSiblings": true
       }
-    ]
+    ],
+    "import/order": [2, { "newlines-between": "always" }]
   },
   "overrides": [
     {

--- a/bin.js
+++ b/bin.js
@@ -1,10 +1,12 @@
 #!/usr/bin/env node
+const path = require("path");
+
 const minimist = require("minimist");
 const cliOpts = require("cliclopts");
-const zipIt = require(".");
-const path = require("path")
 
 const pkg = require("./package.json");
+
+const zipIt = require(".");
 
 const allowedOptions = [
   {

--- a/src/finders.js
+++ b/src/finders.js
@@ -1,5 +1,6 @@
 const path = require("path");
 const fs = require("fs");
+
 const packList = require("npm-packlist");
 const precinct = require("precinct");
 const resolve = require("resolve");

--- a/src/zip.js
+++ b/src/zip.js
@@ -1,10 +1,12 @@
 const path = require("path");
 const fs = require("fs");
+
 const glob = require("glob");
 const archiver = require("archiver");
 const elfTools = require("elf-tools");
-const { getDependencies, findModuleDir, findHandler } = require("./finders");
 const pAll = require("p-all");
+
+const { getDependencies, findModuleDir, findHandler } = require("./finders");
 
 class Zip {
   constructor(path) {

--- a/src/zip.test.js
+++ b/src/zip.test.js
@@ -1,10 +1,12 @@
-const test = require("ava");
-const { filesForFunctionZip } = require("./zip");
-const tempy = require("tempy");
 const path = require("path");
+
+const tempy = require("tempy");
+const test = require("ava");
 const promisify = require("util.promisify");
 const cpx = require("cpx");
 const rimraf = promisify(require("rimraf"));
+
+const { filesForFunctionZip } = require("./zip");
 
 test.serial("find function files with a package.json", async t => {
   const tmp = tempy.directory();


### PR DESCRIPTION
**- Summary**

This ensures the `require()` statements are grouped: first the core modules, then the node modules, then the local imports. This is much easier to browse code when imports/require are on top of the file and grouped.

The `import/order` ESLint rule is added so that the grouping happens automatically on `eslint --fix`, i.e. we don't need to think about it. This happens on save if your IDE supports (VSCode does). 

**- Description for the changelog**

Group `require()` statements together.