### PR TITLE
chore: add prepublish script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "src/**/*.js"
   ],
   "scripts": {
+    "prepublishOnly": "npm ci && npm test",
     "test": "run-s format test:dev",
     "format": "run-s format:check-fix:*",
     "format:ci": "run-s format:check:*",


### PR DESCRIPTION
Enforces syncing dependencies and passing tests before publishing a package.