### PR TITLE
Add `yargs` to `renovate.json5`

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -17,7 +17,8 @@
         'get-stream',
         'locate-path',
         'p-map',
-        'prettier'
+        'prettier',
+        'yargs',
       ],
       major: {
         enabled: false


### PR DESCRIPTION
This adds `yargs` to the list of dependencies that do not support Node 8