### PR TITLE
Improve error message

### DIFF
--- a/src/dependencies.js
+++ b/src/dependencies.js
@@ -52,7 +52,7 @@ const getDependencies = async function(mainFile, srcDir) {
   try {
     return await getFileDependencies(mainFile, packageJson, state)
   } catch (error) {
-    error.message = `In file "${mainFile}": ${error.message}`
+    error.message = `In file "${mainFile}"\n${error.message}`
     throw error
   }
 }


### PR DESCRIPTION
This slightly improves an error message.

`mainFile` is the absolute file path, which leads this error message to be too long unless a newline is used.