### PR TITLE
Fix bug in `resolve()`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -226,6 +226,15 @@
             "safe-buffer": "~5.1.1"
           }
         },
+        "resolve": {
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -2364,6 +2373,15 @@
             "to-fast-properties": "^2.0.0"
           }
         },
+        "resolve": {
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        },
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -4363,6 +4381,15 @@
             "to-fast-properties": "^2.0.0"
           }
         },
+        "resolve": {
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -6318,6 +6345,15 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
+        },
+        "resolve": {
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
         }
       }
     },
@@ -6477,6 +6513,15 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
+        },
+        "resolve": {
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
         }
       }
     },
@@ -6501,6 +6546,15 @@
           "dev": true,
           "requires": {
             "eslint-visitor-keys": "^1.1.0"
+          }
+        },
+        "resolve": {
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
           }
         },
         "semver": {
@@ -9168,6 +9222,17 @@
         "resolve": "^1.10.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        }
       }
     },
     "normalize-path": {
@@ -10578,9 +10643,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
-      "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
+      "version": "2.0.0-next.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.1.tgz",
+      "integrity": "sha512-ZGTmuLZAW++TDjgslfUMRZcv7kXHv8z0zwxvuRWOPjnqc56HVsn1lVaqsWOZeQ8MwiilPVJLrcPVKG909QsAfA==",
       "requires": {
         "path-parse": "^1.0.6"
       }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "pkg-dir": "^4.2.0",
     "precinct": "^6.2.0",
     "require-package-name": "^2.0.1",
-    "resolve": "^1.15.1",
+    "resolve": "^2.0.0-next.1",
     "unixify": "^1.0.0",
     "util.promisify": "^1.0.1",
     "yargs": "^15.3.1"

--- a/src/dependencies.js
+++ b/src/dependencies.js
@@ -3,10 +3,10 @@ const { dirname } = require('path')
 const glob = require('glob')
 const precinct = require('precinct')
 const requirePackageName = require('require-package-name')
-const resolve = require('resolve')
 const promisify = require('util.promisify')
 
-const pResolve = promisify(resolve)
+const { resolveLocation } = require('./resolve')
+
 const pGlob = promisify(glob)
 
 // Retrieve all the files recursively required by a Node.js file
@@ -64,7 +64,7 @@ const LOCAL_IMPORT_REGEXP = /^(\.|\/)/
 
 // When a file requires another one, we apply the top-level logic recursively
 const getLocalImportDependencies = async function(dependency, basedir, packageJson, state) {
-  const dependencyPath = await pResolve(dependency, { basedir })
+  const dependencyPath = await resolveLocation(dependency, basedir)
   const depsPath = await getFileDependencies(dependencyPath, packageJson, state)
   return [dependencyPath, ...depsPath]
 }
@@ -89,7 +89,7 @@ const getModuleNameDependencies = async function(moduleName, basedir, state) {
   }
 
   // Find the Node.js module directory path
-  const packagePath = await pResolve(`${moduleName}/package.json`, { basedir })
+  const packagePath = await resolveLocation(`${moduleName}/package.json`, basedir)
   const modulePath = dirname(packagePath)
 
   if (state.modulePaths.includes(modulePath)) {

--- a/src/resolve.js
+++ b/src/resolve.js
@@ -1,0 +1,19 @@
+const resolve = require('resolve')
+
+// Like `require.resolve()` but works with a custom base directory.
+// We need to use `new Promise()` due to a bug with `utils.promisify()` on
+// `resolve`:
+//   https://github.com/browserify/resolve/issues/151#issuecomment-368210310
+const resolveLocation = function(location, basedir) {
+  return new Promise((success, reject) => {
+    resolve(location, { basedir }, (error, resolvedLocation) => {
+      if (error) {
+        return reject(error)
+      }
+
+      success(resolvedLocation)
+    })
+  })
+}
+
+module.exports = { resolveLocation }


### PR DESCRIPTION
Fixes #104.

The `resolve` package uses a callback async signature. Due to [a bug in that package](https://github.com/browserify/resolve/issues/151#issuecomment-368210310), it does not work with `util.promisify`. Instead, `new Promise()` must be used.

This PR also upgrade `resolve` to the next major version, currently in beta, but that version probably solves more problems than it introduces.