### PR TITLE
Add support for dynamically generated source files

### DIFF
--- a/src/fixtures/side-module/function.js
+++ b/src/fixtures/side-module/function.js
@@ -1,0 +1,1 @@
+module.exports = require('@prisma/client') && require('.prisma/client')

--- a/src/fixtures/side-module/node_modules/.prisma/client/index.js
+++ b/src/fixtures/side-module/node_modules/.prisma/client/index.js
@@ -1,0 +1,1 @@
+module.exports = true

--- a/src/fixtures/side-module/node_modules/@prisma/client/index.js
+++ b/src/fixtures/side-module/node_modules/@prisma/client/index.js
@@ -1,0 +1,1 @@
+module.exports = true

--- a/src/fixtures/side-module/node_modules/@prisma/client/package.json
+++ b/src/fixtures/side-module/node_modules/@prisma/client/package.json
@@ -1,0 +1,7 @@
+{
+  "description": "Prisma Client is an auto-generated and type-safe query builder for Node.js & TypeScript that's tailored to your data.",
+  "license": "Apache-2.0",
+  "main": "index.js",
+  "name": "@prisma/client",
+  "version": "2.0.0-beta.4"
+}

--- a/src/fixtures/side-module/package.json
+++ b/src/fixtures/side-module/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "local-node-module",
+  "version": "1.0.0",
+  "dependencies": {
+    "@prisma/client": "^2.0.0-beta.4"
+  }
+}

--- a/src/main.test.js
+++ b/src/main.test.js
@@ -42,6 +42,10 @@ test('Can require node modules nested files', async t => {
   await zipNode(t, 'node-module-path')
 })
 
+test('Can require dynamically generated node modules', async t => {
+  await zipNode(t, 'side-module')
+})
+
 test('Ignore some excluded node modules', async t => {
   const { tmpDir } = await zipNode(t, 'node-module-excluded')
   t.false(await pathExists(`${tmpDir}/src/node_modules/aws-sdk`))


### PR DESCRIPTION
Fixes #101.

Netlify Functions bundles their Node.js dependencies. By default, we bundle all published files of Node.js dependencies. However some Node.js modules (`@prisma/client`) generate source files on `postinstall` and put them in a parent directory (for example `node_modules/@prisma/client` creates `node_modules/.prisma/client`).

This PR adds support for this, with the specific `@prisma/client` use case.
This also adds tests for this.

@timsuchanek 