### PR TITLE
Check peerDependenciesMeta for Optional Dependencies

### DIFF
--- a/src/finders.js
+++ b/src/finders.js
@@ -117,6 +117,16 @@ function getDependencies(filename, basedir) {
     const currentModulePath = path.join(currentModule.path, '..')
     const packageJson = currentModule.packageJson
 
+    if (packageJson.peerDependenciesMeta) {
+      packageJson.optionalDependencies = packageJson.optionalDependencies || {}
+
+      for (const depKey in packageJson.peerDependenciesMeta) {
+        if (packageJson.peerDependenciesMeta[depKey].optional) {
+          packageJson.optionalDependencies[depKey] = packageJson.peerDependencies[depKey]
+        }
+      }
+    }
+
     if (modulePaths.has(currentModulePath)) {
       continue
     }

--- a/src/fixtures/node-module-peer-optional/function.js
+++ b/src/fixtures/node-module-peer-optional/function.js
@@ -1,0 +1,7 @@
+try {
+  // eslint-disable-next-line node/no-missing-require
+  require('consistent-ids')
+  // eslint-disable-next-line no-empty
+} catch (error) {}
+
+module.exports = true

--- a/src/fixtures/node-module-peer-optional/package.json
+++ b/src/fixtures/node-module-peer-optional/package.json
@@ -1,0 +1,11 @@
+{
+  "peerDependencies": {
+    "consistent-ids": "0.1.1"
+  },
+  "peerDependenciesMeta": {
+  	"consistent-ids": {
+  		"optional": true
+  	}
+  }
+}
+

--- a/src/main.test.js
+++ b/src/main.test.js
@@ -68,6 +68,10 @@ test.skip('Ignore missing whitelisted optional dependencies', async t => {
   await zipNode(t, 'node-module-optional-whitelist')
 })
 
+test.skip('Ignore missing optional peer dependencies', async t => {
+  await zipNode(t, 'node-module-peer-optional')
+})
+
 test('Can require local files', async t => {
   await zipNode(t, 'local-require')
 })


### PR DESCRIPTION
- Summary

This updates the optional dependencies check to also check peer dependencies meta

The Peer Dependencies Meta field was added to Yarn here:
[Yarn#6671](https://github.com/yarnpkg/yarn/pull/6671)

This is used by a number of packages to allow them to be `yarn -pnp` compatible, most notably [Knex](https://github.com/knex/knex). 
This feature was added in version [0.20.1](https://github.com/knex/knex/blob/master/CHANGELOG.md#0201---29-october-2019)

- Test plan

Unit tests are included but cannot be run as it cannot get to that branch of the code in a similar way as the `Ignore missing optional dependencies` test.

- Description for the changelog

Check Peer Dependencies Meta for Optional Dependencies