### PR TITLE
Add `pkg-dir` to `renovate.json5`

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -18,6 +18,7 @@
         'get-stream',
         'locate-path',
         'p-map',
+        'pkg-dir',
         'prettier',
         'yargs',
       ],


### PR DESCRIPTION
`pkg-dir@5` is not compatible with Node 8