### PR TITLE
github tools: fix fossa workflow file

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -13,31 +13,19 @@ jobs:
   fossa:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Fossa init
-      run: |- 
-        curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash
-        fossa init
-        echo ::set-env name=line_number::$(grep -n "project" .fossa.yml | cut -f1 -d:)
-    - name: Configuration
-      run: |-
-       sed -i "${line_number}s|.*|  project: git@github.com:${GITHUB_REPOSITORY}.git|" .fossa.yml
-    - name: Set env for go-simple
-      run: |-
-         echo ::set-env name=go_simple_line_number::$(grep -m 1 -n "go-simple" .fossa.yml | cut -f1 -d:)
-         echo ::set-env name=go_simple_last_line_number::$(grep -n "go-simple" .fossa.yml | tail -1 | cut -f1 -d:)
-    - name: Remove go-simple module
-      run: sed -i "${go_simple_line_number},${go_simple_last_line_number}d" .fossa.yml
-    - name: Set env for fixtures/list
-      run: |-
-         echo ::set-env name=fixtures_list_line_number::$(grep -m 1 -n "fixtures/list" .fossa.yml | cut -f1 -d:)
-         echo ::set-env name=fixtures_list_last_line_number::$(grep -n "fixtures/list" .fossa.yml | tail -1 | cut -f1 -d:)
-    - name: Remove fixtures/list module
-      run: sed -i "${fixtures_list_line_number},${fixtures_list_last_line_number}d" .fossa.yml
-    - name: View config file
-      run: cat .fossa.yml
-    - name: Upload dependencies
-      run: fossa analyze --debug
-      env:
-        FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Fossa init
+        run: |-
+          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash
+          fossa init
+      - name: Set env
+        run: echo "line_number=$(grep -n "project" .fossa.yml | cut -f1 -d:)" >> $GITHUB_ENV
+      - name: Configuration
+        run: |-
+          sed -i "${line_number}s|.*|  project: git@github.com:${GITHUB_REPOSITORY}.git|" .fossa.yml
+          cat .fossa.yml
+      - name: Upload dependencies
+        run: fossa analyze --debug
+        env:
+          FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}


### PR DESCRIPTION
Updates github actions fossa workflow to use environment files instead of deprecated set-env command.