### PR TITLE
Enable `promise/param-names` ESLint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,7 +12,6 @@ module.exports = {
     'fp/no-mutating-methods': 0,
     'import/no-dynamic-require': 0,
     'node/global-require': 0,
-    'promise/param-names': 0,
   },
   overrides: [...overrides],
 }

--- a/src/resolve.js
+++ b/src/resolve.js
@@ -2,7 +2,7 @@ const { version: nodeVersion } = require('process')
 
 const findUp = require('find-up')
 const pathExists = require('path-exists')
-const resolve = require('resolve')
+const resolveLib = require('resolve')
 const { lt: ltVersion } = require('semver')
 
 // Find the path to a module's `package.json`
@@ -47,13 +47,13 @@ const REQUEST_RESOLVE_MIN_VERSION = '8.9.0'
 // `resolve`:
 //   https://github.com/browserify/resolve/issues/151#issuecomment-368210310
 const resolvePathPreserveSymlinks = function (path, basedir) {
-  return new Promise((success, reject) => {
-    resolve(path, { basedir, preserveSymlinks: true }, (error, resolvedLocation) => {
+  return new Promise((resolve, reject) => {
+    resolveLib(path, { basedir, preserveSymlinks: true }, (error, resolvedLocation) => {
       if (error) {
         return reject(error)
       }
 
-      success(resolvedLocation)
+      resolve(resolvedLocation)
     })
   })
 }


### PR DESCRIPTION
This enables the `promise/param-names` ESLint rule.