### PR TITLE
Fix `skipGo` and `zipGo` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ const zipped = [
 ```js
 {
   parallelLimit: 5, // Limit the number of concurrent zipping operations at a time
-  skipGo: false // Don't zip go functions, just move them to the destination path
+  zipGo: false // Don't zip go functions, just move them to the destination path
 }
 ```
 
@@ -101,7 +101,7 @@ $ zip-it-and-ship-it --help
 @netlify/zip-it-and-ship-it: Zip lambda functions and their dependencies for deployment
 
 Usage: zip-it-and-ship-it [source] [destination] {options}
-    --skip-go             do not zip go binaries (default: true)
+    --zip-go              zip go binaries (default: false)
     --help, -h            show help
     --version, -v         print the version of the program
 ```

--- a/src/bin.js
+++ b/src/bin.js
@@ -7,10 +7,10 @@ const zipIt = require('..')
 
 // CLI entry point
 const runCli = async function() {
-  const { srcFolder, destFolder, zipGo = false, skipGo = !zipGo } = parseArgs()
+  const { srcFolder, destFolder, zipGo } = parseArgs()
 
   try {
-    const zipped = await zipIt.zipFunctions(srcFolder, destFolder, { skipGo })
+    const zipped = await zipIt.zipFunctions(srcFolder, destFolder, { zipGo })
     console.log(JSON.stringify(zipped, null, 2))
   } catch (error) {
     console.error(error.toString())
@@ -28,13 +28,9 @@ const parseArgs = function() {
 }
 
 const OPTIONS = {
-  'skip-go': {
-    boolean: true,
-    describe: 'Whether Go binaries should be copied as is or zipped'
-  },
-  // TODO: deprecated. Remove on the next major release
   'zip-go': {
     boolean: true,
+    default: false,
     describe: 'Whether Go binaries should be zipped or copied as is'
   }
 }

--- a/src/main.test.js
+++ b/src/main.test.js
@@ -181,7 +181,7 @@ test('Copies already zipped files', async t => {
 })
 
 test('Zips Go function files', async t => {
-  const { files, tmpDir } = await zipFixture(t, 'go-simple', 1, { skipGo: false })
+  const { files, tmpDir } = await zipFixture(t, 'go-simple', 1, { zipGo: true })
 
   t.true(files.every(({ runtime }) => runtime === 'go'))
 


### PR DESCRIPTION
We currently have two options that do the same thing:
  - `skipGo` is only in Node.js and defaults to `true`
  - `zipGo` is only in the CLI and defaults to `false`. Its behavior is inverse to `skipGo`

To make it more consistent, #89 tried to enforce using `skipGo` only. However @mraerino pointed out that boolean option should ideally default to `false`. Therefore this PR switches to enforcing using `zipGo` only. `skipGo` is still kept for backward compatibility until the next major release.