### PR TITLE
Add `node/prefer-global/buffer` ESLint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,7 +15,6 @@ module.exports = {
     'fp/no-mutating-methods': 0,
     'import/no-dynamic-require': 0,
     'node/global-require': 0,
-    'node/prefer-global/buffer': 0,
     'promise/param-names': 0,
   },
   overrides: [...overrides],

--- a/src/node.js
+++ b/src/node.js
@@ -1,3 +1,4 @@
+const { Buffer } = require('buffer')
 const fs = require('fs')
 const { dirname, normalize, sep } = require('path')
 const { promisify } = require('util')


### PR DESCRIPTION
This enables the `node/prefer-global/buffer` ESLint rule.