### PR TITLE
Enable `no-magic-numbers` ESLint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,7 +6,6 @@ module.exports = {
     // TODO: enable those rules
     'max-lines': 0,
     'max-statements': 0,
-    'no-magic-numbers': 0,
     'import/no-dynamic-require': 0,
     'node/global-require': 0,
   },

--- a/src/archive.js
+++ b/src/archive.js
@@ -9,10 +9,12 @@ const pEndOfStream = promisify(endOfStream)
 // Start zipping files
 const startZip = function (destPath) {
   const output = createWriteStream(destPath)
-  const archive = archiver('zip', { level: 9 })
+  const archive = archiver('zip', { level: ZIP_LEVEL })
   archive.pipe(output)
   return { archive, output }
 }
+
+const ZIP_LEVEL = 9
 
 // Add new file to zip
 const addZipFile = function (archive, file, name, stat) {

--- a/src/main.js
+++ b/src/main.js
@@ -17,7 +17,11 @@ const pLstat = promisify(lstat)
 // Zip `srcFolder/*` (Node.js or Go files) to `destFolder/*.zip` so it can be
 // used by AWS Lambda
 // TODO: remove `skipGo` option in next major release
-const zipFunctions = async function (srcFolder, destFolder, { parallelLimit = 5, skipGo, zipGo } = {}) {
+const zipFunctions = async function (
+  srcFolder,
+  destFolder,
+  { parallelLimit = DEFAULT_PARALLEL_LIMIT, skipGo, zipGo } = {},
+) {
   const srcPaths = await getSrcPaths(srcFolder)
 
   const zipped = await pMap(srcPaths, (srcPath) => zipFunction(srcPath, destFolder, { skipGo, zipGo }), {
@@ -25,6 +29,8 @@ const zipFunctions = async function (srcFolder, destFolder, { parallelLimit = 5,
   })
   return zipped.filter(Boolean)
 }
+
+const DEFAULT_PARALLEL_LIMIT = 5
 
 const zipFunction = async function (srcPath, destFolder, { skipGo = true, zipGo = !skipGo } = {}) {
   const { runtime, filename, extension, srcDir, stat, mainFile } = await getFunctionInfo(srcPath)

--- a/tests/main.js
+++ b/tests/main.js
@@ -221,8 +221,10 @@ test('Works with many dependencies', async (t) => {
 })
 
 test('Works with many function files', async (t) => {
-  await zipNode(t, 'many-functions', { length: 6 })
+  await zipNode(t, 'many-functions', { length: TEST_FUNCTIONS_LENGTH })
 })
+
+const TEST_FUNCTIONS_LENGTH = 6
 
 test('Produces deterministic checksums', async (t) => {
   const [checksumOne, checksumTwo] = await Promise.all([getZipChecksum(t), getZipChecksum(t)])
@@ -294,7 +296,7 @@ test('Zips Go function files', async (t) => {
   // https://github.com/cthackers/adm-zip/issues/86
   // However `chmod()` is not cross-platform
   if (platform === 'linux') {
-    await pChmod(unzippedFile, 0o755)
+    await pChmod(unzippedFile, EXECUTABLE_PERMISSION)
 
     const { stdout } = await execa(unzippedFile)
     t.is(stdout, 'test')
@@ -384,7 +386,7 @@ test('Zips Rust function files', async (t) => {
   // https://github.com/cthackers/adm-zip/issues/86
   // However `chmod()` is not cross-platform
   if (platform === 'linux') {
-    await pChmod(unzippedFile, 0o755)
+    await pChmod(unzippedFile, EXECUTABLE_PERMISSION)
 
     const { stdout } = await execa(unzippedFile)
     t.is(stdout, 'Hello, world!')
@@ -395,3 +397,5 @@ test('Zips Rust function files', async (t) => {
   const tc = (await pReadFile(tcFile, 'utf8')).trim()
   t.is(tc, '{"runtime":"rs"}')
 })
+
+const EXECUTABLE_PERMISSION = 0o755


### PR DESCRIPTION
This enables the `no-magic-numbers` ESLint rule.