### PR TITLE
Fix Go Functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ $ zip-it-and-ship-it --help
 @netlify/zip-it-and-ship-it: Zip lambda functions and their dependencies for deployment
 
 Usage: zip-it-and-ship-it [source] [destination] {options}
-    --zip-go, -g          zip go binaries (default: false)
+    --skip-go             do not zip go binaries (default: true)
     --help, -h            show help
     --version, -v         print the version of the program
 ```

--- a/src/bin.js
+++ b/src/bin.js
@@ -7,12 +7,10 @@ const zipIt = require('..')
 
 // CLI entry point
 const runCli = async function() {
-  const { srcFolder, destFolder, zipGo } = parseArgs()
+  const { srcFolder, destFolder, zipGo = false, skipGo = !zipGo } = parseArgs()
 
   try {
-    const zipped = await zipIt.zipFunctions(srcFolder, destFolder, {
-      skipGo: !zipGo
-    })
+    const zipped = await zipIt.zipFunctions(srcFolder, destFolder, { skipGo })
     console.log(JSON.stringify(zipped, null, 2))
   } catch (error) {
     console.error(error.toString())
@@ -30,9 +28,13 @@ const parseArgs = function() {
 }
 
 const OPTIONS = {
+  'skip-go': {
+    boolean: true,
+    describe: 'Whether Go binaries should be copied as is or zipped'
+  },
+  // TODO: deprecated. Remove on the next major release
   'zip-go': {
     boolean: true,
-    default: false,
     describe: 'Whether Go binaries should be zipped or copied as is'
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -15,7 +15,7 @@ const pLstat = promisify(lstat)
 
 // Zip `srcFolder/*` (Node.js or Go files) to `destFolder/*.zip` so it can be
 // used by AWS Lambda
-const zipFunctions = async function(srcFolder, destFolder, { parallelLimit = 5, skipGo } = {}) {
+const zipFunctions = async function(srcFolder, destFolder, { parallelLimit = 5, skipGo = true } = {}) {
   const filenames = await listFilenames(srcFolder)
   const srcPaths = filenames.map(filename => resolve(srcFolder, filename))
 

--- a/src/main.test.js
+++ b/src/main.test.js
@@ -181,7 +181,7 @@ test('Copies already zipped files', async t => {
 })
 
 test('Zips Go function files', async t => {
-  const { files, tmpDir } = await zipFixture(t, 'go-simple')
+  const { files, tmpDir } = await zipFixture(t, 'go-simple', 1, { skipGo: false })
 
   t.true(files.every(({ runtime }) => runtime === 'go'))
 
@@ -203,7 +203,7 @@ test('Zips Go function files', async t => {
 })
 
 test('Can skip zipping Go function files', async t => {
-  const { files } = await zipFixture(t, 'go-simple', 1, { skipGo: true })
+  const { files } = await zipFixture(t, 'go-simple', 1)
 
   t.true(files.every(({ runtime }) => runtime === 'go'))
   t.true(


### PR DESCRIPTION
Go Functions can be bundled in two different modes:
  1. Copied as is
  2. Bundled in a `.zip` file

The `skipGo` option (called `zip-go` in the CLI with the inverse value) controls this.

We accidentally changed the default value of `skipGo` with the latest beta version of `zip-it-and-ship-it`. Go Functions are now bundled as `.zip` file (`2.`) instead of being copied as is (`1.`). Due to this, Go Functions are currently failing in production when Netlify Build beta is enabled (https://github.com/netlify/build/issues/1089). 

Part of the confusion was due to the fact that we are using:
  - the `skipGo` boolean option programmatically
  - the `--zip-go` boolean CLI flag, with an inverse value

This PR also introduces a `--skip-go` boolean CLI flag with the same value as the `skipGo` programmatic option. It deprecates the `--zip-go` CLI flag which should be removed in the next major release.