### PR TITLE
Do not bundle TypeScript types

### DIFF
--- a/src/dependencies.js
+++ b/src/dependencies.js
@@ -84,7 +84,7 @@ const getModuleDependencies = async function(dependency, basedir, state, package
 const BACKSLASH_REGEXP = /\\/g
 
 const getModuleNameDependencies = async function(moduleName, basedir, state) {
-  if (EXCLUDED_MODULES.includes(moduleName)) {
+  if (isExludedModule(moduleName)) {
     return []
   }
 
@@ -107,6 +107,9 @@ const getModuleNameDependencies = async function(moduleName, basedir, state) {
   return [...publishedFiles, ...depsPaths]
 }
 
+const isExludedModule = function(moduleName) {
+  return EXCLUDED_MODULES.includes(moduleName) || moduleName.startsWith('@types/')
+}
 const EXCLUDED_MODULES = ['aws-sdk']
 
 // We use all the files published by the Node.js except some that are not needed

--- a/src/main.test.js
+++ b/src/main.test.js
@@ -47,6 +47,11 @@ test('Ignore some excluded node modules', async t => {
   t.false(await pathExists(`${tmpDir}/node_modules/aws-sdk`))
 })
 
+test('Ignore TypeScript types', async t => {
+  const { tmpDir } = await zipNode(t, 'node-module-typescript-types')
+  t.false(await pathExists(`${tmpDir}/src/node_modules/@types/node`))
+})
+
 test('Include most files from node modules', async t => {
   const { tmpDir } = await zipNode(t, 'node-module-included')
   const [mapExists, htmlExists] = await Promise.all([


### PR DESCRIPTION
Fixes #86.

This excludes TypeScript types from bundles since those are not needed in production code and only add to the size of the Function.