### PR TITLE
Move `make-dir` statement

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -41,6 +41,8 @@ const zipFunction = async function(srcPath, destFolder, { skipGo = true, zipGo =
     return
   }
 
+  await makeDir(destFolder)
+
   if (extension === '.zip') {
     await cpFile(srcPath, destCopyPath)
     return { path: destCopyPath, runtime: 'js' }
@@ -71,7 +73,6 @@ const statFile = async function(srcPath, destFolder) {
   const handler = await getHandler(srcPath, filename, stat)
   const srcDir = stat.isDirectory() ? srcPath : dirname(srcPath)
 
-  await makeDir(destFolder)
   const destCopyPath = join(destFolder, filename)
   const destPath = join(destFolder, `${filename.replace(FUNCTION_EXTENSIONS, '')}.zip`)
 


### PR DESCRIPTION
We create the destination directory when it does not exist.

However, this does not need to be done when no Function will be bundled, e.g. when the directory is not a Function directory such as `node_modules` directories (which are skipped).

This PR moves the `make-dir` statement creating this directory a little later in the logic, to prevent unnecessary calls.