### PR TITLE
Move a line of code

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -16,11 +16,12 @@ const pStat = promisify(stat)
 
 // Zip a Node.js function file
 const zipNodeJs = async function(srcPath, srcDir, destPath, filename, mainFile, stat) {
-  const { archive, output } = startZip(destPath)
-
   const packageRoot = await pkgDir(srcDir)
 
   const files = await filesForFunctionZip(srcPath, filename, mainFile, packageRoot, stat)
+
+  const { archive, output } = startZip(destPath)
+
   const dirnames = files.map(dirname)
   const commonPrefix = commonPathPrefix(dirnames)
 


### PR DESCRIPTION
This moves a line of code a little below.

Starting the Zip archive can be delayed a little down the code, as a performance optimization, in case they are errors while crawling for Node.js files.