### PR TITLE
Rename `handler` variable to `mainFile`

### DIFF
--- a/src/dependencies.js
+++ b/src/dependencies.js
@@ -10,15 +10,15 @@ const { resolvePathPreserveSymlinks, resolvePackage } = require('./resolve')
 const pGlob = promisify(glob)
 
 // Retrieve all the files recursively required by a Node.js file
-const getDependencies = async function(handler, packageRoot) {
+const getDependencies = async function(mainFile, packageRoot) {
   const packageJson = getPackageJson(packageRoot)
 
   const state = { localFiles: [], modulePaths: [] }
 
   try {
-    return await getFileDependencies(handler, packageJson, state)
+    return await getFileDependencies(mainFile, packageJson, state)
   } catch (error) {
-    error.message = `In file "${handler}": ${error.message}`
+    error.message = `In file "${mainFile}": ${error.message}`
     throw error
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -35,9 +35,9 @@ const listFilenames = async function(srcFolder) {
 }
 
 const zipFunction = async function(srcPath, destFolder, { skipGo = true, zipGo = !skipGo } = {}) {
-  const { filename, extension, srcDir, stat, handler, destPath, destCopyPath } = await statFile(srcPath, destFolder)
+  const { filename, extension, srcDir, stat, mainFile, destPath, destCopyPath } = await statFile(srcPath, destFolder)
 
-  if (filename === 'node_modules' || (stat.isDirectory() && handler === undefined)) {
+  if (filename === 'node_modules' || (stat.isDirectory() && mainFile === undefined)) {
     return
   }
 
@@ -47,7 +47,7 @@ const zipFunction = async function(srcPath, destFolder, { skipGo = true, zipGo =
   }
 
   if (extension === '.js' || stat.isDirectory()) {
-    await zipNodeJs(srcPath, srcDir, destPath, filename, handler, stat)
+    await zipNodeJs(srcPath, srcDir, destPath, filename, mainFile, stat)
     return { path: destPath, runtime: 'js' }
   }
 
@@ -68,7 +68,7 @@ const statFile = async function(srcPath, destFolder) {
   const filename = basename(srcPath)
   const extension = extname(srcPath)
   const stat = await pLstat(srcPath)
-  const handler = await getHandler(srcPath, filename, stat)
+  const mainFile = await getMainFile(srcPath, filename, stat)
   const srcDir = stat.isDirectory() ? srcPath : dirname(srcPath)
 
   await makeDir(destFolder)
@@ -80,7 +80,7 @@ const statFile = async function(srcPath, destFolder) {
     extension,
     srcDir,
     stat,
-    handler,
+    mainFile,
     destCopyPath,
     destPath
   }
@@ -88,19 +88,19 @@ const statFile = async function(srcPath, destFolder) {
 
 // Each `srcPath` can also be a directory with an `index.js` file or a file
 // using the same filename as its directory
-const getHandler = async function(srcPath, filename, stat) {
+const getMainFile = async function(srcPath, filename, stat) {
   if (!stat.isDirectory()) {
     return srcPath
   }
 
-  const namedHandler = join(srcPath, `${filename}.js`)
-  if (await pathExists(namedHandler)) {
-    return namedHandler
+  const namedMainFile = join(srcPath, `${filename}.js`)
+  if (await pathExists(namedMainFile)) {
+    return namedMainFile
   }
 
-  const indexHandler = join(srcPath, 'index.js')
-  if (await pathExists(indexHandler)) {
-    return indexHandler
+  const indexMainFile = join(srcPath, 'index.js')
+  if (await pathExists(indexMainFile)) {
+    return indexMainFile
   }
 }
 

--- a/src/main.test.js
+++ b/src/main.test.js
@@ -144,7 +144,7 @@ if (platform !== 'win32') {
   })
 }
 
-test('Can target a directory with a handler with the same name', async t => {
+test('Can target a directory with a main file with the same name', async t => {
   await zipNode(t, 'directory-handler')
 })
 
@@ -189,7 +189,7 @@ test('Do not consider node_modules as a function file', async t => {
   await zipNode(t, 'ignore-node-modules')
 })
 
-test('Ignore non-handler directories', async t => {
+test('Ignore directories without a main file', async t => {
   await zipNode(t, 'ignore-directories')
 })
 


### PR DESCRIPTION
This renames an internal variable from `handler` to `mainFile` since this is more accurate.

This is refactoring only.