### PR TITLE
Allow requiring files outside of the function directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "archiver": "^3.0.0",
+    "common-path-prefix": "^2.0.0",
     "debug": "^4.1.1",
     "elf-tools": "^1.1.1",
     "glob": "^7.1.3",


### PR DESCRIPTION
**- Summary**

Fixes #38 and (maybe) #37.
There is an alternative solution at #39.

At the moment, `zip-it-and-ship-it` fails when requiring any files outside the function directory. 

This solves it by keeping the same directory structure inside the zip archive. The required files and node modules will be present in the archive, but not the non-required files and node modules. The lowest common ancestor directory is used, which makes it work whether there's a `package.json` or not.

Since the BuildBot relies on the entry point being the same filename as the archive (can you please confirm this?), the archive includes an entry point that simply forwards to the function main file using `module.exports = require("...")`. The archive is namespaced under a `src/` folder to ensure the entry point does not overwrite any files.

For example, when using the following source files:

```
one/
  one.js
  two.js (required by one/one.js)
  three.js (not required by one/one.js)
four.js
test/
  one.js (required by one/one.js)
  four.js (required by four.js)
```  

Results in `one.zip` containing:

```
src/
  one/
    one.js
    two.js
  test/
    one.js
one.js (this requires "./src/one/one.js")
```

and `two.zip` containing:

```
src/
  four.js
  test/
    four.js
four.js (this requires "./src/four.js")
```

**- Test plan**

There's some unit tests for it at #47.

I've also tried it against the [demo repository](https://github.com/netlify-labs/repro-zisi-file-resolution) and it fixes the issue.
 
**- Description for the changelog**

Allow requiring files outside of the function directory.