### PR TITLE
Fix `packagePath` being `undefined`

### DIFF
--- a/src/dependencies.js
+++ b/src/dependencies.js
@@ -136,6 +136,11 @@ const getModuleNameDependencies = async function(moduleName, basedir, state) {
 
   // Find the Node.js module directory path
   const packagePath = await resolvePackage(moduleName, basedir)
+
+  if (packagePath === undefined) {
+    return []
+  }
+
   const modulePath = dirname(packagePath)
 
   if (state.modulePaths.includes(modulePath)) {


### PR DESCRIPTION
Fixes #129.

It looks like like the `resolve` library sometimes resolves paths to `undefined` instead of `string`. This creates the following bug:

```
In file "/opt/build/repo/functions/test/test.js": The "path" argument must be of type string. Received undefined 
    internal/validators.js:117:11 validateString
    path.js:1128:5 dirname
    node_modules/@netlify/zip-it-and-ship-it/src/dependencies.js:107:22 getModuleNameDependencies
    node_modules/@netlify/zip-it-and-ship-it/src/dependencies.js:84:12 async getModuleDependencies
    node_modules/@netlify/zip-it-and-ship-it/src/dependencies.js:47:21 async getFileDependencies
    node_modules/@netlify/zip-it-and-ship-it/src/dependencies.js:19:12 async getDependencies
    node_modules/@netlify/zip-it-and-ship-it/src/node.js:38:33 async filesForFunctionZip
    node_modules/@netlify/zip-it-and-ship-it/src/node.js:23:17 async zipNodeJs
```

This PR fixes this use case by handling it.

Adding a test is unfortunately difficult because I'm unclear under which conditions the `resolve` library has this behavior (which might be a bug in that library).