### PR TITLE
Use Codecov for test coverage

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,43 +1,25 @@
-name: Continuous integration
+name: Build
 on: [push]
 env:
-  CI: true
+  CI: 'true'
 jobs:
   build:
     strategy:
       matrix:
         os: [macOS-latest]
-        node: [8.5.0, 10, 12]
+        node: [8.5.0, 13]
       fail-fast: false
-    runs-on: ${{matrix.os}}
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Git checkout
         uses: actions/checkout@v1
-      - name: Node.js ${{matrix.node}}
+      - name: Node.js ${{ matrix.node }}
         uses: actions/setup-node@v1
         with:
-          node-version: ${{matrix.node}}
+          node-version: ${{ matrix.node }}
       - name: Install dependencies
         run: npm install
       - name: Tests
         run: npm run test-ci
-      - name: Coveralls test coverage
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{secrets.github_token}}
-          parallel: true
-  coveralls:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Git checkout
-        uses: actions/checkout@v1
-      - name: Node.js 12
-        uses: actions/setup-node@v1
-        with:
-          node-version: 12
-      - name: Coveralls finished
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{secrets.github_token}}
-          parallel-finished: true
+      - name: Codecov test coverage
+        run: bash scripts/coverage.sh "${{ secrets.CODECOV_TOKEN }}" "${{ matrix.os }}" "${{ matrix.node }}"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # zip-it-and-ship-it
 
-[![Coverage Status](https://coveralls.io/repos/github/netlify/zip-it-and-ship-it/badge.svg)](https://coveralls.io/github/netlify/zip-it-and-ship-it)
 [![npm version](https://img.shields.io/npm/v/@netlify/zip-it-and-ship-it.svg)](https://npmjs.org/package/@netlify/zip-it-and-ship-it)
+[![Coverage Status](https://codecov.io/gh/netlify/zip-it-and-ship-it/branch/master/graph/badge.svg)](https://codecov.io/gh/netlify/zip-it-and-ship-it)
+[![Build](https://github.com/netlify/zip-it-and-ship-it/workflows/Build/badge.svg)](https://github.com/netlify/zip-it-and-ship-it/actions)
 [![Dependencies](https://david-dm.org/netlify/zip-it-and-ship-it/status.svg)](https://david-dm.org/netlify/zip-it-and-ship-it)
 [![Downloads](https://img.shields.io/npm/dm/@netlify/zip-it-and-ship-it.svg)](https://www.npmjs.com/package/@netlify/zip-it-and-ship-it)
 

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "test:lint": "eslint --ignore-path .gitignore --fix --cache --format=codeframe --max-warnings=0 \"src/**/*.js\" \"*.js\"",
     "test:prettier": "prettier --ignore-path .gitignore --write --loglevel warn \"src/**/*.js\" \"*.{js,md,yml,json}\"",
     "test:dev:ava": "ava",
-    "test:ci:ava": "nyc -r lcovonly -r text ava",
+    "test:ci:ava": "nyc -r lcovonly -r text -r json ava",
     "version": "auto-changelog -p --template keepachangelog --breaking-pattern breaking && git add CHANGELOG.md"
   }
 }

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Upload test coverage to Codecov
+
+token="$1"
+
+os="$2"
+os="${os/-latest/}"
+
+node="$3"
+node="node_${node//./_}"
+
+curl -s https://codecov.io/bash | \
+  bash -s -- -Z -y codecov.yml -f coverage/coverage-final.json -t "$token" -F "$os" -F "$node"


### PR DESCRIPTION
This uses Codecov for test coverage instead of Coveralls.
Coveralls has pending bugs with parallel test coverage which makes it not fit for multi-OS testing.