### PR TITLE
Fix using symlinks in Functions

### DIFF
--- a/src/fixtures/symlinks/function/function.js
+++ b/src/fixtures/symlinks/function/function.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line node/no-missing-require
+module.exports = require('./file')

--- a/src/fixtures/symlinks/function/target.js
+++ b/src/fixtures/symlinks/function/target.js
@@ -1,0 +1,1 @@
+module.exports = true

--- a/src/node.js
+++ b/src/node.js
@@ -1,4 +1,4 @@
-const { lstat } = require('fs')
+const { stat } = require('fs')
 const { dirname, normalize, sep } = require('path')
 
 const commonPathPrefix = require('common-path-prefix')
@@ -11,7 +11,7 @@ const { startZip, addZipFile, addZipContent, endZip } = require('./archive')
 const { getDependencies } = require('./dependencies')
 
 const pGlob = promisify(glob)
-const pLstat = promisify(lstat)
+const pStat = promisify(stat)
 
 // Zip a Node.js function file
 const zipNodeJs = async function(srcPath, srcDir, destPath, filename, handler, stat) {
@@ -63,7 +63,7 @@ const addEntryFile = function(commonPrefix, archive, filename, handler) {
 
 const zipJsFile = async function(file, commonPrefix, archive) {
   const filename = normalizeFilePath(file, commonPrefix)
-  const stat = await pLstat(file)
+  const stat = await pStat(file)
   addZipFile(archive, file, filename, stat)
 }
 

--- a/src/resolve.js
+++ b/src/resolve.js
@@ -6,7 +6,7 @@ const resolve = require('resolve')
 //   https://github.com/browserify/resolve/issues/151#issuecomment-368210310
 const resolveLocation = function(location, basedir) {
   return new Promise((success, reject) => {
-    resolve(location, { basedir }, (error, resolvedLocation) => {
+    resolve(location, { basedir, preserveSymlinks: true }, (error, resolvedLocation) => {
       if (error) {
         return reject(error)
       }


### PR DESCRIPTION
Fixes #106.

Symlinks in Functions do not always work due to two reasons:
  - Zipping does not always keep them as symlinks. Instead we should archive the symlink target file, not the symlink itself.
  - When there is no `package.json`, the absolute path is used to target files inside the zip archive. `resolve()` resolves symlinks with `realpath`, but this creates issues with absolute paths not having the same root directory.

This PR fixes those problems and adds a regression test.

This PR also fixes CI tests on macOS.