### PR TITLE
Improve ESLint and Prettier configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ zip-it-and-ship-it*
 
 .nyc_output
 coverage
+.eslintcache

--- a/package.json
+++ b/package.json
@@ -93,8 +93,8 @@
     "prepublishOnly": "run-s pkg && git push && git push --tags && gh-release -a build/zip-it-and-ship-it_$(git describe --abbrev=0 --tags)_Linux-64bit.tar.gz,build/zip-it-and-ship-it_$(git describe --abbrev=0 --tags)_macOS-64bit.tar.gz",
     "test": "run-s test:* test:dev:*",
     "test-ci": "run-s test:* test:ci:*",
-    "test:lint": "eslint --fix \"src/**/*.js\" \"*.js\"",
-    "test:prettier": "prettier --write --loglevel warn \"src/**/*.js\" \"*.{js,md,yml,json}\"",
+    "test:lint": "eslint --ignore-path .gitignore --fix --cache --format=codeframe --max-warnings=0 \"src/**/*.js\" \"*.js\"",
+    "test:prettier": "prettier --ignore-path .gitignore --write --loglevel warn \"src/**/*.js\" \"*.{js,md,yml,json}\"",
     "test:dev:ava": "ava",
     "test:ci:ava": "nyc -r lcovonly -r text ava",
     "version": "auto-changelog -p --template keepachangelog --breaking-pattern breaking && git add CHANGELOG.md"


### PR DESCRIPTION
This speeds up ESLint by using caching.

This also print errors with the source code lines that failed.