### PR TITLE
Add `archiver` to skipped dependencies upgrades

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -6,6 +6,7 @@
   automerge: false,
   ignoreDeps: [
     // Those cannot be upgraded until we drop support for Node 8
+    'archiver',
     'ava',
     'cp-file',
     'eslint',


### PR DESCRIPTION
`archiver` cannot be upgraded because v5 lacks support for Node 8.