### PR TITLE
feat: improvements to esbuild bundling

### DIFF
--- a/src/bin.js
+++ b/src/bin.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-const { exit } = require('process')
+const { env, exit } = require('process')
 
 const yargs = require('yargs')
 
@@ -39,12 +39,13 @@ const OPTIONS = {
   },
   'use-esbuild': {
     boolean: true,
-    default: false,
+    default: Boolean(env.NETLIFY_EXPERIMENTAL_ESBUILD),
     describe: 'Whether to use esbuild to bundle JavaScript functions',
     hidden: true,
   },
   'external-modules': {
     array: true,
+    default: (env.NETLIFY_EXPERIMENTAL_EXTERNAL_MODULES || '').split(','),
     describe: 'List of Node modules to keep out of the bundle',
     hidden: true,
   },

--- a/src/info.js
+++ b/src/info.js
@@ -37,7 +37,7 @@ const getFunctionInfo = async function (srcPath) {
     return {}
   }
 
-  if (['.js', '.ts', '.zip'].includes(extension)) {
+  if (['.js', '.zip'].includes(extension)) {
     return { runtime: 'js', name, filename, stat, mainFile, extension, srcPath, srcDir }
   }
 

--- a/src/info.js
+++ b/src/info.js
@@ -37,7 +37,7 @@ const getFunctionInfo = async function (srcPath) {
     return {}
   }
 
-  if (extension === '.zip' || extension === '.js') {
+  if (['.js', '.ts', '.zip'].includes(extension)) {
     return { runtime: 'js', name, filename, stat, mainFile, extension, srcPath, srcDir }
   }
 

--- a/src/runtimes/go.js
+++ b/src/runtimes/go.js
@@ -1,0 +1,19 @@
+const { join } = require('path')
+
+const cpFile = require('cp-file')
+
+const { zipBinary } = require('../runtime')
+
+const zipGoFunction = async function ({ srcPath, destFolder, stat, zipGo, filename, runtime }) {
+  if (zipGo) {
+    const destPath = join(destFolder, `${filename}.zip`)
+    await zipBinary({ srcPath, destPath, filename, stat, runtime })
+    return destPath
+  }
+
+  const destPath = join(destFolder, filename)
+  await cpFile(srcPath, destPath)
+  return destPath
+}
+
+module.exports = { zipGoFunction }

--- a/src/runtimes/index.js
+++ b/src/runtimes/index.js
@@ -5,5 +5,5 @@ const { zipRustFunction } = require('./rust')
 module.exports = {
   go: zipGoFunction,
   js: zipJsFunction,
-  rust: zipRustFunction,
+  rs: zipRustFunction,
 }

--- a/src/runtimes/index.js
+++ b/src/runtimes/index.js
@@ -1,0 +1,9 @@
+const { zipGoFunction } = require('./go')
+const { zipJsFunction } = require('./node')
+const { zipRustFunction } = require('./rust')
+
+module.exports = {
+  go: zipGoFunction,
+  js: zipJsFunction,
+  rust: zipRustFunction,
+}

--- a/src/runtimes/node.js
+++ b/src/runtimes/node.js
@@ -1,0 +1,38 @@
+const { join, basename } = require('path')
+
+const cpFile = require('cp-file')
+
+const { zipNodeJs } = require('../zip_node')
+
+const zipJsFunction = async function ({
+  srcPath,
+  destFolder,
+  mainFile,
+  filename,
+  extension,
+  srcFiles,
+  pluginsModulesPath,
+  useEsbuild,
+  externalModules,
+}) {
+  if (extension === '.zip') {
+    const destPath = join(destFolder, filename)
+    await cpFile(srcPath, destPath)
+    return destPath
+  }
+
+  const destPath = join(destFolder, `${basename(filename, extension)}.zip`)
+  await zipNodeJs({
+    srcFiles,
+    destFolder,
+    destPath,
+    filename,
+    mainFile,
+    pluginsModulesPath,
+    useEsbuild,
+    externalModules,
+  })
+  return destPath
+}
+
+module.exports = { zipJsFunction }

--- a/src/runtimes/rust.js
+++ b/src/runtimes/rust.js
@@ -1,0 +1,16 @@
+const { join } = require('path')
+
+const { zipBinary } = require('../runtime')
+
+// Rust functions must always be zipped.
+// The name of the binary inside the zip file must
+// always be `bootstrap` because they include the
+// Lambda runtime, and that's the name that AWS
+// expects for those kind of functions.
+const zipRustFunction = async function ({ srcPath, destFolder, stat, filename, runtime }) {
+  const destPath = join(destFolder, `${filename}.zip`)
+  await zipBinary({ srcPath, destPath, filename: 'bootstrap', stat, runtime })
+  return destPath
+}
+
+module.exports = { zipRustFunction }

--- a/src/zip_node.js
+++ b/src/zip_node.js
@@ -1,6 +1,6 @@
 const { Buffer } = require('buffer')
 const fs = require('fs')
-const { dirname, join, normalize, sep } = require('path')
+const { basename, dirname, extname, join, normalize, sep } = require('path')
 const { promisify } = require('util')
 
 const commonPathPrefix = require('common-path-prefix')
@@ -54,7 +54,8 @@ const zipNodeJsWithEsbuild = async function ({
   mainFile,
   pluginsModulesPath,
 }) {
-  const bundledFilePath = join(destFolder, filename)
+  const jsFilename = `${basename(filename, extname(filename))}.js`
+  const bundledFilePath = join(destFolder, jsFilename)
 
   await esbuild.build({
     bundle: true,
@@ -69,7 +70,7 @@ const zipNodeJsWithEsbuild = async function ({
     const { archive, output } = startZip(destPath)
     const { srcFile, stat } = await addStat(bundledFilePath)
 
-    addEntryFile(destFolder, archive, filename, bundledFilePath)
+    addEntryFile(destFolder, archive, jsFilename, bundledFilePath)
 
     zipJsFile({ archive, commonPrefix: destFolder, pluginsModulesPath, srcFile, stat })
 


### PR DESCRIPTION
**- Summary**

This PR includes [a bypass](https://github.com/netlify/zip-it-and-ship-it/blob/121bb49456a35ab99139160f3b99e12db1002d0f/src/main.js#L122-L124) for the legacy bundling logic when using esbuild, removing unnecessary computations and thus improving performance.

It also adds support for TypeScript.

Finally, to comply with the `max-lines` ESLint rule, it breaks the Go, JS and Rust runtime-specific logic into different files.

I'm sorry that the PR is larger than what I'd like, but the three changes are heavily interconnected.

**- Description for the changelog**

feat: improvements to esbuild bundling

**- A picture of a cute animal (not mandatory but encouraged)**

![maxresdefault](https://user-images.githubusercontent.com/4162329/107518743-45d17f00-6ba7-11eb-8ded-00f9e79b2fcb.jpg)
