### PR TITLE
Fix CI setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
 language: node_js
-node_js:
-  - "node"
-  - "lts/*"
-sudo: false
+node_js: "12"
+dist: bionic
+jobs:
+  include:
+    - os: windows
+    - os: osx
+    - node_js: "8.5.0"
+    - node_js: "12"
 cache: npm
-install:
-  - npm i
-script:
-  - node --version
-  - npm --version
-  - npm test
+after_success: npm run report

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "test:ava": "nyc --reporter=lcov ava --verbose && nyc report",
     "test:deps": "dependency-check ./package.json --unused --missing --no-dev --no-peer",
     "test:lint": "eslint src",
+    "report": "nyc report --reporter=text-lcov | coveralls",
     "version": "auto-changelog -p --template keepachangelog --breaking-pattern breaking && git add CHANGELOG.md"
   }
 }


### PR DESCRIPTION
**- Summary**

Fixes #8.

This fixes CI setup:
  - test on Node `8.5.0` and `12` instead of `10` and `12`, since our supported Node.js version is `8.5.0`.
  - test on Ubuntu `18.04` instead of `14.04`.
  - test on Windows and Mac OS as well, not only Linux.
  - `sudo: false` in `.travis.yml` [is deprecated](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration) and not used anymore.
  - printing `node --version` and `npm --version` does not have to be explicit. It's already done by Travis CI.
  - some syntax in `.travis.yml` could be simplified/removed thanks to default values (`npm i` and `npm test` are the default commands).

Also this adds test coverage with coveralls.

**- Description for the changelog**

Fix CI setup.