### PR TITLE
Ensure Zip archives contents are deterministic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4770,10 +4770,13 @@
       "dev": true
     },
     "get-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-      "dev": true
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+      "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+      "dev": true,
+      "requires": {
+        "pump": "^3.0.0"
+      }
     },
     "get-value": {
       "version": "2.0.6",
@@ -4978,6 +4981,14 @@
             "timed-out": "^4.0.0",
             "unzip-response": "^2.0.1",
             "url-parse-lax": "^1.0.0"
+          },
+          "dependencies": {
+            "get-stream": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+              "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+              "dev": true
+            }
           }
         },
         "inquirer": {
@@ -9141,6 +9152,14 @@
             "p-finally": "^1.0.0",
             "signal-exit": "^3.0.0",
             "strip-eof": "^1.0.0"
+          },
+          "dependencies": {
+            "get-stream": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+              "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+              "dev": true
+            }
           }
         },
         "is-stream": {

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.1.4",
     "execa": "^3.4.0",
+    "get-stream": "^5.1.0",
     "gh-release": "^3.5.0",
     "husky": "^4.2.5",
     "npm-run-all": "^4.1.5",

--- a/src/dependencies.js
+++ b/src/dependencies.js
@@ -18,7 +18,9 @@ const listNodeFiles = async function(srcPath, filename, mainFile, srcDir, stat) 
   const [treeFiles, depFiles] = await Promise.all([getTreeFiles(srcPath, stat), getDependencies(mainFile, srcDir)])
   const files = [...treeFiles, ...depFiles].map(normalize)
   const uniqueFiles = [...new Set(files)]
-  const filteredFiles = uniqueFiles.filter(isNotJunk)
+
+  // We sort so that the archive's checksum is deterministic.
+  const filteredFiles = uniqueFiles.filter(isNotJunk).sort()
   return filteredFiles
 }
 

--- a/src/helpers/sha.js
+++ b/src/helpers/sha.js
@@ -1,0 +1,16 @@
+const { createHash } = require('crypto')
+const { createReadStream } = require('fs')
+
+const getStream = require('get-stream')
+
+// Retrieve the SHA1 checksum of a file.
+// Does it in streaming mode, for best performance.
+const computeSha1 = async function(filePath) {
+  const fileStream = createReadStream(filePath)
+  const hashStream = createHash('sha1')
+  hashStream.setEncoding('hex')
+  const sha1Checksum = await getStream(fileStream.pipe(hashStream))
+  return sha1Checksum
+}
+
+module.exports = { computeSha1 }


### PR DESCRIPTION
The order in which files are added to a Zip archive does not change how they are extracted. However, this changes the archive's checksum.

Producing non-deterministic Zip archives prevents caching them based on their checksum. This is currently a problem in our API (https://github.com/netlify/ansible/issues/4282).

This PR ensures files are added in a deterministic order to the Zip archive by:
  - Sorting them by file path
  - Ensuring any parallelism does not make the archive non-deterministic

This also adds a regression test.