### PR TITLE
chore(deps): disable precinct major updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -20,6 +20,7 @@
         'p-map',
         'pkg-dir',
         'prettier',
+        'precinct',
         'yargs',
       ],
       major: {


### PR DESCRIPTION
Latest major version of `precinct` requires Node.10