### PR TITLE
Improve older Node.js support

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "eslint-plugin-import": "^2.16.0",
     "eslint-plugin-node": "^8.0.1",
     "eslint-plugin-prettier": "^3.0.1",
-    "execa": "^2.0.4",
+    "execa": "^3.2.0",
     "gh-release": "^3.5.0",
     "mkdirp": "^0.5.1",
     "npm-run-all": "^4.1.5",
@@ -68,7 +68,7 @@
     "util.promisify": "^1.0.0"
   },
   "engines": {
-    "node": ">=8.12.0"
+    "node": ">=8.3.0"
   },
   "homepage": "https://github.com/netlify/zip-it-and-ship-it#README",
   "keywords": [


### PR DESCRIPTION
This improves our Node.js support from `>= 8.12.0` to `>= 8.3.0`.
:tada: 