### PR TITLE
feat: add Next.js special case to esbuild bundler

### DIFF
--- a/src/node_dependencies/index.js
+++ b/src/node_dependencies/index.js
@@ -5,6 +5,7 @@ const precinct = require('precinct')
 
 const { getPackageJson } = require('./package_json')
 const { resolvePathPreserveSymlinks } = require('./resolve')
+const { getExternalAndIgnoredModulesFromSpecialCases } = require('./special_cases')
 const {
   getDependencyPathsForDependency,
   getDependencyNamesAndPathsForDependencies,
@@ -117,5 +118,6 @@ module.exports = {
   getDependencyPathsForDependency,
   getDependencyNamesAndPathsForDependencies,
   getDependencyNamesAndPathsForDependency,
+  getExternalAndIgnoredModulesFromSpecialCases,
   listFilesUsingLegacyBundler,
 }

--- a/src/node_dependencies/special_cases.js
+++ b/src/node_dependencies/special_cases.js
@@ -1,0 +1,33 @@
+const { getPackageJson } = require('./package_json')
+
+const getPackageJsonIfAvailable = async (srcDir) => {
+  try {
+    const packageJson = await getPackageJson(srcDir)
+
+    return packageJson
+  } catch (_) {
+    return {}
+  }
+}
+
+const getModulesForNextJs = ({ dependencies }) => {
+  const externalModules = dependencies.next ? ['critters', 'nanoid'] : []
+  const ignoredModules = []
+
+  return {
+    externalModules,
+    ignoredModules,
+  }
+}
+
+const getExternalAndIgnoredModulesFromSpecialCases = async ({ srcDir }) => {
+  const { dependencies = {} } = await getPackageJsonIfAvailable(srcDir)
+  const { externalModules, ignoredModules } = getModulesForNextJs({ dependencies })
+
+  return {
+    externalModules,
+    ignoredModules,
+  }
+}
+
+module.exports = { getExternalAndIgnoredModulesFromSpecialCases }

--- a/tests/main.js
+++ b/tests/main.js
@@ -162,6 +162,22 @@ BUNDLERS.forEach((bundler) => {
     await zipNodeWithBundler(t, 'local-parent-require')
   })
 
+  test(`[bundler: ${bundler}] Ignore missing critters dependency for Next.js 10`, async (t) => {
+    await zipNodeWithBundler(t, 'node-module-next10-critters')
+  })
+
+  test(`[bundler: ${bundler}] Ignore missing critters dependency for Next.js exact version 10.0.5`, async (t) => {
+    await zipNodeWithBundler(t, 'node-module-next10-critters-exact')
+  })
+
+  test(`[bundler: ${bundler}] Ignore missing critters dependency for Next.js with range ^10.0.5`, async (t) => {
+    await zipNodeWithBundler(t, 'node-module-next10-critters-10.0.5-range')
+  })
+
+  test(`[bundler: ${bundler}] Ignore missing critters dependency for Next.js with version='latest'`, async (t) => {
+    await zipNodeWithBundler(t, 'node-module-next10-critters-latest')
+  })
+
   // Need to create symlinks dynamically because they sometimes get lost when
   // committed on Windows
   if (platform !== 'win32') {
@@ -406,22 +422,6 @@ test('[bundler: legacy] Include most files from node modules', async (t) => {
 
 test('[bundler: legacy] Throws on missing critters dependency for Next.js 9', async (t) => {
   await t.throwsAsync(zipNode(t, 'node-module-next9-critters', { bundler: 'legacy' }))
-})
-
-test('[bundler: legacy] Ignore missing critters dependency for Next.js 10', async (t) => {
-  await zipNode(t, 'node-module-next10-critters', { bundler: 'legacy' })
-})
-
-test('[bundler: legacy] Ignore missing critters dependency for Next.js exact version 10.0.5', async (t) => {
-  await zipNode(t, 'node-module-next10-critters-exact', { bundler: 'legacy' })
-})
-
-test('[bundler: legacy] Ignore missing critters dependency for Next.js with range ^10.0.5', async (t) => {
-  await zipNode(t, 'node-module-next10-critters-10.0.5-range', { bundler: 'legacy' })
-})
-
-test("[bundler: legacy] Ignore missing critters dependency for Next.js with version='latest'", async (t) => {
-  await zipNode(t, 'node-module-next10-critters-latest', { bundler: 'legacy' })
 })
 
 test('[bundler: legacy] Includes specific Next.js dependencies when using next-on-netlify', async (t) => {


### PR DESCRIPTION
**- Summary**

This PR adds special cases for the Next.js dependency quirks to the esbuild bundling mechanism.

It also handles the case where a module that isn't installed is included in `externalModules`. A corresponding test for this case is included.

**- Test plan**

Relevant tests were moved from being legacy-specific to the common test pool.

**- Description for the changelog**

feat: add Next.js special case to esbuild bundler

**- A picture of a cute animal (not mandatory but encouraged)**

![b7c32f70a50b163bda92b6bcf1956515](https://user-images.githubusercontent.com/4162329/108367478-6aee6f00-71f1-11eb-9209-110df248eeab.jpg)

