### PR TITLE
Enable `fp/no-mutating-methods` ESLint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,7 +9,6 @@ module.exports = {
     'max-lines': 0,
     'max-statements': 0,
     'no-magic-numbers': 0,
-    'fp/no-mutating-methods': 0,
     'import/no-dynamic-require': 0,
     'node/global-require': 0,
   },

--- a/src/dependencies.js
+++ b/src/dependencies.js
@@ -20,6 +20,8 @@ const listNodeFiles = async function (srcPath, mainFile, srcDir, stat) {
   const uniqueFiles = [...new Set(files)]
 
   // We sort so that the archive's checksum is deterministic.
+  // Mutating is fine since `Array.filter()` returns a shallow copy
+  // eslint-disable-next-line fp/no-mutating-methods
   const filteredFiles = uniqueFiles.filter(isNotJunk).sort()
   return filteredFiles
 }


### PR DESCRIPTION
This enables the `fp/no-mutating-methods` ESLint rule.