### PR TITLE
fix: add `prisma` CLI to EXCLUDED_PEER_DEPENDENCIES

### DIFF
--- a/src/node_dependencies/nested.js
+++ b/src/node_dependencies/nested.js
@@ -18,7 +18,7 @@ const shouldIncludePeerDependency = function (name) {
   return !EXCLUDED_PEER_DEPENDENCIES.has(name)
 }
 
-const EXCLUDED_PEER_DEPENDENCIES = new Set(['@prisma/cli', 'prisma2'])
+const EXCLUDED_PEER_DEPENDENCIES = new Set(['@prisma/cli', 'prisma2', 'prisma'])
 
 // Modules can be required conditionally (inside an `if` or `try`/`catch` block).
 // When a `require()` statement is found but the module is not found, it is


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

The new package url https://www.npmjs.com/package/prisma

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

Prisma is going to rename the CLI package from `@prisma/cli` to `prisma`, so the excluded list needs to be updated with that new package name (and keep the older names for retro-compatibility).

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**

add `prisma` CLI to EXCLUDED_PEER_DEPENDENCIES

**- A picture of a cute animal (not mandatory but encouraged)**

![juuiev6a6oyy](https://user-images.githubusercontent.com/1328733/106312469-f7e37f80-6266-11eb-975c-9301b03491b1.jpg)
