### PR TITLE
Fix typo in variable name

### DIFF
--- a/src/dependencies.js
+++ b/src/dependencies.js
@@ -84,7 +84,7 @@ const getModuleDependencies = async function(dependency, basedir, state, package
 const BACKSLASH_REGEXP = /\\/g
 
 const getModuleNameDependencies = async function(moduleName, basedir, state) {
-  if (isExludedModule(moduleName)) {
+  if (isExcludedModule(moduleName)) {
     return []
   }
 
@@ -108,7 +108,7 @@ const getModuleNameDependencies = async function(moduleName, basedir, state) {
   return [...publishedFiles, ...sideFiles, ...depsPaths]
 }
 
-const isExludedModule = function(moduleName) {
+const isExcludedModule = function(moduleName) {
   return EXCLUDED_MODULES.includes(moduleName) || moduleName.startsWith('@types/')
 }
 const EXCLUDED_MODULES = ['aws-sdk']


### PR DESCRIPTION
This fixes a typo in a variable name.