### PR TITLE
Add metadata file to binary zip files.

### DIFF
--- a/src/binary.js
+++ b/src/binary.js
@@ -26,7 +26,7 @@ const RUNTIMES = {
 const zipBinary = async function(srcPath, destPath, filename, stat, runtime) {
   const { archive, output } = startZip(destPath)
   addZipFile(archive, srcPath, filename, stat)
-  addZipContent(archive, `runtime=${runtime}`, "netlify-toolchain")
+  addZipContent(archive, `runtime=${runtime}`, 'netlify-toolchain')
   await endZip(archive, output)
 }
 

--- a/src/binary.js
+++ b/src/binary.js
@@ -3,7 +3,7 @@ const { promisify } = require('util')
 
 const { detect, Runtime } = require('elf-cam')
 
-const { startZip, addZipFile, endZip } = require('./archive')
+const { startZip, addZipFile, addZipContent, endZip } = require('./archive')
 
 const pReadFile = promisify(readFile)
 
@@ -23,9 +23,10 @@ const RUNTIMES = {
 }
 
 // Zip a binary function file
-const zipBinary = async function(srcPath, destPath, filename, stat) {
+const zipBinary = async function(srcPath, destPath, filename, stat, runtime) {
   const { archive, output } = startZip(destPath)
   addZipFile(archive, srcPath, filename, stat)
+  addZipContent(archive, `runtime=${runtime}`, "netlify-toolchain")
   await endZip(archive, output)
 }
 

--- a/src/binary.js
+++ b/src/binary.js
@@ -26,7 +26,7 @@ const RUNTIMES = {
 const zipBinary = async function(srcPath, destPath, filename, stat, runtime) {
   const { archive, output } = startZip(destPath)
   addZipFile(archive, srcPath, filename, stat)
-  addZipContent(archive, `runtime=${runtime}`, 'netlify-toolchain')
+  addZipContent(archive, JSON.stringify({ runtime }), 'netlify-toolchain')
   await endZip(archive, output)
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -52,7 +52,7 @@ const zipFunction = async function(srcPath, destFolder, { skipGo = true, zipGo =
   if (runtime === 'go') {
     if (zipGo) {
       const destPath = join(destFolder, `${filename}.zip`)
-      await zipBinary(srcPath, destPath, filename, stat)
+      await zipBinary(srcPath, destPath, filename, stat, runtime)
       return { path: destPath, runtime }
     } else {
       const destPath = join(destFolder, filename)
@@ -68,7 +68,7 @@ const zipFunction = async function(srcPath, destFolder, { skipGo = true, zipGo =
     // Lambda runtime, and that's the name that AWS
     // expects for those kind of functions.
     const destPath = join(destFolder, `${filename}.zip`)
-    await zipBinary(srcPath, destPath, 'bootstrap', stat)
+    await zipBinary(srcPath, destPath, 'bootstrap', stat, runtime)
     return { path: destPath, runtime }
   }
 }

--- a/src/main.test.js
+++ b/src/main.test.js
@@ -258,7 +258,7 @@ test('Zips Go function files', async t => {
   await unzipFiles(files)
 
   const unzippedFile = `${tmpDir}/test`
-  await pathExists(unzippedFile)
+  t.true(await pathExists(unzippedFile))
 
   // The library we use for unzipping does not keep executable permissions.
   // https://github.com/cthackers/adm-zip/issues/86
@@ -271,9 +271,9 @@ test('Zips Go function files', async t => {
   }
 
   const tcFile = `${tmpDir}/netlify-toolchain`
-  await pathExists(tcFile)
+  t.true(await pathExists(tcFile))
   const tc = (await pReadFile(tcFile, 'utf8')).trim()
-  t.is(tc, 'runtime=go')
+  t.is(tc, '{"runtime":"go"}')
 })
 
 test('Can skip zipping Go function files', async t => {
@@ -348,7 +348,7 @@ test('Zips Rust function files', async t => {
   await unzipFiles(files)
 
   const unzippedFile = `${tmpDir}/bootstrap`
-  await pathExists(unzippedFile)
+  t.true(await pathExists(unzippedFile))
 
   // The library we use for unzipping does not keep executable permissions.
   // https://github.com/cthackers/adm-zip/issues/86
@@ -361,7 +361,7 @@ test('Zips Rust function files', async t => {
   }
 
   const tcFile = `${tmpDir}/netlify-toolchain`
-  await pathExists(tcFile)
+  t.true(await pathExists(tcFile))
   const tc = (await pReadFile(tcFile, 'utf8')).trim()
-  t.is(tc, 'runtime=rs')
+  t.is(tc, '{"runtime":"rs"}')
 })

--- a/src/main.test.js
+++ b/src/main.test.js
@@ -258,7 +258,6 @@ test('Zips Go function files', async t => {
   await unzipFiles(files)
 
   const unzippedFile = `${tmpDir}/test`
-
   await pathExists(unzippedFile)
 
   // The library we use for unzipping does not keep executable permissions.
@@ -270,6 +269,11 @@ test('Zips Go function files', async t => {
     const { stdout } = await execa(unzippedFile)
     t.is(stdout, 'test')
   }
+
+  const tcFile = `${tmpDir}/netlify-toolchain`
+  await pathExists(tcFile)
+  const tc = (await pReadFile(tcFile, 'utf8')).trim()
+  t.is(tc, 'runtime=go')
 })
 
 test('Can skip zipping Go function files', async t => {
@@ -344,7 +348,6 @@ test('Zips Rust function files', async t => {
   await unzipFiles(files)
 
   const unzippedFile = `${tmpDir}/bootstrap`
-
   await pathExists(unzippedFile)
 
   // The library we use for unzipping does not keep executable permissions.
@@ -356,4 +359,9 @@ test('Zips Rust function files', async t => {
     const { stdout } = await execa(unzippedFile)
     t.is(stdout, 'Hello, world!')
   }
+
+  const tcFile = `${tmpDir}/netlify-toolchain`
+  await pathExists(tcFile)
+  const tc = (await pReadFile(tcFile, 'utf8')).trim()
+  t.is(tc, 'runtime=rs')
 })


### PR DESCRIPTION
This metadata file, called "netlify-toolchain" allows adding extra information about how the file was generated and what's in it without having to check other files.

This will help fixing https://github.com/netlify/build/issues/2114

Signed-off-by: David Calavera <david.calavera@gmail.com>
