### PR TITLE
README: Fix installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This module handles zipping up lambda functions with their dependencies before d
 ## Installation
 
 ```bash
-npm install zip-it-and-ship-it
+npm install @netlify/zip-it-and-ship-it
 ```
 
 ## Usage


### PR DESCRIPTION
Hi there!

Tiny fix in the README for installing this package.

The install command should be `npm install @netlify/zip-it-and-ship-it` rather than `npm install zip-it-and-ship-it`.


Keep up the great work :heart: 