### PR TITLE
Fix tests on Windows

### DIFF
--- a/src/bin.test.js
+++ b/src/bin.test.js
@@ -11,20 +11,20 @@ const { FIXTURES_DIR } = require('./helpers/main.js')
 const BINARY_PATH = `${__dirname}/bin.js`
 
 test('CLI | --version', async t => {
-  const { stdout } = await execa.command(`${BINARY_PATH} --version`)
+  const { stdout } = await execa(BINARY_PATH, ['--version'])
 
   t.is(stdout, version)
 })
 
 test('CLI | --help', async t => {
-  const { stdout } = await execa.command(`${BINARY_PATH} --help`)
+  const { stdout } = await execa(BINARY_PATH, ['--help'])
 
   t.true(stdout.includes('Options:'))
 })
 
 test('CLI | Normal execution', async t => {
   const tmpDir = await tmpName({ prefix: 'zip-it-test' })
-  const { stdout } = await execa.command(`${BINARY_PATH} ${join(FIXTURES_DIR, 'simple')} ${tmpDir}`)
+  const { stdout } = await execa(BINARY_PATH, [join(FIXTURES_DIR, 'simple'), tmpDir])
   const zipped = JSON.parse(stdout)
 
   t.is(zipped.length, 1)
@@ -32,25 +32,21 @@ test('CLI | Normal execution', async t => {
 })
 
 test('CLI | Error execution', async t => {
-  const { exitCode, stderr } = await execa.command(`${BINARY_PATH} doesNotExist destFolder`, { reject: false })
+  const { exitCode, stderr } = await execa(BINARY_PATH, ['doesNotExist', 'destFolder'], { reject: false })
 
   t.is(exitCode, 1)
   t.true(stderr !== '')
 })
 
 test('CLI | Should throw on missing srcFolder', async t => {
-  const { exitCode, stderr } = await execa.command(BINARY_PATH, {
-    reject: false
-  })
+  const { exitCode, stderr } = await execa(BINARY_PATH, { reject: false })
 
   t.is(exitCode, 1)
   t.true(stderr.includes('Not enough non-option arguments'))
 })
 
 test('CLI | Should throw on missing destFolder', async t => {
-  const { exitCode, stderr } = await execa.command(`${BINARY_PATH} srcFolder`, {
-    reject: false
-  })
+  const { exitCode, stderr } = await execa(BINARY_PATH, ['srcFolder'], { reject: false })
 
   t.is(exitCode, 1)
   t.true(stderr.includes('Not enough non-option arguments'))


### PR DESCRIPTION
When the root directory where this library is closed contains spaces in its file path, some tests are failing. This is especially common on Windows and was reported in https://github.com/sindresorhus/execa/issues/444.

This PR fixes this by switching from `execa.command()` to `execa()`.