### PR TITLE
Fix parsing invalid `require()`

### DIFF
--- a/src/dependencies.js
+++ b/src/dependencies.js
@@ -74,6 +74,12 @@ const getLocalImportDependencies = async function(dependency, basedir, packageJs
 const getModuleDependencies = async function(dependency, basedir, state, packageJson) {
   const moduleName = requirePackageName(dependency.replace(BACKSLASH_REGEXP, '/'))
 
+  // Happens when doing require("@scope") (not "@scope/name") or other oddities
+  // Ignore those.
+  if (moduleName === null) {
+    return []
+  }
+
   try {
     return await getModuleNameDependencies(moduleName, basedir, state)
   } catch (error) {

--- a/src/fixtures/invalid-require/function.js
+++ b/src/fixtures/invalid-require/function.js
@@ -1,0 +1,7 @@
+// eslint-disable-next-line no-constant-condition
+if (false) {
+  // eslint-disable-next-line node/no-missing-require
+  require('@scope')
+}
+
+module.exports = true

--- a/src/main.test.js
+++ b/src/main.test.js
@@ -108,6 +108,10 @@ test('Throws on missing non-optional peer dependencies', async t => {
   await t.throwsAsync(zipNode(t, 'node-module-peer-not-optional'))
 })
 
+test('Ignore invalid require()', async t => {
+  await zipNode(t, 'invalid-require')
+})
+
 test('Can require local files', async t => {
   await zipNode(t, 'local-require')
 })


### PR DESCRIPTION
Netlify Functions that do weird/invalid `require()` like `require('@scope')` currently fail with:

```
Cannot read property 'startsWith' of null 
```

[Bugsnag error](https://app.bugsnag.com/netlify/netlify-build/errors/5ed069ee275ecb0017438a5a).

This PR fixes this, and add a test for it.