### PR TITLE
Add `files` field to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,12 @@
   "bin": {
     "zip-it-and-ship-it": "./src/bin.js"
   },
+  "files": [
+    "src/**/*.js",
+    "!src/helpers",
+    "!src/fixtures",
+    "!src/**/**.test.js"
+  ],
   "bugs": {
     "url": "https://github.com/netlify/zip-it-and-ship-it/issues"
   },


### PR DESCRIPTION
**- Summary**

We don't have any `files` field in `package.json` nor `.npmignore`, so our npm package publishes every file.
 
```
$ npm pack --dry-run
npm notice 
npm notice 📦  @netlify/zip-it-and-ship-it@0.3.1
npm notice === Tarball Contents === 
npm notice 0     src/fixtures/no-package-json-example/node_modules/.keep                     
npm notice 0     src/fixtures/package-json-example/node_modules/.keep                        
npm notice 1.1kB LICENSE                                                                     
npm notice 72B   src/fixtures/go-simple/test.go~                                             
npm notice 188B  src/fixtures/no-package-json-example/functions/a-function/a-function.js     
npm notice 234B  src/fixtures/package-json-example/functions/a-function.js                   
npm notice 37B   src/fixtures/no-package-json-example/functions/a-function/a-module.js       
npm notice 1.3kB bin.js                                                                      
npm notice 5.2kB src/finders.js                                                              
npm notice 113B  index.js                                                                    
npm notice 6.5kB src/fixtures/package-json-example/node_modules/cool-ascii-faces/index.js    
npm notice 5.1kB src/zip.js                                                                  
npm notice 1.2kB src/zip.test.js                                                             
npm notice 96B   src/fixtures/local-node-module/function.js~                                 
npm notice 3B    src/fixtures/node-module-error/function.js~                                 
npm notice 0     src/fixtures/node-module-error/node_modules/test/test.js~                   
npm notice 664B  .eslintrc.json                                                              
npm notice 3B    .prettierrc.json                                                            
npm notice 3.8kB package.json                                                                
npm notice 1.4kB src/fixtures/package-json-example/node_modules/cool-ascii-faces/package.json
npm notice 301B  src/fixtures/package-json-example/package.json                              
npm notice 2.6kB package.json~                                                               
npm notice 111B  src/fixtures/local-node-module/package.json~                                
npm notice 8.4kB CHANGELOG.md                                                                
npm notice 3.2kB CODE_OF_CONDUCT.md                                                          
npm notice 1.1kB CONTRIBUTING.md                                                             
npm notice 1.1kB .github/ISSUE_TEMPLATE.md                                                   
npm notice 949B  .github/PULL_REQUEST_TEMPLATE.md                                            
npm notice 3.6kB README.md                                                                   
npm notice 150B  .travis.yml                                                                 
npm notice === Tarball Details === 
npm notice name:          @netlify/zip-it-and-ship-it             
npm notice version:       0.3.1                                   
npm notice filename:      netlify-zip-it-and-ship-it-0.3.1.tgz    
npm notice package size:  17.2 kB                                 
npm notice unpacked size: 48.4 kB                                 
npm notice shasum:        2b46f4708facf2cd34ed4df75b1f5d7be40a1bfd
npm notice integrity:     sha512-w4XGnrEhb60YC[...]T9Mgl/hrBoWQw==
npm notice total files:   30                                      
npm notice 
netlify-zip-it-and-ship-it-0.3.1.tgz
```

Adding a `files` field reduces package size by 50% and make sure users are not importing files not meant to be published.

```
$ npm pack --dry-run
npm notice 
npm notice 📦  @netlify/zip-it-and-ship-it@0.3.1
npm notice === Tarball Contents === 
npm notice 1.1kB LICENSE       
npm notice 5.2kB src/finders.js
npm notice 113B  index.js      
npm notice 5.1kB src/zip.js    
npm notice 3.9kB package.json  
npm notice 8.4kB CHANGELOG.md  
npm notice 3.6kB README.md     
npm notice === Tarball Details === 
npm notice name:          @netlify/zip-it-and-ship-it             
npm notice version:       0.3.1                                   
npm notice filename:      netlify-zip-it-and-ship-it-0.3.1.tgz    
npm notice package size:  8.6 kB                                  
npm notice unpacked size: 27.3 kB                                 
npm notice shasum:        a65cdec24e30fe7a77ef266dcb40b37aa122c3a7
npm notice integrity:     sha512-iR3Z5cP/uCAdJ[...]7F1l01wGqZfOA==
npm notice total files:   7                                       
npm notice 
netlify-zip-it-and-ship-it-0.3.1.tgz
```

Note that `src/helpers` does not exist yet but is added by #48.

**- Description for the changelog**

Add `files` field to `package.json`