### PR TITLE
feat: add JS bundler fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,31 @@ _Default value_: `5`
 
 Maximum number of Functions to bundle at the same time.
 
+#### jsBundlerVersion
+
+_Type_: `number`\
+_Default value_: `undefined`
+
+The version number of the JavaScript bundling mechanism.
+
+#### jsExternalModules
+
+_Type_: `array<string>`\
+_Default value_: `[]`
+
+List of Node modules to include separately inside a node_modules directory.
+
+Applicable only when `jsBundlerVersion` is `2`.
+
+#### jsIgnoredModules
+
+_Type_: `array<string>`\
+_Default value_: `[]`
+
+List of Node modules to keep out of the bundle.
+
+Applicable only when `jsBundlerVersion` is `2`.
+
 ### Return value
 
 This returns a `Promise` resolving to an array of objects describing each archive. Each object has the following

--- a/README.md
+++ b/README.md
@@ -86,12 +86,14 @@ _Default value_: `5`
 
 Maximum number of Functions to bundle at the same time.
 
-#### jsBundlerVersion
+#### jsBundler
 
 _Type_: `number`\
 _Default value_: `undefined`
 
-The version number of the JavaScript bundling mechanism.
+The bundler to use when processing JavaScript functions. Possible values: `zisi`, `esbuild`.
+
+When `undefined`, `esbuild` will be used with a fallback to `zisi` in case of an error.
 
 #### jsExternalModules
 
@@ -100,7 +102,7 @@ _Default value_: `[]`
 
 List of Node modules to include separately inside a node_modules directory.
 
-Applicable only when `jsBundlerVersion` is `2`.
+Applicable only when `jsBundler` is `esbuild`.
 
 #### jsIgnoredModules
 
@@ -109,7 +111,7 @@ _Default value_: `[]`
 
 List of Node modules to keep out of the bundle.
 
-Applicable only when `jsBundlerVersion` is `2`.
+Applicable only when `jsBundler` is `esbuild`.
 
 ### Return value
 

--- a/README.md
+++ b/README.md
@@ -89,11 +89,11 @@ Maximum number of Functions to bundle at the same time.
 #### jsBundler
 
 _Type_: `number`\
-_Default value_: `undefined`
+_Default value_: `zisi`
 
-The bundler to use when processing JavaScript functions. Possible values: `zisi`, `esbuild`.
+The bundler to use when processing JavaScript functions. Possible values: `zisi`, `esbuild`, `esbuild_zisi`.
 
-When `undefined`, `esbuild` will be used with a fallback to `zisi` in case of an error.
+When the value is `esbuild_zisi`, `esbuild` will be used with a fallback to `zisi` in case of an error.
 
 #### jsExternalModules
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "elf-cam": "^0.1.1",
         "end-of-stream": "^1.4.4",
         "esbuild": "^0.8.46",
+        "filter-obj": "^2.0.1",
         "find-up": "^4.1.0",
         "glob": "^7.1.6",
         "junk": "^3.1.0",
@@ -5605,6 +5606,14 @@
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/filter-obj": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-2.0.1.tgz",
+      "integrity": "sha512-yDEp513p7+iLdFHWBVdZFnRiOYwg8ZqmpaAiZCMjzqsbo7tCS4Qm4ulXOht337NGzkukKa9u3W4wqQ9tQPm3Ug==",
       "engines": {
         "node": ">=8"
       }
@@ -16959,6 +16968,11 @@
       "requires": {
         "to-regex-range": "^5.0.1"
       }
+    },
+    "filter-obj": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-2.0.1.tgz",
+      "integrity": "sha512-yDEp513p7+iLdFHWBVdZFnRiOYwg8ZqmpaAiZCMjzqsbo7tCS4Qm4ulXOht337NGzkukKa9u3W4wqQ9tQPm3Ug=="
     },
     "find-cache-dir": {
       "version": "3.3.1",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "elf-cam": "^0.1.1",
     "end-of-stream": "^1.4.4",
     "esbuild": "^0.8.46",
+    "filter-obj": "^2.0.1",
     "find-up": "^4.1.0",
     "glob": "^7.1.6",
     "junk": "^3.1.0",

--- a/src/bin.js
+++ b/src/bin.js
@@ -4,6 +4,7 @@ const { exit } = require('process')
 const yargs = require('yargs')
 
 const zipIt = require('./main')
+const { JS_BUNDLER_ZISI } = require('./utils/consts')
 
 // CLI entry point
 const runCli = async function () {
@@ -34,6 +35,7 @@ const OPTIONS = {
   },
   'js-bundler': {
     string: true,
+    default: JS_BUNDLER_ZISI,
     describe: 'The bundler to use when processing JavaScript functions',
   },
   'js-external-modules': {

--- a/src/bin.js
+++ b/src/bin.js
@@ -32,9 +32,9 @@ const OPTIONS = {
     number: true,
     describe: 'Maximum number of Functions to bundle at the same time',
   },
-  'js-bundler-version': {
-    number: true,
-    describe: 'The version of the JavaScript bundling mechanism',
+  'js-bundler': {
+    string: true,
+    describe: 'The bundler to use when processing JavaScript functions',
   },
   'js-external-modules': {
     array: true,

--- a/src/bin.js
+++ b/src/bin.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-const { env, exit } = require('process')
+const { exit } = require('process')
 
 const yargs = require('yargs')
 
@@ -32,23 +32,19 @@ const OPTIONS = {
     number: true,
     describe: 'Maximum number of Functions to bundle at the same time',
   },
-  'use-esbuild': {
-    boolean: true,
-    default: Boolean(env.NETLIFY_EXPERIMENTAL_ESBUILD),
-    describe: 'Whether to use esbuild to bundle JavaScript functions',
-    hidden: true,
+  'js-bundler-version': {
+    number: true,
+    describe: 'The version of the JavaScript bundling mechanism',
   },
-  'external-modules': {
+  'js-external-modules': {
     array: true,
-    default: (env.NETLIFY_EXPERIMENTAL_EXTERNAL_MODULES || '').split(','),
+    default: [],
     describe: 'List of Node modules to include separately inside a node_modules directory',
-    hidden: true,
   },
-  'ignored-modules': {
+  'js-ignored-modules': {
     array: true,
-    default: (env.NETLIFY_EXPERIMENTAL_IGNORED_MODULES || '').split(','),
+    default: [],
     describe: 'List of Node modules to keep out of the bundle',
-    hidden: true,
   },
 }
 

--- a/src/bundler.js
+++ b/src/bundler.js
@@ -31,6 +31,7 @@ const bundleJsFile = async function ({
     bundle: true,
     entryPoints: [srcFile],
     external,
+    logLevel: 'silent',
     outfile: bundlePath,
     nodePaths: additionalModulePaths,
     platform: 'node',

--- a/src/main.js
+++ b/src/main.js
@@ -82,7 +82,7 @@ const zipFunction = async function (
     return { path: destPath, runtime: 'js' }
   }
 
-  const { bundlerErrors, bundlerVersion, bundlerWarnings, path } = await runtimes[runtime].zipFunction({
+  const { bundler, bundlerErrors, bundlerWarnings, path } = await runtimes[runtime].zipFunction({
     jsBundler,
     jsExternalModules,
     jsIgnoredModules,
@@ -97,7 +97,7 @@ const zipFunction = async function (
     runtime,
     pluginsModulesPath,
   })
-  return removeFalsy({ bundlerErrors, bundlerVersion, bundlerWarnings, path, runtime })
+  return removeFalsy({ bundler, bundlerErrors, bundlerWarnings, path, runtime })
 }
 
 // List all Netlify Functions main entry files for a specific directory

--- a/src/main.js
+++ b/src/main.js
@@ -1,105 +1,11 @@
-const { extname, join } = require('path')
-
-const cpFile = require('cp-file')
-const findUp = require('find-up')
-const makeDir = require('make-dir')
-const pMap = require('p-map')
+const { extname } = require('path')
 
 require('./utils/polyfills')
-const { getFunctionInfos, getSrcPaths, getFunctionInfo } = require('./info')
+const { getFunctionInfos } = require('./info')
+const { getPluginsModulesPath } = require('./node_dependencies')
 const runtimes = require('./runtimes')
-const { removeFalsy } = require('./utils/remove_falsy')
 const { JS_BUNDLER_ZISI } = require('./utils/consts')
-
-const AUTO_PLUGINS_DIR = '.netlify/plugins/'
-const DEFAULT_PARALLEL_LIMIT = 5
-
-const getPluginsModulesPath = (srcDir) => findUp(`${AUTO_PLUGINS_DIR}node_modules`, { cwd: srcDir, type: 'directory' })
-
-// Zip `srcFolder/*` (Node.js or Go files) to `destFolder/*.zip` so it can be
-// used by AWS Lambda
-// TODO: remove `skipGo` option in next major release
-const zipFunctions = async function (
-  srcFolder,
-  destFolder,
-  {
-    jsBundler,
-    jsExternalModules = [],
-    jsIgnoredModules = [],
-    parallelLimit = DEFAULT_PARALLEL_LIMIT,
-    skipGo,
-    zipGo,
-  } = {},
-) {
-  const [srcPaths, pluginsModulesPath] = await Promise.all([getSrcPaths(srcFolder), getPluginsModulesPath(srcFolder)])
-
-  const zipped = await pMap(
-    srcPaths,
-    (srcPath) =>
-      zipFunction(srcPath, destFolder, {
-        jsBundler,
-        jsExternalModules,
-        jsIgnoredModules,
-        pluginsModulesPath,
-        skipGo,
-        zipGo,
-      }),
-    {
-      concurrency: parallelLimit,
-    },
-  )
-  return zipped.filter(Boolean)
-}
-
-const zipFunction = async function (
-  srcPath,
-  destFolder,
-  {
-    jsBundler,
-    jsExternalModules,
-    jsIgnoredModules,
-    pluginsModulesPath: defaultModulesPath,
-    skipGo = true,
-    zipGo = !skipGo,
-  } = {},
-) {
-  const { runtime, filename, extension, srcDir, stat, mainFile } = await getFunctionInfo(srcPath)
-
-  if (runtime === undefined) {
-    return
-  }
-
-  const pluginsModulesPath =
-    defaultModulesPath === undefined ? await getPluginsModulesPath(srcPath) : defaultModulesPath
-
-  await makeDir(destFolder)
-
-  // If the file is a zip, we assume the function is bundled and ready to go.
-  // We assume its runtime to be JavaScript and simply copy it to the
-  // destination path with no further processing.
-  if (extension === '.zip') {
-    const destPath = join(destFolder, filename)
-    await cpFile(srcPath, destPath)
-    return { path: destPath, runtime: 'js' }
-  }
-
-  const { bundler, bundlerErrors, bundlerWarnings, path } = await runtimes[runtime].zipFunction({
-    jsBundler,
-    jsExternalModules,
-    jsIgnoredModules,
-    srcPath,
-    destFolder,
-    mainFile,
-    filename,
-    extension,
-    srcDir,
-    stat,
-    zipGo,
-    runtime,
-    pluginsModulesPath,
-  })
-  return removeFalsy({ bundler, bundlerErrors, bundlerWarnings, path, runtime })
-}
+const { zipFunction, zipFunctions } = require('./zip')
 
 // List all Netlify Functions main entry files for a specific directory
 const listFunctions = async function (srcFolder) {

--- a/src/main.js
+++ b/src/main.js
@@ -9,6 +9,7 @@ require('./utils/polyfills')
 const { getFunctionInfos, getSrcPaths, getFunctionInfo } = require('./info')
 const runtimes = require('./runtimes')
 const { removeFalsy } = require('./utils/remove_falsy')
+const { JS_BUNDLER_ZISI } = require('./utils/consts')
 
 const AUTO_PLUGINS_DIR = '.netlify/plugins/'
 const DEFAULT_PARALLEL_LIMIT = 5
@@ -108,7 +109,10 @@ const listFunctions = async function (srcFolder) {
 }
 
 // List all Netlify Functions files for a specific directory
-const listFunctionsFiles = async function (srcFolder, { jsBundler, jsExternalModules, jsIgnoredModules } = {}) {
+const listFunctionsFiles = async function (
+  srcFolder,
+  { jsBundler = JS_BUNDLER_ZISI, jsExternalModules, jsIgnoredModules } = {},
+) {
   const [functionInfos, pluginsModulesPath] = await Promise.all([
     getFunctionInfos(srcFolder),
     getPluginsModulesPath(srcFolder),

--- a/src/node_dependencies/index.js
+++ b/src/node_dependencies/index.js
@@ -1,5 +1,6 @@
 const { dirname, basename, normalize } = require('path')
 
+const findUp = require('find-up')
 const { not: notJunk } = require('junk')
 const precinct = require('precinct')
 
@@ -14,6 +15,10 @@ const {
 } = require('./traverse')
 const { getTreeFiles } = require('./tree_files')
 const { shouldTreeShake } = require('./tree_shake')
+
+const AUTO_PLUGINS_DIR = '.netlify/plugins/'
+
+const getPluginsModulesPath = (srcDir) => findUp(`${AUTO_PLUGINS_DIR}node_modules`, { cwd: srcDir, type: 'directory' })
 
 // Retrieve the paths to the Node.js files to zip.
 // We only include the files actually needed by the function because AWS Lambda
@@ -119,5 +124,6 @@ module.exports = {
   getDependencyNamesAndPathsForDependencies,
   getDependencyNamesAndPathsForDependency,
   getExternalAndIgnoredModulesFromSpecialCases,
+  getPluginsModulesPath,
   listFilesUsingLegacyBundler,
 }

--- a/src/node_dependencies/special_cases.js
+++ b/src/node_dependencies/special_cases.js
@@ -10,8 +10,9 @@ const getPackageJsonIfAvailable = async (srcDir) => {
   }
 }
 
-const getModulesForNextJs = ({ dependencies }) => {
-  const externalModules = dependencies.next ? ['critters', 'nanoid'] : []
+const getModulesForNextJs = ({ dependencies, devDependencies }) => {
+  const allDependencies = { ...dependencies, ...devDependencies }
+  const externalModules = allDependencies.next ? ['critters', 'nanoid'] : []
   const ignoredModules = []
 
   return {
@@ -21,8 +22,8 @@ const getModulesForNextJs = ({ dependencies }) => {
 }
 
 const getExternalAndIgnoredModulesFromSpecialCases = async ({ srcDir }) => {
-  const { dependencies = {} } = await getPackageJsonIfAvailable(srcDir)
-  const { externalModules, ignoredModules } = getModulesForNextJs({ dependencies })
+  const { dependencies = {}, devDependencies = {} } = await getPackageJsonIfAvailable(srcDir)
+  const { externalModules, ignoredModules } = getModulesForNextJs({ dependencies, devDependencies })
 
   return {
     externalModules,

--- a/src/node_dependencies/traverse.js
+++ b/src/node_dependencies/traverse.js
@@ -54,9 +54,8 @@ const getDependencyNamesAndPathsForDependencies = async function ({
       }),
     ),
   )
-  const filteredDependencies = dependencies.filter(Boolean)
-  const moduleNames = new Set(filteredDependencies.flatMap((dependency) => [...dependency.moduleNames]))
-  const paths = new Set(filteredDependencies.flatMap((dependency) => [...dependency.paths]))
+  const moduleNames = new Set(dependencies.flatMap((dependency) => [...dependency.moduleNames]))
+  const paths = new Set(dependencies.flatMap((dependency) => [...dependency.paths]))
 
   return {
     moduleNames: [...moduleNames],

--- a/src/runtimes/go.js
+++ b/src/runtimes/go.js
@@ -8,12 +8,12 @@ const zipFunction = async function ({ srcPath, destFolder, stat, zipGo, filename
   if (zipGo) {
     const destPath = join(destFolder, `${filename}.zip`)
     await zipBinary({ srcPath, destPath, filename, stat, runtime })
-    return destPath
+    return { path: destPath }
   }
 
   const destPath = join(destFolder, filename)
   await cpFile(srcPath, destPath)
-  return destPath
+  return { path: destPath }
 }
 
 module.exports = { zipFunction }

--- a/src/runtimes/node.js
+++ b/src/runtimes/node.js
@@ -8,7 +8,7 @@ const {
   getExternalAndIgnoredModulesFromSpecialCases,
   listFilesUsingLegacyBundler,
 } = require('../node_dependencies')
-const { JS_BUNDLER_ESBUILD, JS_BUNDLER_ZISI } = require('../utils/consts')
+const { JS_BUNDLER_ESBUILD, JS_BUNDLER_ESBUILD_ZISI, JS_BUNDLER_ZISI } = require('../utils/consts')
 const { zipNodeJs } = require('../zip_node')
 
 const getSrcFiles = async function (options) {
@@ -55,7 +55,7 @@ const zipFunction = async function ({
   destFolder,
   extension,
   filename,
-  jsBundler,
+  jsBundler = JS_BUNDLER_ZISI,
   jsExternalModules: externalModulesFromConfig = [],
   jsIgnoredModules: ignoredModulesFromConfig = [],
   mainFile,
@@ -144,10 +144,10 @@ const zipFunction = async function ({
   return { bundler: JS_BUNDLER_ESBUILD, bundlerWarnings, path: destPath }
 }
 
-const zipWithFunctionWithFallback = async (parameters) => {
+const zipWithFunctionWithFallback = async ({ jsBundler, ...parameters }) => {
   // If a specific JS bundler version is specified, we'll use it.
-  if (parameters.jsBundler) {
-    return zipFunction(parameters)
+  if (jsBundler !== JS_BUNDLER_ESBUILD_ZISI) {
+    return zipFunction({ ...parameters, jsBundler })
   }
 
   // Otherwise, we'll try to bundle with esbuild and, if that fails, fallback

--- a/src/runtimes/rust.js
+++ b/src/runtimes/rust.js
@@ -10,7 +10,7 @@ const { zipBinary } = require('../runtime')
 const zipFunction = async function ({ srcPath, destFolder, stat, filename, runtime }) {
   const destPath = join(destFolder, `${filename}.zip`)
   await zipBinary({ srcPath, destPath, filename: 'bootstrap', stat, runtime })
-  return destPath
+  return { path: destPath }
 }
 
 module.exports = { zipFunction }

--- a/src/utils/consts.js
+++ b/src/utils/consts.js
@@ -1,4 +1,4 @@
 module.exports = {
-  JS_BUNDLER_LEGACY: 'zisi',
+  JS_BUNDLER_ZISI: 'zisi',
   JS_BUNDLER_ESBUILD: 'esbuild',
 }

--- a/src/utils/consts.js
+++ b/src/utils/consts.js
@@ -1,0 +1,4 @@
+module.exports = {
+  JS_BUNDLER_LEGACY: 1,
+  JS_BUNDLER_ESBUILD: 2,
+}

--- a/src/utils/consts.js
+++ b/src/utils/consts.js
@@ -1,4 +1,5 @@
 module.exports = {
-  JS_BUNDLER_ZISI: 'zisi',
   JS_BUNDLER_ESBUILD: 'esbuild',
+  JS_BUNDLER_ESBUILD_ZISI: 'esbuild_zisi',
+  JS_BUNDLER_ZISI: 'zisi',
 }

--- a/src/utils/consts.js
+++ b/src/utils/consts.js
@@ -1,4 +1,4 @@
 module.exports = {
-  JS_BUNDLER_LEGACY: 1,
-  JS_BUNDLER_ESBUILD: 2,
+  JS_BUNDLER_LEGACY: 'zisi',
+  JS_BUNDLER_ESBUILD: 'esbuild',
 }

--- a/src/utils/remove_falsy.js
+++ b/src/utils/remove_falsy.js
@@ -1,0 +1,12 @@
+const filterObj = require('filter-obj')
+
+// Remove falsy values from object
+const removeFalsy = function (obj) {
+  return filterObj(obj, isDefined)
+}
+
+const isDefined = function (key, value) {
+  return value !== undefined && value !== ''
+}
+
+module.exports = { removeFalsy }

--- a/src/zip.js
+++ b/src/zip.js
@@ -1,0 +1,99 @@
+const { join } = require('path')
+
+const cpFile = require('cp-file')
+const makeDir = require('make-dir')
+const pMap = require('p-map')
+
+const { getSrcPaths, getFunctionInfo } = require('./info')
+const { getPluginsModulesPath } = require('./node_dependencies')
+const runtimes = require('./runtimes')
+const { removeFalsy } = require('./utils/remove_falsy')
+
+const DEFAULT_PARALLEL_LIMIT = 5
+
+// Zip `srcFolder/*` (Node.js or Go files) to `destFolder/*.zip` so it can be
+// used by AWS Lambda
+// TODO: remove `skipGo` option in next major release
+const zipFunctions = async function (
+  srcFolder,
+  destFolder,
+  {
+    jsBundler,
+    jsExternalModules = [],
+    jsIgnoredModules = [],
+    parallelLimit = DEFAULT_PARALLEL_LIMIT,
+    skipGo,
+    zipGo,
+  } = {},
+) {
+  const [srcPaths, pluginsModulesPath] = await Promise.all([getSrcPaths(srcFolder), getPluginsModulesPath(srcFolder)])
+
+  const zipped = await pMap(
+    srcPaths,
+    (srcPath) =>
+      zipFunction(srcPath, destFolder, {
+        jsBundler,
+        jsExternalModules,
+        jsIgnoredModules,
+        pluginsModulesPath,
+        skipGo,
+        zipGo,
+      }),
+    {
+      concurrency: parallelLimit,
+    },
+  )
+  return zipped.filter(Boolean)
+}
+
+const zipFunction = async function (
+  srcPath,
+  destFolder,
+  {
+    jsBundler,
+    jsExternalModules,
+    jsIgnoredModules,
+    pluginsModulesPath: defaultModulesPath,
+    skipGo = true,
+    zipGo = !skipGo,
+  } = {},
+) {
+  const { runtime, filename, extension, srcDir, stat, mainFile } = await getFunctionInfo(srcPath)
+
+  if (runtime === undefined) {
+    return
+  }
+
+  const pluginsModulesPath =
+    defaultModulesPath === undefined ? await getPluginsModulesPath(srcPath) : defaultModulesPath
+
+  await makeDir(destFolder)
+
+  // If the file is a zip, we assume the function is bundled and ready to go.
+  // We assume its runtime to be JavaScript and simply copy it to the
+  // destination path with no further processing.
+  if (extension === '.zip') {
+    const destPath = join(destFolder, filename)
+    await cpFile(srcPath, destPath)
+    return { path: destPath, runtime: 'js' }
+  }
+
+  const { bundler, bundlerErrors, bundlerWarnings, path } = await runtimes[runtime].zipFunction({
+    jsBundler,
+    jsExternalModules,
+    jsIgnoredModules,
+    srcPath,
+    destFolder,
+    mainFile,
+    filename,
+    extension,
+    srcDir,
+    stat,
+    zipGo,
+    runtime,
+    pluginsModulesPath,
+  })
+  return removeFalsy({ bundler, bundlerErrors, bundlerWarnings, path, runtime })
+}
+
+module.exports = { zipFunction, zipFunctions }

--- a/src/zip_node.js
+++ b/src/zip_node.js
@@ -10,7 +10,7 @@ const { startZip, addZipFile, addZipContent, endZip } = require('./archive')
 const pStat = promisify(fs.stat)
 
 // Zip a Node.js function file
-const zipNodeJs = async function ({ basePath, destPath, filename, mainFile, pluginsModulesPath, renames, srcFiles }) {
+const zipNodeJs = async function ({ basePath, destPath, filename, mainFile, pluginsModulesPath, aliases, srcFiles }) {
   const { archive, output } = startZip(destPath)
 
   addEntryFile(basePath, archive, filename, mainFile)
@@ -20,7 +20,7 @@ const zipNodeJs = async function ({ basePath, destPath, filename, mainFile, plug
   // We ensure this is not async, so that the archive's checksum is
   // deterministic. Otherwise it depends on the order the files were added.
   srcFilesInfos.forEach(({ srcFile, stat }) => {
-    zipJsFile({ srcFile, commonPrefix: basePath, pluginsModulesPath, archive, stat, renames })
+    zipJsFile({ srcFile, commonPrefix: basePath, pluginsModulesPath, archive, stat, aliases })
   })
 
   await endZip(archive, output)
@@ -39,10 +39,10 @@ const addStat = async function (srcFile) {
   return { srcFile, stat }
 }
 
-const zipJsFile = function ({ srcFile, commonPrefix, pluginsModulesPath, archive, stat, renames = {} }) {
-  const filename = renames[srcFile] || srcFile
-  const normalizedFilename = normalizeFilePath(filename, commonPrefix, pluginsModulesPath)
-  addZipFile(archive, srcFile, normalizedFilename, stat)
+const zipJsFile = function ({ srcFile, commonPrefix, pluginsModulesPath, archive, stat, aliases = {} }) {
+  const srcPath = aliases[srcFile] || srcFile
+  const normalizedFilename = normalizeFilePath(srcFile, commonPrefix, pluginsModulesPath)
+  addZipFile(archive, srcPath, normalizedFilename, stat)
 }
 
 // `adm-zip` and `require()` expect Unix paths.

--- a/tests/fixtures/node-module-native/function.js
+++ b/tests/fixtures/node-module-native/function.js
@@ -1,0 +1,1 @@
+module.exports = require('test')

--- a/tests/fixtures/node-module-native/node_modules/test/index.js
+++ b/tests/fixtures/node-module-native/node_modules/test/index.js
@@ -1,0 +1,14 @@
+let hasLoaded = false
+
+try {
+  require('./native.node')
+} catch (error) {
+  hasLoaded = error.message.includes('no suitable image found')
+}
+
+if (!hasLoaded) {
+  throw new Error('Something is up!')
+}
+
+
+module.exports = true

--- a/tests/fixtures/node-module-native/node_modules/test/index.js
+++ b/tests/fixtures/node-module-native/node_modules/test/index.js
@@ -1,13 +1,7 @@
-let hasLoaded = false
-
 try {
   require('./native.node')
-} catch (error) {
-  hasLoaded = error.message.includes('no suitable image found')
-}
-
-if (!hasLoaded) {
-  throw new Error('Something is up!')
+} catch (_) {
+  // The .node file is empty, so the `require` is expected to fail.
 }
 
 

--- a/tests/fixtures/node-module-native/node_modules/test/package.json
+++ b/tests/fixtures/node-module-native/node_modules/test/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "test",
+  "version": "1.0.0",
+  "main": "./index.js"
+}

--- a/tests/fixtures/node-module-native/package.json
+++ b/tests/fixtures/node-module-native/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "local-node-module",
+  "version": "1.0.0",
+  "dependencies": {
+    "test": "1.0.2"
+  }
+}

--- a/tests/helpers/main.js
+++ b/tests/helpers/main.js
@@ -9,20 +9,18 @@ const { zipFunctions } = require('../..')
 
 const FIXTURES_DIR = join(__dirname, '..', 'fixtures')
 
-const zipNode = async function (t, fixture, { bundler, length, fixtureDir, opts } = {}) {
-  const bundlerOpts = bundler === 'esbuild' ? { useEsbuild: true } : {}
+const zipNode = async function (t, fixture, { length, fixtureDir, opts } = {}) {
   const { files, tmpDir } = await zipFixture(t, fixture, {
-    bundler,
     length,
     fixtureDir,
-    opts: { ...opts, ...bundlerOpts },
+    opts,
   })
   await requireExtractedFiles(t, files)
   return { files, tmpDir }
 }
 
-const zipFixture = async function (t, fixture, { bundler, length, fixtureDir, opts } = {}) {
-  const { path: tmpDir } = await getTmpDir({ prefix: `zip-it-test-${bundler}` })
+const zipFixture = async function (t, fixture, { length, fixtureDir, opts = {} } = {}) {
+  const { path: tmpDir } = await getTmpDir({ prefix: `zip-it-test-bundler-${opts.jsBundlerVersion}` })
   const { files } = await zipCheckFunctions(t, fixture, { length, fixtureDir, tmpDir, opts })
   return { files, tmpDir }
 }

--- a/tests/helpers/main.js
+++ b/tests/helpers/main.js
@@ -20,7 +20,7 @@ const zipNode = async function (t, fixture, { length, fixtureDir, opts } = {}) {
 }
 
 const zipFixture = async function (t, fixture, { length, fixtureDir, opts = {} } = {}) {
-  const { path: tmpDir } = await getTmpDir({ prefix: `zip-it-test-bundler-${opts.jsBundlerVersion}` })
+  const { path: tmpDir } = await getTmpDir({ prefix: `zip-it-test-bundler-${opts.jsBundler}` })
   const { files } = await zipCheckFunctions(t, fixture, { length, fixtureDir, tmpDir, opts })
   return { files, tmpDir }
 }

--- a/tests/helpers/test_bundlers.js
+++ b/tests/helpers/test_bundlers.js
@@ -1,0 +1,19 @@
+const makeTestBundlers = (test) => {
+  const testBundlers = (title, bundlers, assertions, testFn = test) => {
+    bundlers.forEach((bundler) => {
+      const testTitle = bundler ? `${title} [forcing JS bundler to v${bundler}]` : title
+
+      testFn(testTitle, assertions.bind(null, bundler))
+    })
+  }
+
+  const testFns = ['failing', 'only', 'serial', 'skip']
+
+  testFns.forEach((fn) => {
+    testBundlers[fn] = (...args) => testBundlers(...args, test[fn])
+  })
+
+  return testBundlers
+}
+
+module.exports = { makeTestBundlers }

--- a/tests/helpers/test_bundlers.js
+++ b/tests/helpers/test_bundlers.js
@@ -1,7 +1,7 @@
 const makeTestBundlers = (test) => {
   const testBundlers = (title, bundlers, assertions, testFn = test) => {
     bundlers.forEach((bundler) => {
-      const testTitle = bundler ? `${title} [forcing JS bundler to v${bundler}]` : title
+      const testTitle = bundler ? `${title} [JS bundler: ${bundler}]` : title
 
       testFn(testTitle, assertions.bind(null, bundler))
     })

--- a/tests/main.js
+++ b/tests/main.js
@@ -12,9 +12,11 @@ const pathExists = require('path-exists')
 const { dir: getTmpDir, tmpName } = require('tmp-promise')
 
 const { zipFunction, listFunctions, listFunctionsFiles } = require('..')
+const { JS_BUNDLER_ESBUILD: ESBUILD, JS_BUNDLER_LEGACY: LEGACY } = require('../src/utils/consts')
 
 const { getRequires, zipNode, zipFixture, unzipFiles, zipCheckFunctions, FIXTURES_DIR } = require('./helpers/main')
 const { computeSha1 } = require('./helpers/sha')
+const { makeTestBundlers } = require('./helpers/test_bundlers')
 
 const pReadFile = promisify(readFile)
 const pChmod = promisify(chmod)
@@ -22,7 +24,8 @@ const pSymlink = promisify(symlink)
 const pUnlink = promisify(unlink)
 const pRename = promisify(rename)
 
-const BUNDLERS = ['legacy', 'esbuild']
+// Alias for the default bundler.
+const DEFAULT = undefined
 const EXECUTABLE_PERMISSION = 0o755
 
 const normalizeFiles = function (fixtureDir, { name, mainFile, runtime, extension, srcFile }) {
@@ -31,333 +34,355 @@ const normalizeFiles = function (fixtureDir, { name, mainFile, runtime, extensio
   return { name, mainFile: mainFileA, runtime, extension, ...srcFileA }
 }
 
-const getZipChecksum = async function (t) {
+const getZipChecksum = async function (t, bundler) {
   const {
     files: [{ path }],
-  } = await zipFixture(t, 'many-dependencies')
+  } = await zipFixture(t, 'many-dependencies', { opts: { jsBundlerVersion: bundler } })
   const sha1sum = computeSha1(path)
   return sha1sum
 }
 
 test.after.always(async () => {
-  await del(`${tmpdir()}/zip-it-test*`, { force: true })
+  await del(`${tmpdir()}/zip-it-test-bundler-all*`, { force: true })
 })
 
-// Common tests.
-BUNDLERS.forEach((bundler) => {
-  const zipNodeWithBundler = (t, fixture, options = {}) => zipNode(t, fixture, { bundler, ...options })
+// Convenience method for running a test for each JS bundler.
+const testBundlers = makeTestBundlers(test)
 
-  test(`[bundler: ${bundler}] Zips Node.js function files`, async (t) => {
-    const { files } = await zipNode(t, 'simple')
-    t.true(files.every(({ runtime }) => runtime === 'js'))
+testBundlers('Zips Node.js function files', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+  const { files } = await zipNode(t, 'simple', { opts: { jsBundlerVersion: bundler } })
+  t.true(files.every(({ runtime }) => runtime === 'js'))
+})
+
+testBundlers('Handles Node module with native bindings', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+  const jsExternalModules = bundler === ESBUILD ? ['test'] : undefined
+  const { files } = await zipNode(t, 'node-module-native', {
+    opts: { jsBundlerVersion: bundler, jsExternalModules },
+  })
+  t.true(files.every(({ runtime }) => runtime === 'js'))
+})
+
+testBundlers('Can require node modules', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+  await zipNode(t, 'local-node-module', { opts: { jsBundlerVersion: bundler } })
+})
+
+testBundlers('Can require scoped node modules', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+  await zipNode(t, 'node-module-scope', { opts: { jsBundlerVersion: bundler } })
+})
+
+testBundlers('Can require node modules nested files', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+  await zipNode(t, 'node-module-path', { opts: { jsBundlerVersion: bundler } })
+})
+
+testBundlers('Can require dynamically generated node modules', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+  await zipNode(t, 'side-module', { opts: { jsBundlerVersion: bundler } })
+})
+
+testBundlers('Ignore some excluded node modules', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+  const { tmpDir } = await zipNode(t, 'node-module-excluded', { opts: { jsBundlerVersion: bundler } })
+  t.false(await pathExists(`${tmpDir}/src/node_modules/aws-sdk`))
+})
+
+testBundlers('Ignore TypeScript types', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+  const { tmpDir } = await zipNode(t, 'node-module-typescript-types', {
+    opts: { jsBundlerVersion: bundler },
+  })
+  t.false(await pathExists(`${tmpDir}/src/node_modules/@types/node`))
+})
+
+testBundlers('Throws on runtime errors', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+  await t.throwsAsync(zipNode(t, 'node-module-error', { opts: { jsBundlerVersion: bundler } }))
+})
+
+testBundlers('Throws on missing dependencies', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+  await t.throwsAsync(zipNode(t, 'node-module-missing', { opts: { jsBundlerVersion: bundler } }))
+})
+
+testBundlers(
+  'Throws on missing dependencies with no optionalDependencies',
+  [ESBUILD, LEGACY, DEFAULT],
+  async (bundler, t) => {
+    await t.throwsAsync(zipNode(t, 'node-module-missing-package', { opts: { jsBundlerVersion: bundler } }))
+  },
+)
+
+testBundlers('Throws on missing conditional dependencies', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+  await t.throwsAsync(zipNode(t, 'node-module-missing-conditional', { opts: { jsBundlerVersion: bundler } }))
+})
+
+testBundlers("Throws on missing dependencies' dependencies", [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+  await t.throwsAsync(zipNode(t, 'node-module-missing-deep', { opts: { jsBundlerVersion: bundler } }))
+})
+
+testBundlers('Ignore missing optional dependencies', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+  await zipNode(t, 'node-module-missing-optional', { opts: { jsBundlerVersion: bundler } })
+})
+
+testBundlers('Ignore modules conditional dependencies', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+  await zipNode(t, 'node-module-deep-conditional', { opts: { jsBundlerVersion: bundler } })
+})
+
+testBundlers('Ignore missing optional peer dependencies', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+  await zipNode(t, 'node-module-peer-optional', { opts: { jsBundlerVersion: bundler } })
+})
+
+testBundlers(
+  'Throws on missing optional peer dependencies with no peer dependencies',
+  [ESBUILD, LEGACY, DEFAULT],
+  async (bundler, t) => {
+    await t.throwsAsync(zipNode(t, 'node-module-peer-optional-none', { opts: { jsBundlerVersion: bundler } }))
+  },
+)
+
+testBundlers('Throws on missing non-optional peer dependencies', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+  await t.throwsAsync(zipNode(t, 'node-module-peer-not-optional', { opts: { jsBundlerVersion: bundler } }))
+})
+
+testBundlers(
+  'Resolves dependencies from .netlify/plugins/node_modules',
+  [ESBUILD, LEGACY, DEFAULT],
+  async (bundler, t) => {
+    await zipNode(t, 'node-module-next-image', { opts: { jsBundlerVersion: bundler } })
+  },
+)
+
+// We persist `package.json` as `package.json.txt` in git. Otherwise ESLint
+// tries to load when linting sibling JavaScript files. In this test, we
+// temporarily rename it to an actual `package.json`.
+testBundlers('Throws on invalid package.json', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+  const fixtureDir = await tmpName({ prefix: `zip-it-test-bundler-${bundler}` })
+  await cpy('**', `${fixtureDir}/invalid-package-json`, {
+    cwd: `${FIXTURES_DIR}/invalid-package-json`,
+    parents: true,
   })
 
-  test(`[bundler: ${bundler}] Can require node modules`, async (t) => {
-    await zipNodeWithBundler(t, 'local-node-module')
-  })
+  const invalidPackageJsonDir = `${fixtureDir}/invalid-package-json`
+  const srcPackageJson = `${invalidPackageJsonDir}/package.json.txt`
+  const distPackageJson = `${invalidPackageJsonDir}/package.json`
+  const expectedErrorRegex =
+    bundler === ESBUILD ? /package.json:1:1: error: Expected string but found "{"/ : /invalid JSON/
 
-  test(`[bundler: ${bundler}] Can require scoped node modules`, async (t) => {
-    await zipNodeWithBundler(t, 'node-module-scope')
-  })
+  await pRename(srcPackageJson, distPackageJson)
+  try {
+    await t.throwsAsync(
+      zipNode(t, 'invalid-package-json', { opts: { jsBundlerVersion: bundler }, fixtureDir }),
+      expectedErrorRegex,
+    )
+  } finally {
+    await pRename(distPackageJson, srcPackageJson)
+  }
+})
 
-  test(`[bundler: ${bundler}] Can require node modules nested files`, async (t) => {
-    await zipNodeWithBundler(t, 'node-module-path')
-  })
+testBundlers('Ignore invalid require()', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+  await zipNode(t, 'invalid-require', { opts: { jsBundlerVersion: bundler } })
+})
 
-  test(`[bundler: ${bundler}] Can require dynamically generated node modules`, async (t) => {
-    await zipNodeWithBundler(t, 'side-module')
-  })
+testBundlers('Can require local files', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+  await zipNode(t, 'local-require', { opts: { jsBundlerVersion: bundler } })
+})
 
-  test(`[bundler: ${bundler}] Ignore some excluded node modules`, async (t) => {
-    const { tmpDir } = await zipNodeWithBundler(t, 'node-module-excluded')
-    t.false(await pathExists(`${tmpDir}/src/node_modules/aws-sdk`))
-  })
+testBundlers('Can require local files deeply', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+  await zipNode(t, 'local-deep-require', { opts: { jsBundlerVersion: bundler } })
+})
 
-  test(`[bundler: ${bundler}] Ignore TypeScript types`, async (t) => {
-    const { tmpDir } = await zipNodeWithBundler(t, 'node-module-typescript-types')
-    t.false(await pathExists(`${tmpDir}/src/node_modules/@types/node`))
-  })
+testBundlers('Can require local files in the parent directories', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+  await zipNode(t, 'local-parent-require', { opts: { jsBundlerVersion: bundler } })
+})
 
-  test(`[bundler: ${bundler}] Throws on runtime errors`, async (t) => {
-    await t.throwsAsync(zipNodeWithBundler(t, 'node-module-error'))
-  })
+testBundlers('Ignore missing critters dependency for Next.js 10', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+  await zipNode(t, 'node-module-next10-critters', { opts: { jsBundlerVersion: bundler } })
+})
 
-  test(`[bundler: ${bundler}] Throws on missing dependencies`, async (t) => {
-    await t.throwsAsync(zipNodeWithBundler(t, 'node-module-missing'))
-  })
+testBundlers(
+  'Ignore missing critters dependency for Next.js exact version 10.0.5',
+  [ESBUILD, LEGACY, DEFAULT],
+  async (bundler, t) => {
+    await zipNode(t, 'node-module-next10-critters-exact', { opts: { jsBundlerVersion: bundler } })
+  },
+)
 
-  test(`[bundler: ${bundler}] Throws on missing dependencies with no optionalDependencies`, async (t) => {
-    await t.throwsAsync(zipNodeWithBundler(t, 'node-module-missing-package'))
-  })
+testBundlers(
+  'Ignore missing critters dependency for Next.js with range ^10.0.5',
+  [ESBUILD, LEGACY, DEFAULT],
+  async (bundler, t) => {
+    await zipNode(t, 'node-module-next10-critters-10.0.5-range', { opts: { jsBundlerVersion: bundler } })
+  },
+)
 
-  test(`[bundler: ${bundler}] Throws on missing conditional dependencies`, async (t) => {
-    await t.throwsAsync(zipNodeWithBundler(t, 'node-module-missing-conditional'))
-  })
+testBundlers(
+  "Ignore missing critters dependency for Next.js with version='latest'",
+  [ESBUILD, LEGACY, DEFAULT],
+  async (bundler, t) => {
+    await zipNode(t, 'node-module-next10-critters-latest', { opts: { jsBundlerVersion: bundler } })
+  },
+)
 
-  test(`[bundler: ${bundler}] Throws on missing dependencies' dependencies`, async (t) => {
-    await t.throwsAsync(zipNodeWithBundler(t, 'node-module-missing-deep'))
-  })
-
-  test(`[bundler: ${bundler}] Ignore missing optional dependencies`, async (t) => {
-    await zipNodeWithBundler(t, 'node-module-missing-optional')
-  })
-
-  test(`[bundler: ${bundler}] Ignore modules conditional dependencies`, async (t) => {
-    await zipNodeWithBundler(t, 'node-module-deep-conditional')
-  })
-
-  test(`[bundler: ${bundler}] Ignore missing optional peer dependencies`, async (t) => {
-    await zipNodeWithBundler(t, 'node-module-peer-optional')
-  })
-
-  test(`[bundler: ${bundler}] Throws on missing optional peer dependencies with no peer dependencies`, async (t) => {
-    await t.throwsAsync(zipNodeWithBundler(t, 'node-module-peer-optional-none'))
-  })
-
-  test(`[bundler: ${bundler}] Throws on missing non-optional peer dependencies`, async (t) => {
-    await t.throwsAsync(zipNodeWithBundler(t, 'node-module-peer-not-optional'))
-  })
-
-  test(`[bundler: ${bundler}] Resolves dependencies from .netlify/plugins/node_modules`, async (t) => {
-    await zipNodeWithBundler(t, 'node-module-next-image')
-  })
-
-  // We persist `package.json` as `package.json.txt` in git. Otherwise ESLint
-  // tries to load when linting sibling JavaScript files. In this test, we
-  // temporarily rename it to an actual `package.json`.
-  test(`[bundler: ${bundler}] Throws on invalid package.json`, async (t) => {
+// Need to create symlinks dynamically because they sometimes get lost when
+// committed on Windows
+if (platform !== 'win32') {
+  testBundlers('Can require symlinks', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
     const fixtureDir = await tmpName({ prefix: `zip-it-test-bundler-${bundler}` })
-    await cpy('**', `${fixtureDir}/invalid-package-json`, {
-      cwd: `${FIXTURES_DIR}/invalid-package-json`,
+    await cpy('**', `${fixtureDir}/symlinks`, {
+      cwd: `${FIXTURES_DIR}/symlinks`,
       parents: true,
     })
 
-    const invalidPackageJsonDir = `${fixtureDir}/invalid-package-json`
-    const srcPackageJson = `${invalidPackageJsonDir}/package.json.txt`
-    const distPackageJson = `${invalidPackageJsonDir}/package.json`
-    const expectedErrorRegex =
-      bundler === 'esbuild' ? /package.json:1:1: error: Expected string but found "{"/ : /invalid JSON/
+    const symlinkDir = `${fixtureDir}/symlinks/function`
+    const symlinkFile = `${symlinkDir}/file.js`
+    const targetFile = `${symlinkDir}/target.js`
 
-    await pRename(srcPackageJson, distPackageJson)
+    if (!(await pathExists(symlinkFile))) {
+      await pSymlink(targetFile, symlinkFile)
+    }
+
     try {
-      await t.throwsAsync(zipNodeWithBundler(t, 'invalid-package-json', { fixtureDir }), expectedErrorRegex)
+      await zipNode(t, 'symlinks', { opts: { jsBundlerVersion: bundler }, fixtureDir })
     } finally {
-      await pRename(distPackageJson, srcPackageJson)
+      await pUnlink(symlinkFile)
     }
   })
+}
 
-  test(`[bundler: ${bundler}] Ignore invalid require()`, async (t) => {
-    await zipNodeWithBundler(t, 'invalid-require')
-  })
+testBundlers(
+  'Can target a directory with a main file with the same name',
+  [ESBUILD, LEGACY, DEFAULT],
+  async (bundler, t) => {
+    await zipNode(t, 'directory-handler', { opts: { jsBundlerVersion: bundler } })
+  },
+)
 
-  test(`[bundler: ${bundler}] Can require local files`, async (t) => {
-    await zipNodeWithBundler(t, 'local-require')
-  })
+testBundlers('Can target a directory with an index.js file', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+  const { files, tmpDir } = await zipFixture(t, 'index-handler', { opts: { jsBundlerVersion: bundler } })
+  await unzipFiles(files)
+  // eslint-disable-next-line import/no-dynamic-require, node/global-require
+  t.true(require(`${tmpDir}/function.js`))
+})
 
-  test(`[bundler: ${bundler}] Can require local files deeply`, async (t) => {
-    await zipNodeWithBundler(t, 'local-deep-require')
-  })
+testBundlers('Keeps non-required files inside the target directory', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+  const { tmpDir } = await zipNode(t, 'keep-dir-files', { opts: { jsBundlerVersion: bundler } })
+  t.true(await pathExists(`${tmpDir}/function.js`))
+})
 
-  test(`[bundler: ${bundler}] Can require local files in the parent directories`, async (t) => {
-    await zipNodeWithBundler(t, 'local-parent-require')
-  })
-
-  test(`[bundler: ${bundler}] Ignore missing critters dependency for Next.js 10`, async (t) => {
-    await zipNodeWithBundler(t, 'node-module-next10-critters')
-  })
-
-  test(`[bundler: ${bundler}] Ignore missing critters dependency for Next.js exact version 10.0.5`, async (t) => {
-    await zipNodeWithBundler(t, 'node-module-next10-critters-exact')
-  })
-
-  test(`[bundler: ${bundler}] Ignore missing critters dependency for Next.js with range ^10.0.5`, async (t) => {
-    await zipNodeWithBundler(t, 'node-module-next10-critters-10.0.5-range')
-  })
-
-  test(`[bundler: ${bundler}] Ignore missing critters dependency for Next.js with version='latest'`, async (t) => {
-    await zipNodeWithBundler(t, 'node-module-next10-critters-latest')
-  })
-
-  // Need to create symlinks dynamically because they sometimes get lost when
-  // committed on Windows
-  if (platform !== 'win32') {
-    test(`[bundler: ${bundler}] Can require symlinks`, async (t) => {
-      const fixtureDir = await tmpName({ prefix: `zip-it-test-bundler-${bundler}` })
-      await cpy('**', `${fixtureDir}/symlinks`, {
-        cwd: `${FIXTURES_DIR}/symlinks`,
-        parents: true,
-      })
-
-      const symlinkDir = `${fixtureDir}/symlinks/function`
-      const symlinkFile = `${symlinkDir}/file.js`
-      const targetFile = `${symlinkDir}/target.js`
-
-      if (!(await pathExists(symlinkFile))) {
-        await pSymlink(targetFile, symlinkFile)
-      }
-
-      try {
-        await zipNodeWithBundler(t, 'symlinks', { fixtureDir })
-      } finally {
-        await pUnlink(symlinkFile)
-      }
-    })
-  }
-
-  test(`[bundler: ${bundler}] Can target a directory with a main file with the same name`, async (t) => {
-    await zipNodeWithBundler(t, 'directory-handler')
-  })
-
-  test(`[bundler: ${bundler}] Can target a directory with an index.js file`, async (t) => {
-    const { files, tmpDir } = await zipFixture(t, 'index-handler')
-    await unzipFiles(files)
-    // eslint-disable-next-line import/no-dynamic-require, node/global-require
-    t.true(require(`${tmpDir}/function.js`))
-  })
-
-  test(`[bundler: ${bundler}] Keeps non-required files inside the target directory`, async (t) => {
-    const { tmpDir } = await zipNodeWithBundler(t, 'keep-dir-files')
-    t.true(await pathExists(`${tmpDir}/function.js`))
-  })
-
-  test(`[bundler: ${bundler}] Ignores non-required node_modules inside the target directory`, async (t) => {
-    const { tmpDir } = await zipNodeWithBundler(t, 'ignore-dir-node-modules')
+testBundlers(
+  'Ignores non-required node_modules inside the target directory',
+  [ESBUILD, LEGACY, DEFAULT],
+  async (bundler, t) => {
+    const { tmpDir } = await zipNode(t, 'ignore-dir-node-modules', { opts: { jsBundlerVersion: bundler } })
     t.false(await pathExists(`${tmpDir}/src/node_modules`))
-  })
+  },
+)
 
-  test(`[bundler: ${bundler}] Ignores deep non-required node_modules inside the target directory`, async (t) => {
-    const { tmpDir } = await zipNodeWithBundler(t, 'ignore-deep-dir-node-modules')
+testBundlers(
+  'Ignores deep non-required node_modules inside the target directory',
+  [ESBUILD, LEGACY, DEFAULT],
+  async (bundler, t) => {
+    const { tmpDir } = await zipNode(t, 'ignore-deep-dir-node-modules', {
+      opts: { jsBundlerVersion: bundler },
+    })
     t.false(await pathExists(`${tmpDir}/src/deep/node_modules`))
+  },
+)
+
+testBundlers('Works with many dependencies', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+  await zipNode(t, 'many-dependencies', { opts: { jsBundlerVersion: bundler } })
+})
+
+testBundlers('Works with many function files', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+  await zipNode(t, 'many-functions', {
+    opts: { jsBundlerVersion: bundler },
+    length: TEST_FUNCTIONS_LENGTH,
   })
+})
 
-  test(`[bundler: ${bundler}] Works with many dependencies`, async (t) => {
-    await zipNodeWithBundler(t, 'many-dependencies')
-  })
+const TEST_FUNCTIONS_LENGTH = 6
 
-  test(`[bundler: ${bundler}] Works with many function files`, async (t) => {
-    await zipNodeWithBundler(t, 'many-functions', { length: TEST_FUNCTIONS_LENGTH })
-  })
+testBundlers('Produces deterministic checksums', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+  const [checksumOne, checksumTwo] = await Promise.all([getZipChecksum(t, bundler), getZipChecksum(t, bundler)])
+  t.is(checksumOne, checksumTwo)
+})
 
-  const TEST_FUNCTIONS_LENGTH = 6
+testBundlers('Throws when the source folder does not exist', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+  await t.throwsAsync(
+    zipNode(t, 'does-not-exist', { opts: { jsBundlerVersion: bundler } }),
+    /Functions folder does not exist/,
+  )
+})
 
-  test(`[bundler: ${bundler}] Produces deterministic checksums`, async (t) => {
-    const [checksumOne, checksumTwo] = await Promise.all([getZipChecksum(t), getZipChecksum(t)])
-    t.is(checksumOne, checksumTwo)
-  })
+testBundlers('Works even if destination folder does not exist', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+  await zipNode(t, 'simple', { opts: { jsBundlerVersion: bundler } })
+})
 
-  test(`[bundler: ${bundler}] Throws when the source folder does not exist`, async (t) => {
-    await t.throwsAsync(zipNodeWithBundler(t, 'does-not-exist'), /Functions folder does not exist/)
-  })
+testBundlers('Do not consider node_modules as a function file', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+  await zipNode(t, 'ignore-node-modules', { opts: { jsBundlerVersion: bundler } })
+})
 
-  test(`[bundler: ${bundler}] Works even if destination folder does not exist`, async (t) => {
-    await zipNodeWithBundler(t, 'simple')
-  })
+testBundlers('Ignore directories without a main file', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+  await zipNode(t, 'ignore-directories', { opts: { jsBundlerVersion: bundler } })
+})
 
-  test(`[bundler: ${bundler}] Do not consider node_modules as a function file`, async (t) => {
-    await zipNodeWithBundler(t, 'ignore-node-modules')
-  })
+testBundlers('Remove useless files', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+  const { tmpDir } = await zipNode(t, 'useless', { opts: { jsBundlerVersion: bundler } })
+  t.false(await pathExists(`${tmpDir}/src/Desktop.ini`))
+})
 
-  test(`[bundler: ${bundler}] Ignore directories without a main file`, async (t) => {
-    await zipNodeWithBundler(t, 'ignore-directories')
-  })
+testBundlers('Works on empty directories', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+  await zipNode(t, 'empty', { opts: { jsBundlerVersion: bundler }, length: 0 })
+})
 
-  test(`[bundler: ${bundler}] Remove useless files`, async (t) => {
-    const { tmpDir } = await zipNodeWithBundler(t, 'useless')
-    t.false(await pathExists(`${tmpDir}/src/Desktop.ini`))
-  })
+testBundlers('Works when no package.json is present', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+  const fixtureDir = await tmpName({ prefix: `zip-it-test-bundler-${bundler}` })
+  await cpy('**', `${fixtureDir}/no-package-json`, { cwd: `${FIXTURES_DIR}/no-package-json`, parents: true })
+  await zipNode(t, 'no-package-json', { opts: { jsBundlerVersion: bundler }, length: 1, fixtureDir })
+})
 
-  test(`[bundler: ${bundler}] Works on empty directories`, async (t) => {
-    await zipNodeWithBundler(t, 'empty', { length: 0 })
-  })
+testBundlers('Copies already zipped files', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+  const tmpDir = await tmpName({ prefix: `zip-it-test-bundler-${bundler}` })
+  const { files } = await zipCheckFunctions(t, 'keep-zip', { tmpDir })
 
-  test(`[bundler: ${bundler}] Works when no package.json is present`, async (t) => {
-    const fixtureDir = await tmpName({ prefix: `zip-it-test-bundler-${bundler}` })
-    await cpy('**', `${fixtureDir}/no-package-json`, { cwd: `${FIXTURES_DIR}/no-package-json`, parents: true })
-    await zipNodeWithBundler(t, 'no-package-json', { length: 1, fixtureDir })
-  })
+  t.true(files.every(({ runtime }) => runtime === 'js'))
+  t.true(
+    (await Promise.all(files.map(async ({ path }) => (await pReadFile(path, 'utf8')).trim() === 'test'))).every(
+      Boolean,
+    ),
+  )
+})
 
-  test(`[bundler: ${bundler}] Copies already zipped files`, async (t) => {
-    const tmpDir = await tmpName({ prefix: `zip-it-test-bundler-${bundler}` })
-    const { files } = await zipCheckFunctions(t, 'keep-zip', { tmpDir })
+testBundlers('Ignore unsupported programming languages', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+  await zipFixture(t, 'unsupported', { length: 0, opts: { jsBundlerVersion: bundler } })
+})
 
-    t.true(files.every(({ runtime }) => runtime === 'js'))
-    t.true(
-      (await Promise.all(files.map(async ({ path }) => (await pReadFile(path, 'utf8')).trim() === 'test'))).every(
-        Boolean,
-      ),
-    )
-  })
+testBundlers('Can reduce parallelism', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+  await zipNode(t, 'simple', { length: 1, opts: { jsBundlerVersion: bundler, parallelLimit: 1 } })
+})
 
-  test(`[bundler: ${bundler}] Zips Go function files`, async (t) => {
-    const { files, tmpDir } = await zipFixture(t, 'go-simple', { length: 1, opts: { zipGo: true } })
+testBundlers('Can use zipFunction()', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+  const { path: tmpDir } = await getTmpDir({ prefix: 'zip-it-test' })
+  const { runtime } = await zipFunction(`${FIXTURES_DIR}/simple/function.js`, tmpDir, { jsBundlerVersion: bundler })
+  t.is(runtime, 'js')
+})
 
-    t.true(files.every(({ runtime }) => runtime === 'go'))
+testBundlers('Can list function main files with listFunctions()', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+  const fixtureDir = `${FIXTURES_DIR}/list`
+  const functions = await listFunctions(fixtureDir)
+  t.deepEqual(
+    functions,
+    [
+      { name: 'four', mainFile: 'four.js/four.js.js', runtime: 'js', extension: '.js' },
+      { name: 'one', mainFile: 'one/index.js', runtime: 'js', extension: '.js' },
+      { name: 'test', mainFile: 'test', runtime: 'go', extension: '' },
+      { name: 'test', mainFile: 'test.js', runtime: 'js', extension: '.js' },
+      { name: 'test', mainFile: 'test.zip', runtime: 'js', extension: '.zip' },
+      { name: 'two', mainFile: 'two/two.js', runtime: 'js', extension: '.js' },
+    ].map(normalizeFiles.bind(null, fixtureDir)),
+  )
+})
 
-    await unzipFiles(files)
-
-    const unzippedFile = `${tmpDir}/test`
-    t.true(await pathExists(unzippedFile))
-
-    // The library we use for unzipping does not keep executable permissions.
-    // https://github.com/cthackers/adm-zip/issues/86
-    // However `chmod()` is not cross-platform
-    if (platform === 'linux') {
-      await pChmod(unzippedFile, EXECUTABLE_PERMISSION)
-
-      const { stdout } = await execa(unzippedFile)
-      t.is(stdout, 'test')
-    }
-
-    const tcFile = `${tmpDir}/netlify-toolchain`
-    t.true(await pathExists(tcFile))
-    const tc = (await pReadFile(tcFile, 'utf8')).trim()
-    t.is(tc, '{"runtime":"go"}')
-  })
-
-  test(`[bundler: ${bundler}] Can skip zipping Go function files`, async (t) => {
-    const { files } = await zipFixture(t, 'go-simple', { length: 1 })
-
-    t.true(files.every(({ runtime }) => runtime === 'go'))
-    t.true(
-      (await Promise.all(files.map(async ({ path }) => !path.endsWith('.zip') && (await pathExists(path))))).every(
-        Boolean,
-      ),
-    )
-  })
-
-  test(`[bundler: ${bundler}] Ignore unsupported programming languages`, async (t) => {
-    await zipFixture(t, 'unsupported', { length: 0 })
-  })
-
-  test(`[bundler: ${bundler}] Can reduce parallelism`, async (t) => {
-    await zipNodeWithBundler(t, 'simple', { length: 1, opts: { parallelLimit: 1 } })
-  })
-
-  test(`[bundler: ${bundler}] Can use zipFunction()`, async (t) => {
-    const { path: tmpDir } = await getTmpDir({ prefix: 'zip-it-test' })
-    const { runtime } = await zipFunction(`${FIXTURES_DIR}/simple/function.js`, tmpDir)
-    t.is(runtime, 'js')
-  })
-
-  test(`[bundler: ${bundler}] Can list function main files with listFunctions()`, async (t) => {
+testBundlers(
+  'Can list all function files with listFunctionsFiles()',
+  [ESBUILD, LEGACY, DEFAULT],
+  async (bundler, t) => {
     const fixtureDir = `${FIXTURES_DIR}/list`
-    const functions = await listFunctions(fixtureDir)
-    t.deepEqual(
-      functions,
-      [
-        { name: 'four', mainFile: 'four.js/four.js.js', runtime: 'js', extension: '.js' },
-        { name: 'one', mainFile: 'one/index.js', runtime: 'js', extension: '.js' },
-        { name: 'test', mainFile: 'test', runtime: 'go', extension: '' },
-        { name: 'test', mainFile: 'test.js', runtime: 'js', extension: '.js' },
-        { name: 'test', mainFile: 'test.zip', runtime: 'js', extension: '.zip' },
-        { name: 'two', mainFile: 'two/two.js', runtime: 'js', extension: '.js' },
-      ].map(normalizeFiles.bind(null, fixtureDir)),
-    )
-  })
-
-  test(`[bundler: ${bundler}] Can list all function files with listFunctionsFiles()`, async (t) => {
-    const fixtureDir = `${FIXTURES_DIR}/list`
-    const functions = await listFunctionsFiles(fixtureDir)
+    const functions = await listFunctionsFiles(fixtureDir, { jsBundlerVersion: bundler })
     t.deepEqual(
       functions,
       [
@@ -372,46 +397,31 @@ BUNDLERS.forEach((bundler) => {
         { name: 'test', mainFile: 'test', runtime: 'go', extension: '', srcFile: 'test' },
         { name: 'test', mainFile: 'test.js', runtime: 'js', extension: '.js', srcFile: 'test.js' },
         { name: 'test', mainFile: 'test.zip', runtime: 'js', extension: '.zip', srcFile: 'test.zip' },
-        { name: 'two', mainFile: 'two/two.js', runtime: 'js', extension: '.json', srcFile: 'two/three.json' },
+
+        // The JSON file should only be present when using the legacy bundler,
+        // since esbuild will inline it within the main file.
+        bundler === LEGACY && {
+          name: 'two',
+          mainFile: 'two/two.js',
+          runtime: 'js',
+          extension: '.json',
+          srcFile: 'two/three.json',
+        },
+
         { name: 'two', mainFile: 'two/two.js', runtime: 'js', extension: '.js', srcFile: 'two/two.js' },
-      ].map(normalizeFiles.bind(null, fixtureDir)),
+      ]
+        .filter(Boolean)
+        .map(normalizeFiles.bind(null, fixtureDir)),
     )
-  })
+  },
+)
 
-  test(`[bundler: ${bundler}] Zips Rust function files`, async (t) => {
-    const { files, tmpDir } = await zipFixture(t, 'rust-simple', { length: 1 })
-
-    t.true(files.every(({ runtime }) => runtime === 'rs'))
-
-    await unzipFiles(files)
-
-    const unzippedFile = `${tmpDir}/bootstrap`
-    t.true(await pathExists(unzippedFile))
-
-    // The library we use for unzipping does not keep executable permissions.
-    // https://github.com/cthackers/adm-zip/issues/86
-    // However `chmod()` is not cross-platform
-    if (platform === 'linux') {
-      await pChmod(unzippedFile, EXECUTABLE_PERMISSION)
-
-      const { stdout } = await execa(unzippedFile)
-      t.is(stdout, 'Hello, world!')
-    }
-
-    const tcFile = `${tmpDir}/netlify-toolchain`
-    t.true(await pathExists(tcFile))
-    const tc = (await pReadFile(tcFile, 'utf8')).trim()
-    t.is(tc, '{"runtime":"rs"}')
-  })
+testBundlers('Zips node modules', [LEGACY], async (bundler, t) => {
+  await zipNode(t, 'node-module', { opts: { jsBundlerVersion: bundler } })
 })
 
-// Legacy bundler tests.
-test('[bundler: legacy] Zips node modules', async (t) => {
-  await zipNode(t, 'node-module', { bundler: 'legacy' })
-})
-
-test('[bundler: legacy] Include most files from node modules', async (t) => {
-  const { tmpDir } = await zipNode(t, 'node-module-included', { bundler: 'legacy' })
+testBundlers('Include most files from node modules', [LEGACY], async (bundler, t) => {
+  const { tmpDir } = await zipNode(t, 'node-module-included', { opts: { jsBundlerVersion: bundler } })
   const [mapExists, htmlExists] = await Promise.all([
     pathExists(`${tmpDir}/src/node_modules/test/test.map`),
     pathExists(`${tmpDir}/src/node_modules/test/test.html`),
@@ -420,12 +430,12 @@ test('[bundler: legacy] Include most files from node modules', async (t) => {
   t.true(htmlExists)
 })
 
-test('[bundler: legacy] Throws on missing critters dependency for Next.js 9', async (t) => {
-  await t.throwsAsync(zipNode(t, 'node-module-next9-critters', { bundler: 'legacy' }))
+testBundlers('Throws on missing critters dependency for Next.js 9', [LEGACY], async (bundler, t) => {
+  await t.throwsAsync(zipNode(t, 'node-module-next9-critters', { opts: { jsBundlerVersion: bundler } }))
 })
 
-test('[bundler: legacy] Includes specific Next.js dependencies when using next-on-netlify', async (t) => {
-  const { tmpDir } = await zipNode(t, 'node-module-next-on-netlify', { bundler: 'legacy' })
+testBundlers('Includes specific Next.js dependencies when using next-on-netlify', [LEGACY], async (bundler, t) => {
+  const { tmpDir } = await zipNode(t, 'node-module-next-on-netlify', { opts: { jsBundlerVersion: bundler } })
   const [constantsExists, semverExists, otherExists, indexExists] = await Promise.all([
     pathExists(`${tmpDir}/src/node_modules/next/dist/next-server/lib/constants.js`),
     pathExists(`${tmpDir}/src/node_modules/next/dist/compiled/semver.js`),
@@ -438,8 +448,8 @@ test('[bundler: legacy] Includes specific Next.js dependencies when using next-o
   t.false(indexExists)
 })
 
-test('[bundler: legacy] Includes all Next.js dependencies when not using next-on-netlify', async (t) => {
-  const { tmpDir } = await zipNode(t, 'node-module-next', { bundler: 'legacy' })
+testBundlers('Includes all Next.js dependencies when not using next-on-netlify', [LEGACY], async (bundler, t) => {
+  const { tmpDir } = await zipNode(t, 'node-module-next', { opts: { jsBundlerVersion: bundler } })
   const [constantsExists, semverExists, otherExists, indexExists] = await Promise.all([
     pathExists(`${tmpDir}/src/node_modules/next/dist/next-server/lib/constants.js`),
     pathExists(`${tmpDir}/src/node_modules/next/dist/compiled/semver.js`),
@@ -452,55 +462,129 @@ test('[bundler: legacy] Includes all Next.js dependencies when not using next-on
   t.true(indexExists)
 })
 
-// esbuild bundler tests.
-test('[bundler: esbuild] Inlines node modules in the bundle', async (t) => {
-  const { tmpDir } = await zipNode(t, 'node-module-included-try-catch', { bundler: 'esbuild' })
+testBundlers('Inlines node modules in the bundle', [ESBUILD, DEFAULT], async (bundler, t) => {
+  const { tmpDir } = await zipNode(t, 'node-module-included-try-catch', { opts: { jsBundlerVersion: bundler } })
   const requires = await getRequires({ filePath: resolve(tmpDir, 'function.js') })
 
   t.false(requires.includes('test'))
   t.false(await pathExists(`${tmpDir}/src/node_modules/test`))
 })
 
-test('[bundler: esbuild] Does not inline node modules and includes them in a `node_modules` directory if they are defined in `externalModules`', async (t) => {
-  const { tmpDir } = await zipNode(t, 'node-module-included-try-catch', {
-    bundler: 'esbuild',
-    opts: { externalModules: ['test'] },
-  })
-  const requires = await getRequires({ filePath: resolve(tmpDir, 'function.js') })
+testBundlers(
+  'Does not inline node modules and includes them in a `node_modules` directory if they are defined in `externalModules`',
+  [ESBUILD, DEFAULT],
+  async (bundler, t) => {
+    const { tmpDir } = await zipNode(t, 'node-module-included-try-catch', {
+      opts: { jsBundlerVersion: bundler, jsExternalModules: ['test'] },
+    })
+    const requires = await getRequires({ filePath: resolve(tmpDir, 'function.js') })
 
-  t.true(requires.includes('test'))
-  t.true(await pathExists(`${tmpDir}/src/node_modules/test`))
+    t.true(requires.includes('test'))
+    t.true(await pathExists(`${tmpDir}/src/node_modules/test`))
+  },
+)
+
+testBundlers(
+  'Does not inline node modules and excludes them from the bundle if they are defined in `ignoredModules`',
+  [ESBUILD, DEFAULT],
+  async (bundler, t) => {
+    const { tmpDir } = await zipNode(t, 'node-module-included-try-catch', {
+      opts: { jsBundlerVersion: bundler, jsIgnoredModules: ['test'] },
+    })
+    const requires = await getRequires({ filePath: resolve(tmpDir, 'function.js') })
+
+    t.true(requires.includes('test'))
+    t.false(await pathExists(`${tmpDir}/src/node_modules/test`))
+  },
+)
+
+testBundlers(
+  'Include most files from node modules present in `externalModules`',
+  [ESBUILD, DEFAULT],
+  async (bundler, t) => {
+    const { tmpDir } = await zipNode(t, 'node-module-included', {
+      opts: { jsBundlerVersion: bundler, jsExternalModules: ['test'] },
+    })
+    const [mapExists, htmlExists] = await Promise.all([
+      pathExists(`${tmpDir}/src/node_modules/test/test.map`),
+      pathExists(`${tmpDir}/src/node_modules/test/test.html`),
+    ])
+    t.false(mapExists)
+    t.true(htmlExists)
+  },
+)
+
+testBundlers(
+  'Does not throw if one of the modules defined in `externalModules` does not exist',
+  [ESBUILD, DEFAULT],
+  async (bundler, t) => {
+    const { tmpDir } = await zipNode(t, 'node-module-included-try-catch', {
+      opts: { jsBundlerVersion: bundler, jsExternalModules: ['i-do-not-exist'] },
+    })
+
+    t.false(await pathExists(`${tmpDir}/src/node_modules/i-do-not-exist`))
+  },
+)
+
+test('Zips Rust function files', async (t) => {
+  const { files, tmpDir } = await zipFixture(t, 'rust-simple', { length: 1 })
+
+  t.true(files.every(({ runtime }) => runtime === 'rs'))
+
+  await unzipFiles(files)
+
+  const unzippedFile = `${tmpDir}/bootstrap`
+  t.true(await pathExists(unzippedFile))
+
+  // The library we use for unzipping does not keep executable permissions.
+  // https://github.com/cthackers/adm-zip/issues/86
+  // However `chmod()` is not cross-platform
+  if (platform === 'linux') {
+    await pChmod(unzippedFile, EXECUTABLE_PERMISSION)
+
+    const { stdout } = await execa(unzippedFile)
+    t.is(stdout, 'Hello, world!')
+  }
+
+  const tcFile = `${tmpDir}/netlify-toolchain`
+  t.true(await pathExists(tcFile))
+  const tc = (await pReadFile(tcFile, 'utf8')).trim()
+  t.is(tc, '{"runtime":"rs"}')
 })
 
-test('[bundler: esbuild] Does not inline node modules and excludes them from the bundle if they are defined in `ignoredModules`', async (t) => {
-  const { tmpDir } = await zipNode(t, 'node-module-included-try-catch', {
-    bundler: 'esbuild',
-    opts: { ignoredModules: ['test'] },
-  })
-  const requires = await getRequires({ filePath: resolve(tmpDir, 'function.js') })
+test('Zips Go function files', async (t) => {
+  const { files, tmpDir } = await zipFixture(t, 'go-simple', { length: 1, opts: { zipGo: true } })
 
-  t.true(requires.includes('test'))
-  t.false(await pathExists(`${tmpDir}/src/node_modules/test`))
+  t.true(files.every(({ runtime }) => runtime === 'go'))
+
+  await unzipFiles(files)
+
+  const unzippedFile = `${tmpDir}/test`
+  t.true(await pathExists(unzippedFile))
+
+  // The library we use for unzipping does not keep executable permissions.
+  // https://github.com/cthackers/adm-zip/issues/86
+  // However `chmod()` is not cross-platform
+  if (platform === 'linux') {
+    await pChmod(unzippedFile, EXECUTABLE_PERMISSION)
+
+    const { stdout } = await execa(unzippedFile)
+    t.is(stdout, 'test')
+  }
+
+  const tcFile = `${tmpDir}/netlify-toolchain`
+  t.true(await pathExists(tcFile))
+  const tc = (await pReadFile(tcFile, 'utf8')).trim()
+  t.is(tc, '{"runtime":"go"}')
 })
 
-test('[bundler: esbuild] Include most files from node modules present in `externalModules`', async (t) => {
-  const { tmpDir } = await zipNode(t, 'node-module-included', {
-    bundler: 'esbuild',
-    opts: { externalModules: ['test'] },
-  })
-  const [mapExists, htmlExists] = await Promise.all([
-    pathExists(`${tmpDir}/src/node_modules/test/test.map`),
-    pathExists(`${tmpDir}/src/node_modules/test/test.html`),
-  ])
-  t.false(mapExists)
-  t.true(htmlExists)
-})
+test('Can skip zipping Go function files', async (t) => {
+  const { files } = await zipFixture(t, 'go-simple', { length: 1 })
 
-test('[bundler: esbuild] Does not throw if one of the modules defined in `externalModules` does not exist', async (t) => {
-  const { tmpDir } = await zipNode(t, 'node-module-included-try-catch', {
-    bundler: 'esbuild',
-    opts: { externalModules: ['i-do-not-exist'] },
-  })
-
-  t.false(await pathExists(`${tmpDir}/src/node_modules/i-do-not-exist`))
+  t.true(files.every(({ runtime }) => runtime === 'go'))
+  t.true(
+    (await Promise.all(files.map(async ({ path }) => !path.endsWith('.zip') && (await pathExists(path))))).every(
+      Boolean,
+    ),
+  )
 })

--- a/tests/main.js
+++ b/tests/main.js
@@ -37,7 +37,7 @@ const normalizeFiles = function (fixtureDir, { name, mainFile, runtime, extensio
 const getZipChecksum = async function (t, bundler) {
   const {
     files: [{ path }],
-  } = await zipFixture(t, 'many-dependencies', { opts: { jsBundlerVersion: bundler } })
+  } = await zipFixture(t, 'many-dependencies', { opts: { jsBundler: bundler } })
   const sha1sum = computeSha1(path)
   return sha1sum
 }
@@ -50,99 +50,99 @@ test.after.always(async () => {
 const testBundlers = makeTestBundlers(test)
 
 testBundlers('Zips Node.js function files', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
-  const { files } = await zipNode(t, 'simple', { opts: { jsBundlerVersion: bundler } })
+  const { files } = await zipNode(t, 'simple', { opts: { jsBundler: bundler } })
   t.true(files.every(({ runtime }) => runtime === 'js'))
 })
 
 testBundlers('Handles Node module with native bindings', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
   const jsExternalModules = bundler === ESBUILD ? ['test'] : undefined
   const { files } = await zipNode(t, 'node-module-native', {
-    opts: { jsBundlerVersion: bundler, jsExternalModules },
+    opts: { jsBundler: bundler, jsExternalModules },
   })
   t.true(files.every(({ runtime }) => runtime === 'js'))
 })
 
 testBundlers('Can require node modules', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
-  await zipNode(t, 'local-node-module', { opts: { jsBundlerVersion: bundler } })
+  await zipNode(t, 'local-node-module', { opts: { jsBundler: bundler } })
 })
 
 testBundlers('Can require scoped node modules', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
-  await zipNode(t, 'node-module-scope', { opts: { jsBundlerVersion: bundler } })
+  await zipNode(t, 'node-module-scope', { opts: { jsBundler: bundler } })
 })
 
 testBundlers('Can require node modules nested files', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
-  await zipNode(t, 'node-module-path', { opts: { jsBundlerVersion: bundler } })
+  await zipNode(t, 'node-module-path', { opts: { jsBundler: bundler } })
 })
 
 testBundlers('Can require dynamically generated node modules', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
-  await zipNode(t, 'side-module', { opts: { jsBundlerVersion: bundler } })
+  await zipNode(t, 'side-module', { opts: { jsBundler: bundler } })
 })
 
 testBundlers('Ignore some excluded node modules', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
-  const { tmpDir } = await zipNode(t, 'node-module-excluded', { opts: { jsBundlerVersion: bundler } })
+  const { tmpDir } = await zipNode(t, 'node-module-excluded', { opts: { jsBundler: bundler } })
   t.false(await pathExists(`${tmpDir}/src/node_modules/aws-sdk`))
 })
 
 testBundlers('Ignore TypeScript types', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
   const { tmpDir } = await zipNode(t, 'node-module-typescript-types', {
-    opts: { jsBundlerVersion: bundler },
+    opts: { jsBundler: bundler },
   })
   t.false(await pathExists(`${tmpDir}/src/node_modules/@types/node`))
 })
 
 testBundlers('Throws on runtime errors', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
-  await t.throwsAsync(zipNode(t, 'node-module-error', { opts: { jsBundlerVersion: bundler } }))
+  await t.throwsAsync(zipNode(t, 'node-module-error', { opts: { jsBundler: bundler } }))
 })
 
 testBundlers('Throws on missing dependencies', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
-  await t.throwsAsync(zipNode(t, 'node-module-missing', { opts: { jsBundlerVersion: bundler } }))
+  await t.throwsAsync(zipNode(t, 'node-module-missing', { opts: { jsBundler: bundler } }))
 })
 
 testBundlers(
   'Throws on missing dependencies with no optionalDependencies',
   [ESBUILD, LEGACY, DEFAULT],
   async (bundler, t) => {
-    await t.throwsAsync(zipNode(t, 'node-module-missing-package', { opts: { jsBundlerVersion: bundler } }))
+    await t.throwsAsync(zipNode(t, 'node-module-missing-package', { opts: { jsBundler: bundler } }))
   },
 )
 
 testBundlers('Throws on missing conditional dependencies', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
-  await t.throwsAsync(zipNode(t, 'node-module-missing-conditional', { opts: { jsBundlerVersion: bundler } }))
+  await t.throwsAsync(zipNode(t, 'node-module-missing-conditional', { opts: { jsBundler: bundler } }))
 })
 
 testBundlers("Throws on missing dependencies' dependencies", [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
-  await t.throwsAsync(zipNode(t, 'node-module-missing-deep', { opts: { jsBundlerVersion: bundler } }))
+  await t.throwsAsync(zipNode(t, 'node-module-missing-deep', { opts: { jsBundler: bundler } }))
 })
 
 testBundlers('Ignore missing optional dependencies', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
-  await zipNode(t, 'node-module-missing-optional', { opts: { jsBundlerVersion: bundler } })
+  await zipNode(t, 'node-module-missing-optional', { opts: { jsBundler: bundler } })
 })
 
 testBundlers('Ignore modules conditional dependencies', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
-  await zipNode(t, 'node-module-deep-conditional', { opts: { jsBundlerVersion: bundler } })
+  await zipNode(t, 'node-module-deep-conditional', { opts: { jsBundler: bundler } })
 })
 
 testBundlers('Ignore missing optional peer dependencies', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
-  await zipNode(t, 'node-module-peer-optional', { opts: { jsBundlerVersion: bundler } })
+  await zipNode(t, 'node-module-peer-optional', { opts: { jsBundler: bundler } })
 })
 
 testBundlers(
   'Throws on missing optional peer dependencies with no peer dependencies',
   [ESBUILD, LEGACY, DEFAULT],
   async (bundler, t) => {
-    await t.throwsAsync(zipNode(t, 'node-module-peer-optional-none', { opts: { jsBundlerVersion: bundler } }))
+    await t.throwsAsync(zipNode(t, 'node-module-peer-optional-none', { opts: { jsBundler: bundler } }))
   },
 )
 
 testBundlers('Throws on missing non-optional peer dependencies', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
-  await t.throwsAsync(zipNode(t, 'node-module-peer-not-optional', { opts: { jsBundlerVersion: bundler } }))
+  await t.throwsAsync(zipNode(t, 'node-module-peer-not-optional', { opts: { jsBundler: bundler } }))
 })
 
 testBundlers(
   'Resolves dependencies from .netlify/plugins/node_modules',
   [ESBUILD, LEGACY, DEFAULT],
   async (bundler, t) => {
-    await zipNode(t, 'node-module-next-image', { opts: { jsBundlerVersion: bundler } })
+    await zipNode(t, 'node-module-next-image', { opts: { jsBundler: bundler } })
   },
 )
 
@@ -165,7 +165,7 @@ testBundlers('Throws on invalid package.json', [ESBUILD, LEGACY, DEFAULT], async
   await pRename(srcPackageJson, distPackageJson)
   try {
     await t.throwsAsync(
-      zipNode(t, 'invalid-package-json', { opts: { jsBundlerVersion: bundler }, fixtureDir }),
+      zipNode(t, 'invalid-package-json', { opts: { jsBundler: bundler }, fixtureDir }),
       expectedErrorRegex,
     )
   } finally {
@@ -174,30 +174,30 @@ testBundlers('Throws on invalid package.json', [ESBUILD, LEGACY, DEFAULT], async
 })
 
 testBundlers('Ignore invalid require()', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
-  await zipNode(t, 'invalid-require', { opts: { jsBundlerVersion: bundler } })
+  await zipNode(t, 'invalid-require', { opts: { jsBundler: bundler } })
 })
 
 testBundlers('Can require local files', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
-  await zipNode(t, 'local-require', { opts: { jsBundlerVersion: bundler } })
+  await zipNode(t, 'local-require', { opts: { jsBundler: bundler } })
 })
 
 testBundlers('Can require local files deeply', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
-  await zipNode(t, 'local-deep-require', { opts: { jsBundlerVersion: bundler } })
+  await zipNode(t, 'local-deep-require', { opts: { jsBundler: bundler } })
 })
 
 testBundlers('Can require local files in the parent directories', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
-  await zipNode(t, 'local-parent-require', { opts: { jsBundlerVersion: bundler } })
+  await zipNode(t, 'local-parent-require', { opts: { jsBundler: bundler } })
 })
 
 testBundlers('Ignore missing critters dependency for Next.js 10', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
-  await zipNode(t, 'node-module-next10-critters', { opts: { jsBundlerVersion: bundler } })
+  await zipNode(t, 'node-module-next10-critters', { opts: { jsBundler: bundler } })
 })
 
 testBundlers(
   'Ignore missing critters dependency for Next.js exact version 10.0.5',
   [ESBUILD, LEGACY, DEFAULT],
   async (bundler, t) => {
-    await zipNode(t, 'node-module-next10-critters-exact', { opts: { jsBundlerVersion: bundler } })
+    await zipNode(t, 'node-module-next10-critters-exact', { opts: { jsBundler: bundler } })
   },
 )
 
@@ -205,7 +205,7 @@ testBundlers(
   'Ignore missing critters dependency for Next.js with range ^10.0.5',
   [ESBUILD, LEGACY, DEFAULT],
   async (bundler, t) => {
-    await zipNode(t, 'node-module-next10-critters-10.0.5-range', { opts: { jsBundlerVersion: bundler } })
+    await zipNode(t, 'node-module-next10-critters-10.0.5-range', { opts: { jsBundler: bundler } })
   },
 )
 
@@ -213,7 +213,7 @@ testBundlers(
   "Ignore missing critters dependency for Next.js with version='latest'",
   [ESBUILD, LEGACY, DEFAULT],
   async (bundler, t) => {
-    await zipNode(t, 'node-module-next10-critters-latest', { opts: { jsBundlerVersion: bundler } })
+    await zipNode(t, 'node-module-next10-critters-latest', { opts: { jsBundler: bundler } })
   },
 )
 
@@ -236,7 +236,7 @@ if (platform !== 'win32') {
     }
 
     try {
-      await zipNode(t, 'symlinks', { opts: { jsBundlerVersion: bundler }, fixtureDir })
+      await zipNode(t, 'symlinks', { opts: { jsBundler: bundler }, fixtureDir })
     } finally {
       await pUnlink(symlinkFile)
     }
@@ -247,19 +247,19 @@ testBundlers(
   'Can target a directory with a main file with the same name',
   [ESBUILD, LEGACY, DEFAULT],
   async (bundler, t) => {
-    await zipNode(t, 'directory-handler', { opts: { jsBundlerVersion: bundler } })
+    await zipNode(t, 'directory-handler', { opts: { jsBundler: bundler } })
   },
 )
 
 testBundlers('Can target a directory with an index.js file', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
-  const { files, tmpDir } = await zipFixture(t, 'index-handler', { opts: { jsBundlerVersion: bundler } })
+  const { files, tmpDir } = await zipFixture(t, 'index-handler', { opts: { jsBundler: bundler } })
   await unzipFiles(files)
   // eslint-disable-next-line import/no-dynamic-require, node/global-require
   t.true(require(`${tmpDir}/function.js`))
 })
 
 testBundlers('Keeps non-required files inside the target directory', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
-  const { tmpDir } = await zipNode(t, 'keep-dir-files', { opts: { jsBundlerVersion: bundler } })
+  const { tmpDir } = await zipNode(t, 'keep-dir-files', { opts: { jsBundler: bundler } })
   t.true(await pathExists(`${tmpDir}/function.js`))
 })
 
@@ -267,7 +267,7 @@ testBundlers(
   'Ignores non-required node_modules inside the target directory',
   [ESBUILD, LEGACY, DEFAULT],
   async (bundler, t) => {
-    const { tmpDir } = await zipNode(t, 'ignore-dir-node-modules', { opts: { jsBundlerVersion: bundler } })
+    const { tmpDir } = await zipNode(t, 'ignore-dir-node-modules', { opts: { jsBundler: bundler } })
     t.false(await pathExists(`${tmpDir}/src/node_modules`))
   },
 )
@@ -277,19 +277,19 @@ testBundlers(
   [ESBUILD, LEGACY, DEFAULT],
   async (bundler, t) => {
     const { tmpDir } = await zipNode(t, 'ignore-deep-dir-node-modules', {
-      opts: { jsBundlerVersion: bundler },
+      opts: { jsBundler: bundler },
     })
     t.false(await pathExists(`${tmpDir}/src/deep/node_modules`))
   },
 )
 
 testBundlers('Works with many dependencies', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
-  await zipNode(t, 'many-dependencies', { opts: { jsBundlerVersion: bundler } })
+  await zipNode(t, 'many-dependencies', { opts: { jsBundler: bundler } })
 })
 
 testBundlers('Works with many function files', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
   await zipNode(t, 'many-functions', {
-    opts: { jsBundlerVersion: bundler },
+    opts: { jsBundler: bundler },
     length: TEST_FUNCTIONS_LENGTH,
   })
 })
@@ -302,37 +302,34 @@ testBundlers('Produces deterministic checksums', [ESBUILD, LEGACY, DEFAULT], asy
 })
 
 testBundlers('Throws when the source folder does not exist', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
-  await t.throwsAsync(
-    zipNode(t, 'does-not-exist', { opts: { jsBundlerVersion: bundler } }),
-    /Functions folder does not exist/,
-  )
+  await t.throwsAsync(zipNode(t, 'does-not-exist', { opts: { jsBundler: bundler } }), /Functions folder does not exist/)
 })
 
 testBundlers('Works even if destination folder does not exist', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
-  await zipNode(t, 'simple', { opts: { jsBundlerVersion: bundler } })
+  await zipNode(t, 'simple', { opts: { jsBundler: bundler } })
 })
 
 testBundlers('Do not consider node_modules as a function file', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
-  await zipNode(t, 'ignore-node-modules', { opts: { jsBundlerVersion: bundler } })
+  await zipNode(t, 'ignore-node-modules', { opts: { jsBundler: bundler } })
 })
 
 testBundlers('Ignore directories without a main file', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
-  await zipNode(t, 'ignore-directories', { opts: { jsBundlerVersion: bundler } })
+  await zipNode(t, 'ignore-directories', { opts: { jsBundler: bundler } })
 })
 
 testBundlers('Remove useless files', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
-  const { tmpDir } = await zipNode(t, 'useless', { opts: { jsBundlerVersion: bundler } })
+  const { tmpDir } = await zipNode(t, 'useless', { opts: { jsBundler: bundler } })
   t.false(await pathExists(`${tmpDir}/src/Desktop.ini`))
 })
 
 testBundlers('Works on empty directories', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
-  await zipNode(t, 'empty', { opts: { jsBundlerVersion: bundler }, length: 0 })
+  await zipNode(t, 'empty', { opts: { jsBundler: bundler }, length: 0 })
 })
 
 testBundlers('Works when no package.json is present', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
   const fixtureDir = await tmpName({ prefix: `zip-it-test-bundler-${bundler}` })
   await cpy('**', `${fixtureDir}/no-package-json`, { cwd: `${FIXTURES_DIR}/no-package-json`, parents: true })
-  await zipNode(t, 'no-package-json', { opts: { jsBundlerVersion: bundler }, length: 1, fixtureDir })
+  await zipNode(t, 'no-package-json', { opts: { jsBundler: bundler }, length: 1, fixtureDir })
 })
 
 testBundlers('Copies already zipped files', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
@@ -348,16 +345,16 @@ testBundlers('Copies already zipped files', [ESBUILD, LEGACY, DEFAULT], async (b
 })
 
 testBundlers('Ignore unsupported programming languages', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
-  await zipFixture(t, 'unsupported', { length: 0, opts: { jsBundlerVersion: bundler } })
+  await zipFixture(t, 'unsupported', { length: 0, opts: { jsBundler: bundler } })
 })
 
 testBundlers('Can reduce parallelism', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
-  await zipNode(t, 'simple', { length: 1, opts: { jsBundlerVersion: bundler, parallelLimit: 1 } })
+  await zipNode(t, 'simple', { length: 1, opts: { jsBundler: bundler, parallelLimit: 1 } })
 })
 
 testBundlers('Can use zipFunction()', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
   const { path: tmpDir } = await getTmpDir({ prefix: 'zip-it-test' })
-  const { runtime } = await zipFunction(`${FIXTURES_DIR}/simple/function.js`, tmpDir, { jsBundlerVersion: bundler })
+  const { runtime } = await zipFunction(`${FIXTURES_DIR}/simple/function.js`, tmpDir, { jsBundler: bundler })
   t.is(runtime, 'js')
 })
 
@@ -382,7 +379,7 @@ testBundlers(
   [ESBUILD, LEGACY, DEFAULT],
   async (bundler, t) => {
     const fixtureDir = `${FIXTURES_DIR}/list`
-    const functions = await listFunctionsFiles(fixtureDir, { jsBundlerVersion: bundler })
+    const functions = await listFunctionsFiles(fixtureDir, { jsBundler: bundler })
     t.deepEqual(
       functions,
       [
@@ -417,11 +414,11 @@ testBundlers(
 )
 
 testBundlers('Zips node modules', [LEGACY], async (bundler, t) => {
-  await zipNode(t, 'node-module', { opts: { jsBundlerVersion: bundler } })
+  await zipNode(t, 'node-module', { opts: { jsBundler: bundler } })
 })
 
 testBundlers('Include most files from node modules', [LEGACY], async (bundler, t) => {
-  const { tmpDir } = await zipNode(t, 'node-module-included', { opts: { jsBundlerVersion: bundler } })
+  const { tmpDir } = await zipNode(t, 'node-module-included', { opts: { jsBundler: bundler } })
   const [mapExists, htmlExists] = await Promise.all([
     pathExists(`${tmpDir}/src/node_modules/test/test.map`),
     pathExists(`${tmpDir}/src/node_modules/test/test.html`),
@@ -431,11 +428,11 @@ testBundlers('Include most files from node modules', [LEGACY], async (bundler, t
 })
 
 testBundlers('Throws on missing critters dependency for Next.js 9', [LEGACY], async (bundler, t) => {
-  await t.throwsAsync(zipNode(t, 'node-module-next9-critters', { opts: { jsBundlerVersion: bundler } }))
+  await t.throwsAsync(zipNode(t, 'node-module-next9-critters', { opts: { jsBundler: bundler } }))
 })
 
 testBundlers('Includes specific Next.js dependencies when using next-on-netlify', [LEGACY], async (bundler, t) => {
-  const { tmpDir } = await zipNode(t, 'node-module-next-on-netlify', { opts: { jsBundlerVersion: bundler } })
+  const { tmpDir } = await zipNode(t, 'node-module-next-on-netlify', { opts: { jsBundler: bundler } })
   const [constantsExists, semverExists, otherExists, indexExists] = await Promise.all([
     pathExists(`${tmpDir}/src/node_modules/next/dist/next-server/lib/constants.js`),
     pathExists(`${tmpDir}/src/node_modules/next/dist/compiled/semver.js`),
@@ -449,7 +446,7 @@ testBundlers('Includes specific Next.js dependencies when using next-on-netlify'
 })
 
 testBundlers('Includes all Next.js dependencies when not using next-on-netlify', [LEGACY], async (bundler, t) => {
-  const { tmpDir } = await zipNode(t, 'node-module-next', { opts: { jsBundlerVersion: bundler } })
+  const { tmpDir } = await zipNode(t, 'node-module-next', { opts: { jsBundler: bundler } })
   const [constantsExists, semverExists, otherExists, indexExists] = await Promise.all([
     pathExists(`${tmpDir}/src/node_modules/next/dist/next-server/lib/constants.js`),
     pathExists(`${tmpDir}/src/node_modules/next/dist/compiled/semver.js`),
@@ -463,7 +460,7 @@ testBundlers('Includes all Next.js dependencies when not using next-on-netlify',
 })
 
 testBundlers('Inlines node modules in the bundle', [ESBUILD, DEFAULT], async (bundler, t) => {
-  const { tmpDir } = await zipNode(t, 'node-module-included-try-catch', { opts: { jsBundlerVersion: bundler } })
+  const { tmpDir } = await zipNode(t, 'node-module-included-try-catch', { opts: { jsBundler: bundler } })
   const requires = await getRequires({ filePath: resolve(tmpDir, 'function.js') })
 
   t.false(requires.includes('test'))
@@ -475,7 +472,7 @@ testBundlers(
   [ESBUILD, DEFAULT],
   async (bundler, t) => {
     const { tmpDir } = await zipNode(t, 'node-module-included-try-catch', {
-      opts: { jsBundlerVersion: bundler, jsExternalModules: ['test'] },
+      opts: { jsBundler: bundler, jsExternalModules: ['test'] },
     })
     const requires = await getRequires({ filePath: resolve(tmpDir, 'function.js') })
 
@@ -489,7 +486,7 @@ testBundlers(
   [ESBUILD, DEFAULT],
   async (bundler, t) => {
     const { tmpDir } = await zipNode(t, 'node-module-included-try-catch', {
-      opts: { jsBundlerVersion: bundler, jsIgnoredModules: ['test'] },
+      opts: { jsBundler: bundler, jsIgnoredModules: ['test'] },
     })
     const requires = await getRequires({ filePath: resolve(tmpDir, 'function.js') })
 
@@ -503,7 +500,7 @@ testBundlers(
   [ESBUILD, DEFAULT],
   async (bundler, t) => {
     const { tmpDir } = await zipNode(t, 'node-module-included', {
-      opts: { jsBundlerVersion: bundler, jsExternalModules: ['test'] },
+      opts: { jsBundler: bundler, jsExternalModules: ['test'] },
     })
     const [mapExists, htmlExists] = await Promise.all([
       pathExists(`${tmpDir}/src/node_modules/test/test.map`),
@@ -519,7 +516,7 @@ testBundlers(
   [ESBUILD, DEFAULT],
   async (bundler, t) => {
     const { tmpDir } = await zipNode(t, 'node-module-included-try-catch', {
-      opts: { jsBundlerVersion: bundler, jsExternalModules: ['i-do-not-exist'] },
+      opts: { jsBundler: bundler, jsExternalModules: ['i-do-not-exist'] },
     })
 
     t.false(await pathExists(`${tmpDir}/src/node_modules/i-do-not-exist`))

--- a/tests/main.js
+++ b/tests/main.js
@@ -12,7 +12,11 @@ const pathExists = require('path-exists')
 const { dir: getTmpDir, tmpName } = require('tmp-promise')
 
 const { zipFunction, listFunctions, listFunctionsFiles } = require('..')
-const { JS_BUNDLER_ESBUILD: ESBUILD, JS_BUNDLER_ZISI: ZISI } = require('../src/utils/consts')
+const {
+  JS_BUNDLER_ESBUILD: ESBUILD,
+  JS_BUNDLER_ESBUILD_ZISI: ESBUILD_ZISI,
+  JS_BUNDLER_ZISI: ZISI,
+} = require('../src/utils/consts')
 
 const { getRequires, zipNode, zipFixture, unzipFiles, zipCheckFunctions, FIXTURES_DIR } = require('./helpers/main')
 const { computeSha1 } = require('./helpers/sha')
@@ -49,98 +53,118 @@ test.after.always(async () => {
 // Convenience method for running a test for each JS bundler.
 const testBundlers = makeTestBundlers(test)
 
-testBundlers('Zips Node.js function files', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Zips Node.js function files', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   const { files } = await zipNode(t, 'simple', { opts: { jsBundler: bundler } })
   t.true(files.every(({ runtime }) => runtime === 'js'))
 })
 
-testBundlers('Handles Node module with native bindings', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
-  const jsExternalModules = bundler === ESBUILD ? ['test'] : undefined
+testBundlers('Handles Node module with native bindings', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
+  const jsExternalModules = bundler === ESBUILD || bundler === ESBUILD ? ['test'] : undefined
   const { files } = await zipNode(t, 'node-module-native', {
     opts: { jsBundler: bundler, jsExternalModules },
   })
   t.true(files.every(({ runtime }) => runtime === 'js'))
 })
 
-testBundlers('Can require node modules', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Can require node modules', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   await zipNode(t, 'local-node-module', { opts: { jsBundler: bundler } })
 })
 
-testBundlers('Can require scoped node modules', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Can require scoped node modules', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   await zipNode(t, 'node-module-scope', { opts: { jsBundler: bundler } })
 })
 
-testBundlers('Can require node modules nested files', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Can require node modules nested files', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   await zipNode(t, 'node-module-path', { opts: { jsBundler: bundler } })
 })
 
-testBundlers('Can require dynamically generated node modules', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
-  await zipNode(t, 'side-module', { opts: { jsBundler: bundler } })
-})
+testBundlers(
+  'Can require dynamically generated node modules',
+  [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT],
+  async (bundler, t) => {
+    await zipNode(t, 'side-module', { opts: { jsBundler: bundler } })
+  },
+)
 
-testBundlers('Ignore some excluded node modules', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Ignore some excluded node modules', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   const { tmpDir } = await zipNode(t, 'node-module-excluded', { opts: { jsBundler: bundler } })
   t.false(await pathExists(`${tmpDir}/src/node_modules/aws-sdk`))
 })
 
-testBundlers('Ignore TypeScript types', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Ignore TypeScript types', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   const { tmpDir } = await zipNode(t, 'node-module-typescript-types', {
     opts: { jsBundler: bundler },
   })
   t.false(await pathExists(`${tmpDir}/src/node_modules/@types/node`))
 })
 
-testBundlers('Throws on runtime errors', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Throws on runtime errors', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   await t.throwsAsync(zipNode(t, 'node-module-error', { opts: { jsBundler: bundler } }))
 })
 
-testBundlers('Throws on missing dependencies', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Throws on missing dependencies', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   await t.throwsAsync(zipNode(t, 'node-module-missing', { opts: { jsBundler: bundler } }))
 })
 
 testBundlers(
   'Throws on missing dependencies with no optionalDependencies',
-  [ESBUILD, ZISI, DEFAULT],
+  [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT],
   async (bundler, t) => {
     await t.throwsAsync(zipNode(t, 'node-module-missing-package', { opts: { jsBundler: bundler } }))
   },
 )
 
-testBundlers('Throws on missing conditional dependencies', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
-  await t.throwsAsync(zipNode(t, 'node-module-missing-conditional', { opts: { jsBundler: bundler } }))
-})
+testBundlers(
+  'Throws on missing conditional dependencies',
+  [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT],
+  async (bundler, t) => {
+    await t.throwsAsync(zipNode(t, 'node-module-missing-conditional', { opts: { jsBundler: bundler } }))
+  },
+)
 
-testBundlers("Throws on missing dependencies' dependencies", [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
-  await t.throwsAsync(zipNode(t, 'node-module-missing-deep', { opts: { jsBundler: bundler } }))
-})
+testBundlers(
+  "Throws on missing dependencies' dependencies",
+  [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT],
+  async (bundler, t) => {
+    await t.throwsAsync(zipNode(t, 'node-module-missing-deep', { opts: { jsBundler: bundler } }))
+  },
+)
 
-testBundlers('Ignore missing optional dependencies', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Ignore missing optional dependencies', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   await zipNode(t, 'node-module-missing-optional', { opts: { jsBundler: bundler } })
 })
 
-testBundlers('Ignore modules conditional dependencies', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Ignore modules conditional dependencies', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   await zipNode(t, 'node-module-deep-conditional', { opts: { jsBundler: bundler } })
 })
 
-testBundlers('Ignore missing optional peer dependencies', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
-  await zipNode(t, 'node-module-peer-optional', { opts: { jsBundler: bundler } })
-})
+testBundlers(
+  'Ignore missing optional peer dependencies',
+  [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT],
+  async (bundler, t) => {
+    await zipNode(t, 'node-module-peer-optional', { opts: { jsBundler: bundler } })
+  },
+)
 
 testBundlers(
   'Throws on missing optional peer dependencies with no peer dependencies',
-  [ESBUILD, ZISI, DEFAULT],
+  [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT],
   async (bundler, t) => {
     await t.throwsAsync(zipNode(t, 'node-module-peer-optional-none', { opts: { jsBundler: bundler } }))
   },
 )
 
-testBundlers('Throws on missing non-optional peer dependencies', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
-  await t.throwsAsync(zipNode(t, 'node-module-peer-not-optional', { opts: { jsBundler: bundler } }))
-})
+testBundlers(
+  'Throws on missing non-optional peer dependencies',
+  [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT],
+  async (bundler, t) => {
+    await t.throwsAsync(zipNode(t, 'node-module-peer-not-optional', { opts: { jsBundler: bundler } }))
+  },
+)
 
 testBundlers(
   'Resolves dependencies from .netlify/plugins/node_modules',
-  [ESBUILD, ZISI, DEFAULT],
+  [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT],
   async (bundler, t) => {
     await zipNode(t, 'node-module-next-image', { opts: { jsBundler: bundler } })
   },
@@ -149,7 +173,7 @@ testBundlers(
 // We persist `package.json` as `package.json.txt` in git. Otherwise ESLint
 // tries to load when linting sibling JavaScript files. In this test, we
 // temporarily rename it to an actual `package.json`.
-testBundlers('Throws on invalid package.json', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Throws on invalid package.json', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   const fixtureDir = await tmpName({ prefix: `zip-it-test-bundler-${bundler}` })
   await cpy('**', `${fixtureDir}/invalid-package-json`, {
     cwd: `${FIXTURES_DIR}/invalid-package-json`,
@@ -160,7 +184,7 @@ testBundlers('Throws on invalid package.json', [ESBUILD, ZISI, DEFAULT], async (
   const srcPackageJson = `${invalidPackageJsonDir}/package.json.txt`
   const distPackageJson = `${invalidPackageJsonDir}/package.json`
   const expectedErrorRegex =
-    bundler === ZISI ? /invalid JSON/ : /package.json:1:1: error: Expected string but found "{"/
+    bundler === ZISI || bundler === DEFAULT ? /invalid JSON/ : /package.json:1:1: error: Expected string but found "{"/
 
   await pRename(srcPackageJson, distPackageJson)
   try {
@@ -173,29 +197,37 @@ testBundlers('Throws on invalid package.json', [ESBUILD, ZISI, DEFAULT], async (
   }
 })
 
-testBundlers('Ignore invalid require()', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Ignore invalid require()', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   await zipNode(t, 'invalid-require', { opts: { jsBundler: bundler } })
 })
 
-testBundlers('Can require local files', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Can require local files', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   await zipNode(t, 'local-require', { opts: { jsBundler: bundler } })
 })
 
-testBundlers('Can require local files deeply', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Can require local files deeply', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   await zipNode(t, 'local-deep-require', { opts: { jsBundler: bundler } })
 })
 
-testBundlers('Can require local files in the parent directories', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
-  await zipNode(t, 'local-parent-require', { opts: { jsBundler: bundler } })
-})
+testBundlers(
+  'Can require local files in the parent directories',
+  [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT],
+  async (bundler, t) => {
+    await zipNode(t, 'local-parent-require', { opts: { jsBundler: bundler } })
+  },
+)
 
-testBundlers('Ignore missing critters dependency for Next.js 10', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
-  await zipNode(t, 'node-module-next10-critters', { opts: { jsBundler: bundler } })
-})
+testBundlers(
+  'Ignore missing critters dependency for Next.js 10',
+  [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT],
+  async (bundler, t) => {
+    await zipNode(t, 'node-module-next10-critters', { opts: { jsBundler: bundler } })
+  },
+)
 
 testBundlers(
   'Ignore missing critters dependency for Next.js exact version 10.0.5',
-  [ESBUILD, ZISI, DEFAULT],
+  [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT],
   async (bundler, t) => {
     await zipNode(t, 'node-module-next10-critters-exact', { opts: { jsBundler: bundler } })
   },
@@ -203,7 +235,7 @@ testBundlers(
 
 testBundlers(
   'Ignore missing critters dependency for Next.js with range ^10.0.5',
-  [ESBUILD, ZISI, DEFAULT],
+  [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT],
   async (bundler, t) => {
     await zipNode(t, 'node-module-next10-critters-10.0.5-range', { opts: { jsBundler: bundler } })
   },
@@ -211,7 +243,7 @@ testBundlers(
 
 testBundlers(
   "Ignore missing critters dependency for Next.js with version='latest'",
-  [ESBUILD, ZISI, DEFAULT],
+  [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT],
   async (bundler, t) => {
     await zipNode(t, 'node-module-next10-critters-latest', { opts: { jsBundler: bundler } })
   },
@@ -220,7 +252,7 @@ testBundlers(
 // Need to create symlinks dynamically because they sometimes get lost when
 // committed on Windows
 if (platform !== 'win32') {
-  testBundlers('Can require symlinks', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
+  testBundlers('Can require symlinks', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
     const fixtureDir = await tmpName({ prefix: `zip-it-test-bundler-${bundler}` })
     await cpy('**', `${fixtureDir}/symlinks`, {
       cwd: `${FIXTURES_DIR}/symlinks`,
@@ -245,27 +277,35 @@ if (platform !== 'win32') {
 
 testBundlers(
   'Can target a directory with a main file with the same name',
-  [ESBUILD, ZISI, DEFAULT],
+  [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT],
   async (bundler, t) => {
     await zipNode(t, 'directory-handler', { opts: { jsBundler: bundler } })
   },
 )
 
-testBundlers('Can target a directory with an index.js file', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
-  const { files, tmpDir } = await zipFixture(t, 'index-handler', { opts: { jsBundler: bundler } })
-  await unzipFiles(files)
-  // eslint-disable-next-line import/no-dynamic-require, node/global-require
-  t.true(require(`${tmpDir}/function.js`))
-})
+testBundlers(
+  'Can target a directory with an index.js file',
+  [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT],
+  async (bundler, t) => {
+    const { files, tmpDir } = await zipFixture(t, 'index-handler', { opts: { jsBundler: bundler } })
+    await unzipFiles(files)
+    // eslint-disable-next-line import/no-dynamic-require, node/global-require
+    t.true(require(`${tmpDir}/function.js`))
+  },
+)
 
-testBundlers('Keeps non-required files inside the target directory', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
-  const { tmpDir } = await zipNode(t, 'keep-dir-files', { opts: { jsBundler: bundler } })
-  t.true(await pathExists(`${tmpDir}/function.js`))
-})
+testBundlers(
+  'Keeps non-required files inside the target directory',
+  [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT],
+  async (bundler, t) => {
+    const { tmpDir } = await zipNode(t, 'keep-dir-files', { opts: { jsBundler: bundler } })
+    t.true(await pathExists(`${tmpDir}/function.js`))
+  },
+)
 
 testBundlers(
   'Ignores non-required node_modules inside the target directory',
-  [ESBUILD, ZISI, DEFAULT],
+  [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT],
   async (bundler, t) => {
     const { tmpDir } = await zipNode(t, 'ignore-dir-node-modules', { opts: { jsBundler: bundler } })
     t.false(await pathExists(`${tmpDir}/src/node_modules`))
@@ -274,7 +314,7 @@ testBundlers(
 
 testBundlers(
   'Ignores deep non-required node_modules inside the target directory',
-  [ESBUILD, ZISI, DEFAULT],
+  [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT],
   async (bundler, t) => {
     const { tmpDir } = await zipNode(t, 'ignore-deep-dir-node-modules', {
       opts: { jsBundler: bundler },
@@ -283,11 +323,11 @@ testBundlers(
   },
 )
 
-testBundlers('Works with many dependencies', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Works with many dependencies', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   await zipNode(t, 'many-dependencies', { opts: { jsBundler: bundler } })
 })
 
-testBundlers('Works with many function files', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Works with many function files', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   await zipNode(t, 'many-functions', {
     opts: { jsBundler: bundler },
     length: TEST_FUNCTIONS_LENGTH,
@@ -296,43 +336,58 @@ testBundlers('Works with many function files', [ESBUILD, ZISI, DEFAULT], async (
 
 const TEST_FUNCTIONS_LENGTH = 6
 
-testBundlers('Produces deterministic checksums', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Produces deterministic checksums', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   const [checksumOne, checksumTwo] = await Promise.all([getZipChecksum(t, bundler), getZipChecksum(t, bundler)])
   t.is(checksumOne, checksumTwo)
 })
 
-testBundlers('Throws when the source folder does not exist', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
-  await t.throwsAsync(zipNode(t, 'does-not-exist', { opts: { jsBundler: bundler } }), /Functions folder does not exist/)
-})
+testBundlers(
+  'Throws when the source folder does not exist',
+  [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT],
+  async (bundler, t) => {
+    await t.throwsAsync(
+      zipNode(t, 'does-not-exist', { opts: { jsBundler: bundler } }),
+      /Functions folder does not exist/,
+    )
+  },
+)
 
-testBundlers('Works even if destination folder does not exist', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
-  await zipNode(t, 'simple', { opts: { jsBundler: bundler } })
-})
+testBundlers(
+  'Works even if destination folder does not exist',
+  [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT],
+  async (bundler, t) => {
+    await zipNode(t, 'simple', { opts: { jsBundler: bundler } })
+  },
+)
 
-testBundlers('Do not consider node_modules as a function file', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
-  await zipNode(t, 'ignore-node-modules', { opts: { jsBundler: bundler } })
-})
+testBundlers(
+  'Do not consider node_modules as a function file',
+  [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT],
+  async (bundler, t) => {
+    await zipNode(t, 'ignore-node-modules', { opts: { jsBundler: bundler } })
+  },
+)
 
-testBundlers('Ignore directories without a main file', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Ignore directories without a main file', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   await zipNode(t, 'ignore-directories', { opts: { jsBundler: bundler } })
 })
 
-testBundlers('Remove useless files', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Remove useless files', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   const { tmpDir } = await zipNode(t, 'useless', { opts: { jsBundler: bundler } })
   t.false(await pathExists(`${tmpDir}/src/Desktop.ini`))
 })
 
-testBundlers('Works on empty directories', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Works on empty directories', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   await zipNode(t, 'empty', { opts: { jsBundler: bundler }, length: 0 })
 })
 
-testBundlers('Works when no package.json is present', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Works when no package.json is present', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   const fixtureDir = await tmpName({ prefix: `zip-it-test-bundler-${bundler}` })
   await cpy('**', `${fixtureDir}/no-package-json`, { cwd: `${FIXTURES_DIR}/no-package-json`, parents: true })
   await zipNode(t, 'no-package-json', { opts: { jsBundler: bundler }, length: 1, fixtureDir })
 })
 
-testBundlers('Copies already zipped files', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Copies already zipped files', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   const tmpDir = await tmpName({ prefix: `zip-it-test-bundler-${bundler}` })
   const { files } = await zipCheckFunctions(t, 'keep-zip', { tmpDir })
 
@@ -344,76 +399,84 @@ testBundlers('Copies already zipped files', [ESBUILD, ZISI, DEFAULT], async (bun
   )
 })
 
-testBundlers('Ignore unsupported programming languages', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Ignore unsupported programming languages', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   await zipFixture(t, 'unsupported', { length: 0, opts: { jsBundler: bundler } })
 })
 
-testBundlers('Can reduce parallelism', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Can reduce parallelism', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   await zipNode(t, 'simple', { length: 1, opts: { jsBundler: bundler, parallelLimit: 1 } })
 })
 
-testBundlers('Can use zipFunction()', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Can use zipFunction()', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   const { path: tmpDir } = await getTmpDir({ prefix: 'zip-it-test' })
   const { runtime } = await zipFunction(`${FIXTURES_DIR}/simple/function.js`, tmpDir, { jsBundler: bundler })
   t.is(runtime, 'js')
 })
 
-testBundlers('Can list function main files with listFunctions()', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
-  const fixtureDir = `${FIXTURES_DIR}/list`
-  const functions = await listFunctions(fixtureDir)
-  t.deepEqual(
-    functions,
-    [
-      { name: 'four', mainFile: 'four.js/four.js.js', runtime: 'js', extension: '.js' },
-      { name: 'one', mainFile: 'one/index.js', runtime: 'js', extension: '.js' },
-      { name: 'test', mainFile: 'test', runtime: 'go', extension: '' },
-      { name: 'test', mainFile: 'test.js', runtime: 'js', extension: '.js' },
-      { name: 'test', mainFile: 'test.zip', runtime: 'js', extension: '.zip' },
-      { name: 'two', mainFile: 'two/two.js', runtime: 'js', extension: '.js' },
-    ].map(normalizeFiles.bind(null, fixtureDir)),
-  )
-})
+testBundlers(
+  'Can list function main files with listFunctions()',
+  [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT],
+  async (bundler, t) => {
+    const fixtureDir = `${FIXTURES_DIR}/list`
+    const functions = await listFunctions(fixtureDir)
+    t.deepEqual(
+      functions,
+      [
+        { name: 'four', mainFile: 'four.js/four.js.js', runtime: 'js', extension: '.js' },
+        { name: 'one', mainFile: 'one/index.js', runtime: 'js', extension: '.js' },
+        { name: 'test', mainFile: 'test', runtime: 'go', extension: '' },
+        { name: 'test', mainFile: 'test.js', runtime: 'js', extension: '.js' },
+        { name: 'test', mainFile: 'test.zip', runtime: 'js', extension: '.zip' },
+        { name: 'two', mainFile: 'two/two.js', runtime: 'js', extension: '.js' },
+      ].map(normalizeFiles.bind(null, fixtureDir)),
+    )
+  },
+)
 
-testBundlers('Can list all function files with listFunctionsFiles()', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
-  const fixtureDir = `${FIXTURES_DIR}/list`
-  const functions = await listFunctionsFiles(fixtureDir, { jsBundler: bundler })
-  t.deepEqual(
-    functions,
-    [
-      {
-        name: 'four',
-        mainFile: 'four.js/four.js.js',
-        runtime: 'js',
-        extension: '.js',
-        srcFile: 'four.js/four.js.js',
-      },
-      { name: 'one', mainFile: 'one/index.js', runtime: 'js', extension: '.js', srcFile: 'one/index.js' },
-      { name: 'test', mainFile: 'test', runtime: 'go', extension: '', srcFile: 'test' },
-      { name: 'test', mainFile: 'test.js', runtime: 'js', extension: '.js', srcFile: 'test.js' },
-      { name: 'test', mainFile: 'test.zip', runtime: 'js', extension: '.zip', srcFile: 'test.zip' },
+testBundlers(
+  'Can list all function files with listFunctionsFiles()',
+  [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT],
+  async (bundler, t) => {
+    const fixtureDir = `${FIXTURES_DIR}/list`
+    const functions = await listFunctionsFiles(fixtureDir, { jsBundler: bundler })
+    t.deepEqual(
+      functions,
+      [
+        {
+          name: 'four',
+          mainFile: 'four.js/four.js.js',
+          runtime: 'js',
+          extension: '.js',
+          srcFile: 'four.js/four.js.js',
+        },
+        { name: 'one', mainFile: 'one/index.js', runtime: 'js', extension: '.js', srcFile: 'one/index.js' },
+        { name: 'test', mainFile: 'test', runtime: 'go', extension: '', srcFile: 'test' },
+        { name: 'test', mainFile: 'test.js', runtime: 'js', extension: '.js', srcFile: 'test.js' },
+        { name: 'test', mainFile: 'test.zip', runtime: 'js', extension: '.zip', srcFile: 'test.zip' },
 
-      // The JSON file should only be present when using the legacy bundler,
-      // since esbuild will inline it within the main file.
-      bundler === ZISI && {
-        name: 'two',
-        mainFile: 'two/two.js',
-        runtime: 'js',
-        extension: '.json',
-        srcFile: 'two/three.json',
-      },
+        // The JSON file should only be present when using the legacy bundler,
+        // since esbuild will inline it within the main file.
+        bundler === ZISI && {
+          name: 'two',
+          mainFile: 'two/two.js',
+          runtime: 'js',
+          extension: '.json',
+          srcFile: 'two/three.json',
+        },
 
-      { name: 'two', mainFile: 'two/two.js', runtime: 'js', extension: '.js', srcFile: 'two/two.js' },
-    ]
-      .filter(Boolean)
-      .map(normalizeFiles.bind(null, fixtureDir)),
-  )
-})
+        { name: 'two', mainFile: 'two/two.js', runtime: 'js', extension: '.js', srcFile: 'two/two.js' },
+      ]
+        .filter(Boolean)
+        .map(normalizeFiles.bind(null, fixtureDir)),
+    )
+  },
+)
 
-testBundlers('Zips node modules', [ZISI], async (bundler, t) => {
+testBundlers('Zips node modules', [ZISI, DEFAULT], async (bundler, t) => {
   await zipNode(t, 'node-module', { opts: { jsBundler: bundler } })
 })
 
-testBundlers('Include most files from node modules', [ZISI], async (bundler, t) => {
+testBundlers('Include most files from node modules', [ZISI, DEFAULT], async (bundler, t) => {
   const { tmpDir } = await zipNode(t, 'node-module-included', { opts: { jsBundler: bundler } })
   const [mapExists, htmlExists] = await Promise.all([
     pathExists(`${tmpDir}/src/node_modules/test/test.map`),
@@ -423,39 +486,47 @@ testBundlers('Include most files from node modules', [ZISI], async (bundler, t) 
   t.true(htmlExists)
 })
 
-testBundlers('Throws on missing critters dependency for Next.js 9', [ZISI], async (bundler, t) => {
+testBundlers('Throws on missing critters dependency for Next.js 9', [ZISI, DEFAULT], async (bundler, t) => {
   await t.throwsAsync(zipNode(t, 'node-module-next9-critters', { opts: { jsBundler: bundler } }))
 })
 
-testBundlers('Includes specific Next.js dependencies when using next-on-netlify', [ZISI], async (bundler, t) => {
-  const { tmpDir } = await zipNode(t, 'node-module-next-on-netlify', { opts: { jsBundler: bundler } })
-  const [constantsExists, semverExists, otherExists, indexExists] = await Promise.all([
-    pathExists(`${tmpDir}/src/node_modules/next/dist/next-server/lib/constants.js`),
-    pathExists(`${tmpDir}/src/node_modules/next/dist/compiled/semver.js`),
-    pathExists(`${tmpDir}/src/node_modules/next/dist/other.js`),
-    pathExists(`${tmpDir}/src/node_modules/next/index.js`),
-  ])
-  t.true(constantsExists)
-  t.true(semverExists)
-  t.false(otherExists)
-  t.false(indexExists)
-})
+testBundlers(
+  'Includes specific Next.js dependencies when using next-on-netlify',
+  [ZISI, DEFAULT],
+  async (bundler, t) => {
+    const { tmpDir } = await zipNode(t, 'node-module-next-on-netlify', { opts: { jsBundler: bundler } })
+    const [constantsExists, semverExists, otherExists, indexExists] = await Promise.all([
+      pathExists(`${tmpDir}/src/node_modules/next/dist/next-server/lib/constants.js`),
+      pathExists(`${tmpDir}/src/node_modules/next/dist/compiled/semver.js`),
+      pathExists(`${tmpDir}/src/node_modules/next/dist/other.js`),
+      pathExists(`${tmpDir}/src/node_modules/next/index.js`),
+    ])
+    t.true(constantsExists)
+    t.true(semverExists)
+    t.false(otherExists)
+    t.false(indexExists)
+  },
+)
 
-testBundlers('Includes all Next.js dependencies when not using next-on-netlify', [ZISI], async (bundler, t) => {
-  const { tmpDir } = await zipNode(t, 'node-module-next', { opts: { jsBundler: bundler } })
-  const [constantsExists, semverExists, otherExists, indexExists] = await Promise.all([
-    pathExists(`${tmpDir}/src/node_modules/next/dist/next-server/lib/constants.js`),
-    pathExists(`${tmpDir}/src/node_modules/next/dist/compiled/semver.js`),
-    pathExists(`${tmpDir}/src/node_modules/next/dist/other.js`),
-    pathExists(`${tmpDir}/src/node_modules/next/index.js`),
-  ])
-  t.true(constantsExists)
-  t.true(semverExists)
-  t.true(otherExists)
-  t.true(indexExists)
-})
+testBundlers(
+  'Includes all Next.js dependencies when not using next-on-netlify',
+  [ZISI, DEFAULT],
+  async (bundler, t) => {
+    const { tmpDir } = await zipNode(t, 'node-module-next', { opts: { jsBundler: bundler } })
+    const [constantsExists, semverExists, otherExists, indexExists] = await Promise.all([
+      pathExists(`${tmpDir}/src/node_modules/next/dist/next-server/lib/constants.js`),
+      pathExists(`${tmpDir}/src/node_modules/next/dist/compiled/semver.js`),
+      pathExists(`${tmpDir}/src/node_modules/next/dist/other.js`),
+      pathExists(`${tmpDir}/src/node_modules/next/index.js`),
+    ])
+    t.true(constantsExists)
+    t.true(semverExists)
+    t.true(otherExists)
+    t.true(indexExists)
+  },
+)
 
-testBundlers('Inlines node modules in the bundle', [ESBUILD, DEFAULT], async (bundler, t) => {
+testBundlers('Inlines node modules in the bundle', [ESBUILD, ESBUILD_ZISI], async (bundler, t) => {
   const { tmpDir } = await zipNode(t, 'node-module-included-try-catch', { opts: { jsBundler: bundler } })
   const requires = await getRequires({ filePath: resolve(tmpDir, 'function.js') })
 
@@ -465,7 +536,7 @@ testBundlers('Inlines node modules in the bundle', [ESBUILD, DEFAULT], async (bu
 
 testBundlers(
   'Does not inline node modules and includes them in a `node_modules` directory if they are defined in `externalModules`',
-  [ESBUILD, DEFAULT],
+  [ESBUILD, ESBUILD_ZISI],
   async (bundler, t) => {
     const { tmpDir } = await zipNode(t, 'node-module-included-try-catch', {
       opts: { jsBundler: bundler, jsExternalModules: ['test'] },
@@ -479,7 +550,7 @@ testBundlers(
 
 testBundlers(
   'Does not inline node modules and excludes them from the bundle if they are defined in `ignoredModules`',
-  [ESBUILD, DEFAULT],
+  [ESBUILD, ESBUILD_ZISI],
   async (bundler, t) => {
     const { tmpDir } = await zipNode(t, 'node-module-included-try-catch', {
       opts: { jsBundler: bundler, jsIgnoredModules: ['test'] },
@@ -493,7 +564,7 @@ testBundlers(
 
 testBundlers(
   'Include most files from node modules present in `externalModules`',
-  [ESBUILD, DEFAULT],
+  [ESBUILD, ESBUILD_ZISI],
   async (bundler, t) => {
     const { tmpDir } = await zipNode(t, 'node-module-included', {
       opts: { jsBundler: bundler, jsExternalModules: ['test'] },
@@ -509,7 +580,7 @@ testBundlers(
 
 testBundlers(
   'Does not throw if one of the modules defined in `externalModules` does not exist',
-  [ESBUILD, DEFAULT],
+  [ESBUILD, ESBUILD_ZISI],
   async (bundler, t) => {
     const { tmpDir } = await zipNode(t, 'node-module-included-try-catch', {
       opts: { jsBundler: bundler, jsExternalModules: ['i-do-not-exist'] },

--- a/tests/main.js
+++ b/tests/main.js
@@ -12,7 +12,7 @@ const pathExists = require('path-exists')
 const { dir: getTmpDir, tmpName } = require('tmp-promise')
 
 const { zipFunction, listFunctions, listFunctionsFiles } = require('..')
-const { JS_BUNDLER_ESBUILD: ESBUILD, JS_BUNDLER_LEGACY: LEGACY } = require('../src/utils/consts')
+const { JS_BUNDLER_ESBUILD: ESBUILD, JS_BUNDLER_ZISI: ZISI } = require('../src/utils/consts')
 
 const { getRequires, zipNode, zipFixture, unzipFiles, zipCheckFunctions, FIXTURES_DIR } = require('./helpers/main')
 const { computeSha1 } = require('./helpers/sha')
@@ -49,12 +49,12 @@ test.after.always(async () => {
 // Convenience method for running a test for each JS bundler.
 const testBundlers = makeTestBundlers(test)
 
-testBundlers('Zips Node.js function files', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+testBundlers('Zips Node.js function files', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
   const { files } = await zipNode(t, 'simple', { opts: { jsBundler: bundler } })
   t.true(files.every(({ runtime }) => runtime === 'js'))
 })
 
-testBundlers('Handles Node module with native bindings', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+testBundlers('Handles Node module with native bindings', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
   const jsExternalModules = bundler === ESBUILD ? ['test'] : undefined
   const { files } = await zipNode(t, 'node-module-native', {
     opts: { jsBundler: bundler, jsExternalModules },
@@ -62,85 +62,85 @@ testBundlers('Handles Node module with native bindings', [ESBUILD, LEGACY, DEFAU
   t.true(files.every(({ runtime }) => runtime === 'js'))
 })
 
-testBundlers('Can require node modules', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+testBundlers('Can require node modules', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
   await zipNode(t, 'local-node-module', { opts: { jsBundler: bundler } })
 })
 
-testBundlers('Can require scoped node modules', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+testBundlers('Can require scoped node modules', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
   await zipNode(t, 'node-module-scope', { opts: { jsBundler: bundler } })
 })
 
-testBundlers('Can require node modules nested files', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+testBundlers('Can require node modules nested files', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
   await zipNode(t, 'node-module-path', { opts: { jsBundler: bundler } })
 })
 
-testBundlers('Can require dynamically generated node modules', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+testBundlers('Can require dynamically generated node modules', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
   await zipNode(t, 'side-module', { opts: { jsBundler: bundler } })
 })
 
-testBundlers('Ignore some excluded node modules', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+testBundlers('Ignore some excluded node modules', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
   const { tmpDir } = await zipNode(t, 'node-module-excluded', { opts: { jsBundler: bundler } })
   t.false(await pathExists(`${tmpDir}/src/node_modules/aws-sdk`))
 })
 
-testBundlers('Ignore TypeScript types', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+testBundlers('Ignore TypeScript types', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
   const { tmpDir } = await zipNode(t, 'node-module-typescript-types', {
     opts: { jsBundler: bundler },
   })
   t.false(await pathExists(`${tmpDir}/src/node_modules/@types/node`))
 })
 
-testBundlers('Throws on runtime errors', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+testBundlers('Throws on runtime errors', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
   await t.throwsAsync(zipNode(t, 'node-module-error', { opts: { jsBundler: bundler } }))
 })
 
-testBundlers('Throws on missing dependencies', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+testBundlers('Throws on missing dependencies', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
   await t.throwsAsync(zipNode(t, 'node-module-missing', { opts: { jsBundler: bundler } }))
 })
 
 testBundlers(
   'Throws on missing dependencies with no optionalDependencies',
-  [ESBUILD, LEGACY, DEFAULT],
+  [ESBUILD, ZISI, DEFAULT],
   async (bundler, t) => {
     await t.throwsAsync(zipNode(t, 'node-module-missing-package', { opts: { jsBundler: bundler } }))
   },
 )
 
-testBundlers('Throws on missing conditional dependencies', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+testBundlers('Throws on missing conditional dependencies', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
   await t.throwsAsync(zipNode(t, 'node-module-missing-conditional', { opts: { jsBundler: bundler } }))
 })
 
-testBundlers("Throws on missing dependencies' dependencies", [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+testBundlers("Throws on missing dependencies' dependencies", [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
   await t.throwsAsync(zipNode(t, 'node-module-missing-deep', { opts: { jsBundler: bundler } }))
 })
 
-testBundlers('Ignore missing optional dependencies', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+testBundlers('Ignore missing optional dependencies', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
   await zipNode(t, 'node-module-missing-optional', { opts: { jsBundler: bundler } })
 })
 
-testBundlers('Ignore modules conditional dependencies', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+testBundlers('Ignore modules conditional dependencies', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
   await zipNode(t, 'node-module-deep-conditional', { opts: { jsBundler: bundler } })
 })
 
-testBundlers('Ignore missing optional peer dependencies', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+testBundlers('Ignore missing optional peer dependencies', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
   await zipNode(t, 'node-module-peer-optional', { opts: { jsBundler: bundler } })
 })
 
 testBundlers(
   'Throws on missing optional peer dependencies with no peer dependencies',
-  [ESBUILD, LEGACY, DEFAULT],
+  [ESBUILD, ZISI, DEFAULT],
   async (bundler, t) => {
     await t.throwsAsync(zipNode(t, 'node-module-peer-optional-none', { opts: { jsBundler: bundler } }))
   },
 )
 
-testBundlers('Throws on missing non-optional peer dependencies', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+testBundlers('Throws on missing non-optional peer dependencies', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
   await t.throwsAsync(zipNode(t, 'node-module-peer-not-optional', { opts: { jsBundler: bundler } }))
 })
 
 testBundlers(
   'Resolves dependencies from .netlify/plugins/node_modules',
-  [ESBUILD, LEGACY, DEFAULT],
+  [ESBUILD, ZISI, DEFAULT],
   async (bundler, t) => {
     await zipNode(t, 'node-module-next-image', { opts: { jsBundler: bundler } })
   },
@@ -149,7 +149,7 @@ testBundlers(
 // We persist `package.json` as `package.json.txt` in git. Otherwise ESLint
 // tries to load when linting sibling JavaScript files. In this test, we
 // temporarily rename it to an actual `package.json`.
-testBundlers('Throws on invalid package.json', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+testBundlers('Throws on invalid package.json', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
   const fixtureDir = await tmpName({ prefix: `zip-it-test-bundler-${bundler}` })
   await cpy('**', `${fixtureDir}/invalid-package-json`, {
     cwd: `${FIXTURES_DIR}/invalid-package-json`,
@@ -160,7 +160,7 @@ testBundlers('Throws on invalid package.json', [ESBUILD, LEGACY, DEFAULT], async
   const srcPackageJson = `${invalidPackageJsonDir}/package.json.txt`
   const distPackageJson = `${invalidPackageJsonDir}/package.json`
   const expectedErrorRegex =
-    bundler === ESBUILD ? /package.json:1:1: error: Expected string but found "{"/ : /invalid JSON/
+    bundler === ZISI ? /invalid JSON/ : /package.json:1:1: error: Expected string but found "{"/
 
   await pRename(srcPackageJson, distPackageJson)
   try {
@@ -173,29 +173,29 @@ testBundlers('Throws on invalid package.json', [ESBUILD, LEGACY, DEFAULT], async
   }
 })
 
-testBundlers('Ignore invalid require()', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+testBundlers('Ignore invalid require()', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
   await zipNode(t, 'invalid-require', { opts: { jsBundler: bundler } })
 })
 
-testBundlers('Can require local files', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+testBundlers('Can require local files', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
   await zipNode(t, 'local-require', { opts: { jsBundler: bundler } })
 })
 
-testBundlers('Can require local files deeply', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+testBundlers('Can require local files deeply', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
   await zipNode(t, 'local-deep-require', { opts: { jsBundler: bundler } })
 })
 
-testBundlers('Can require local files in the parent directories', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+testBundlers('Can require local files in the parent directories', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
   await zipNode(t, 'local-parent-require', { opts: { jsBundler: bundler } })
 })
 
-testBundlers('Ignore missing critters dependency for Next.js 10', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+testBundlers('Ignore missing critters dependency for Next.js 10', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
   await zipNode(t, 'node-module-next10-critters', { opts: { jsBundler: bundler } })
 })
 
 testBundlers(
   'Ignore missing critters dependency for Next.js exact version 10.0.5',
-  [ESBUILD, LEGACY, DEFAULT],
+  [ESBUILD, ZISI, DEFAULT],
   async (bundler, t) => {
     await zipNode(t, 'node-module-next10-critters-exact', { opts: { jsBundler: bundler } })
   },
@@ -203,7 +203,7 @@ testBundlers(
 
 testBundlers(
   'Ignore missing critters dependency for Next.js with range ^10.0.5',
-  [ESBUILD, LEGACY, DEFAULT],
+  [ESBUILD, ZISI, DEFAULT],
   async (bundler, t) => {
     await zipNode(t, 'node-module-next10-critters-10.0.5-range', { opts: { jsBundler: bundler } })
   },
@@ -211,7 +211,7 @@ testBundlers(
 
 testBundlers(
   "Ignore missing critters dependency for Next.js with version='latest'",
-  [ESBUILD, LEGACY, DEFAULT],
+  [ESBUILD, ZISI, DEFAULT],
   async (bundler, t) => {
     await zipNode(t, 'node-module-next10-critters-latest', { opts: { jsBundler: bundler } })
   },
@@ -220,7 +220,7 @@ testBundlers(
 // Need to create symlinks dynamically because they sometimes get lost when
 // committed on Windows
 if (platform !== 'win32') {
-  testBundlers('Can require symlinks', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+  testBundlers('Can require symlinks', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
     const fixtureDir = await tmpName({ prefix: `zip-it-test-bundler-${bundler}` })
     await cpy('**', `${fixtureDir}/symlinks`, {
       cwd: `${FIXTURES_DIR}/symlinks`,
@@ -245,27 +245,27 @@ if (platform !== 'win32') {
 
 testBundlers(
   'Can target a directory with a main file with the same name',
-  [ESBUILD, LEGACY, DEFAULT],
+  [ESBUILD, ZISI, DEFAULT],
   async (bundler, t) => {
     await zipNode(t, 'directory-handler', { opts: { jsBundler: bundler } })
   },
 )
 
-testBundlers('Can target a directory with an index.js file', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+testBundlers('Can target a directory with an index.js file', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
   const { files, tmpDir } = await zipFixture(t, 'index-handler', { opts: { jsBundler: bundler } })
   await unzipFiles(files)
   // eslint-disable-next-line import/no-dynamic-require, node/global-require
   t.true(require(`${tmpDir}/function.js`))
 })
 
-testBundlers('Keeps non-required files inside the target directory', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+testBundlers('Keeps non-required files inside the target directory', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
   const { tmpDir } = await zipNode(t, 'keep-dir-files', { opts: { jsBundler: bundler } })
   t.true(await pathExists(`${tmpDir}/function.js`))
 })
 
 testBundlers(
   'Ignores non-required node_modules inside the target directory',
-  [ESBUILD, LEGACY, DEFAULT],
+  [ESBUILD, ZISI, DEFAULT],
   async (bundler, t) => {
     const { tmpDir } = await zipNode(t, 'ignore-dir-node-modules', { opts: { jsBundler: bundler } })
     t.false(await pathExists(`${tmpDir}/src/node_modules`))
@@ -274,7 +274,7 @@ testBundlers(
 
 testBundlers(
   'Ignores deep non-required node_modules inside the target directory',
-  [ESBUILD, LEGACY, DEFAULT],
+  [ESBUILD, ZISI, DEFAULT],
   async (bundler, t) => {
     const { tmpDir } = await zipNode(t, 'ignore-deep-dir-node-modules', {
       opts: { jsBundler: bundler },
@@ -283,11 +283,11 @@ testBundlers(
   },
 )
 
-testBundlers('Works with many dependencies', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+testBundlers('Works with many dependencies', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
   await zipNode(t, 'many-dependencies', { opts: { jsBundler: bundler } })
 })
 
-testBundlers('Works with many function files', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+testBundlers('Works with many function files', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
   await zipNode(t, 'many-functions', {
     opts: { jsBundler: bundler },
     length: TEST_FUNCTIONS_LENGTH,
@@ -296,43 +296,43 @@ testBundlers('Works with many function files', [ESBUILD, LEGACY, DEFAULT], async
 
 const TEST_FUNCTIONS_LENGTH = 6
 
-testBundlers('Produces deterministic checksums', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+testBundlers('Produces deterministic checksums', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
   const [checksumOne, checksumTwo] = await Promise.all([getZipChecksum(t, bundler), getZipChecksum(t, bundler)])
   t.is(checksumOne, checksumTwo)
 })
 
-testBundlers('Throws when the source folder does not exist', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+testBundlers('Throws when the source folder does not exist', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
   await t.throwsAsync(zipNode(t, 'does-not-exist', { opts: { jsBundler: bundler } }), /Functions folder does not exist/)
 })
 
-testBundlers('Works even if destination folder does not exist', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+testBundlers('Works even if destination folder does not exist', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
   await zipNode(t, 'simple', { opts: { jsBundler: bundler } })
 })
 
-testBundlers('Do not consider node_modules as a function file', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+testBundlers('Do not consider node_modules as a function file', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
   await zipNode(t, 'ignore-node-modules', { opts: { jsBundler: bundler } })
 })
 
-testBundlers('Ignore directories without a main file', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+testBundlers('Ignore directories without a main file', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
   await zipNode(t, 'ignore-directories', { opts: { jsBundler: bundler } })
 })
 
-testBundlers('Remove useless files', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+testBundlers('Remove useless files', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
   const { tmpDir } = await zipNode(t, 'useless', { opts: { jsBundler: bundler } })
   t.false(await pathExists(`${tmpDir}/src/Desktop.ini`))
 })
 
-testBundlers('Works on empty directories', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+testBundlers('Works on empty directories', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
   await zipNode(t, 'empty', { opts: { jsBundler: bundler }, length: 0 })
 })
 
-testBundlers('Works when no package.json is present', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+testBundlers('Works when no package.json is present', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
   const fixtureDir = await tmpName({ prefix: `zip-it-test-bundler-${bundler}` })
   await cpy('**', `${fixtureDir}/no-package-json`, { cwd: `${FIXTURES_DIR}/no-package-json`, parents: true })
   await zipNode(t, 'no-package-json', { opts: { jsBundler: bundler }, length: 1, fixtureDir })
 })
 
-testBundlers('Copies already zipped files', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+testBundlers('Copies already zipped files', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
   const tmpDir = await tmpName({ prefix: `zip-it-test-bundler-${bundler}` })
   const { files } = await zipCheckFunctions(t, 'keep-zip', { tmpDir })
 
@@ -344,21 +344,21 @@ testBundlers('Copies already zipped files', [ESBUILD, LEGACY, DEFAULT], async (b
   )
 })
 
-testBundlers('Ignore unsupported programming languages', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+testBundlers('Ignore unsupported programming languages', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
   await zipFixture(t, 'unsupported', { length: 0, opts: { jsBundler: bundler } })
 })
 
-testBundlers('Can reduce parallelism', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+testBundlers('Can reduce parallelism', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
   await zipNode(t, 'simple', { length: 1, opts: { jsBundler: bundler, parallelLimit: 1 } })
 })
 
-testBundlers('Can use zipFunction()', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+testBundlers('Can use zipFunction()', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
   const { path: tmpDir } = await getTmpDir({ prefix: 'zip-it-test' })
   const { runtime } = await zipFunction(`${FIXTURES_DIR}/simple/function.js`, tmpDir, { jsBundler: bundler })
   t.is(runtime, 'js')
 })
 
-testBundlers('Can list function main files with listFunctions()', [ESBUILD, LEGACY, DEFAULT], async (bundler, t) => {
+testBundlers('Can list function main files with listFunctions()', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
   const fixtureDir = `${FIXTURES_DIR}/list`
   const functions = await listFunctions(fixtureDir)
   t.deepEqual(
@@ -374,50 +374,46 @@ testBundlers('Can list function main files with listFunctions()', [ESBUILD, LEGA
   )
 })
 
-testBundlers(
-  'Can list all function files with listFunctionsFiles()',
-  [ESBUILD, LEGACY, DEFAULT],
-  async (bundler, t) => {
-    const fixtureDir = `${FIXTURES_DIR}/list`
-    const functions = await listFunctionsFiles(fixtureDir, { jsBundler: bundler })
-    t.deepEqual(
-      functions,
-      [
-        {
-          name: 'four',
-          mainFile: 'four.js/four.js.js',
-          runtime: 'js',
-          extension: '.js',
-          srcFile: 'four.js/four.js.js',
-        },
-        { name: 'one', mainFile: 'one/index.js', runtime: 'js', extension: '.js', srcFile: 'one/index.js' },
-        { name: 'test', mainFile: 'test', runtime: 'go', extension: '', srcFile: 'test' },
-        { name: 'test', mainFile: 'test.js', runtime: 'js', extension: '.js', srcFile: 'test.js' },
-        { name: 'test', mainFile: 'test.zip', runtime: 'js', extension: '.zip', srcFile: 'test.zip' },
+testBundlers('Can list all function files with listFunctionsFiles()', [ESBUILD, ZISI, DEFAULT], async (bundler, t) => {
+  const fixtureDir = `${FIXTURES_DIR}/list`
+  const functions = await listFunctionsFiles(fixtureDir, { jsBundler: bundler })
+  t.deepEqual(
+    functions,
+    [
+      {
+        name: 'four',
+        mainFile: 'four.js/four.js.js',
+        runtime: 'js',
+        extension: '.js',
+        srcFile: 'four.js/four.js.js',
+      },
+      { name: 'one', mainFile: 'one/index.js', runtime: 'js', extension: '.js', srcFile: 'one/index.js' },
+      { name: 'test', mainFile: 'test', runtime: 'go', extension: '', srcFile: 'test' },
+      { name: 'test', mainFile: 'test.js', runtime: 'js', extension: '.js', srcFile: 'test.js' },
+      { name: 'test', mainFile: 'test.zip', runtime: 'js', extension: '.zip', srcFile: 'test.zip' },
 
-        // The JSON file should only be present when using the legacy bundler,
-        // since esbuild will inline it within the main file.
-        bundler === LEGACY && {
-          name: 'two',
-          mainFile: 'two/two.js',
-          runtime: 'js',
-          extension: '.json',
-          srcFile: 'two/three.json',
-        },
+      // The JSON file should only be present when using the legacy bundler,
+      // since esbuild will inline it within the main file.
+      bundler === ZISI && {
+        name: 'two',
+        mainFile: 'two/two.js',
+        runtime: 'js',
+        extension: '.json',
+        srcFile: 'two/three.json',
+      },
 
-        { name: 'two', mainFile: 'two/two.js', runtime: 'js', extension: '.js', srcFile: 'two/two.js' },
-      ]
-        .filter(Boolean)
-        .map(normalizeFiles.bind(null, fixtureDir)),
-    )
-  },
-)
+      { name: 'two', mainFile: 'two/two.js', runtime: 'js', extension: '.js', srcFile: 'two/two.js' },
+    ]
+      .filter(Boolean)
+      .map(normalizeFiles.bind(null, fixtureDir)),
+  )
+})
 
-testBundlers('Zips node modules', [LEGACY], async (bundler, t) => {
+testBundlers('Zips node modules', [ZISI], async (bundler, t) => {
   await zipNode(t, 'node-module', { opts: { jsBundler: bundler } })
 })
 
-testBundlers('Include most files from node modules', [LEGACY], async (bundler, t) => {
+testBundlers('Include most files from node modules', [ZISI], async (bundler, t) => {
   const { tmpDir } = await zipNode(t, 'node-module-included', { opts: { jsBundler: bundler } })
   const [mapExists, htmlExists] = await Promise.all([
     pathExists(`${tmpDir}/src/node_modules/test/test.map`),
@@ -427,11 +423,11 @@ testBundlers('Include most files from node modules', [LEGACY], async (bundler, t
   t.true(htmlExists)
 })
 
-testBundlers('Throws on missing critters dependency for Next.js 9', [LEGACY], async (bundler, t) => {
+testBundlers('Throws on missing critters dependency for Next.js 9', [ZISI], async (bundler, t) => {
   await t.throwsAsync(zipNode(t, 'node-module-next9-critters', { opts: { jsBundler: bundler } }))
 })
 
-testBundlers('Includes specific Next.js dependencies when using next-on-netlify', [LEGACY], async (bundler, t) => {
+testBundlers('Includes specific Next.js dependencies when using next-on-netlify', [ZISI], async (bundler, t) => {
   const { tmpDir } = await zipNode(t, 'node-module-next-on-netlify', { opts: { jsBundler: bundler } })
   const [constantsExists, semverExists, otherExists, indexExists] = await Promise.all([
     pathExists(`${tmpDir}/src/node_modules/next/dist/next-server/lib/constants.js`),
@@ -445,7 +441,7 @@ testBundlers('Includes specific Next.js dependencies when using next-on-netlify'
   t.false(indexExists)
 })
 
-testBundlers('Includes all Next.js dependencies when not using next-on-netlify', [LEGACY], async (bundler, t) => {
+testBundlers('Includes all Next.js dependencies when not using next-on-netlify', [ZISI], async (bundler, t) => {
   const { tmpDir } = await zipNode(t, 'node-module-next', { opts: { jsBundler: bundler } })
   const [constantsExists, semverExists, otherExists, indexExists] = await Promise.all([
     pathExists(`${tmpDir}/src/node_modules/next/dist/next-server/lib/constants.js`),

--- a/tests/main.js
+++ b/tests/main.js
@@ -12,11 +12,7 @@ const pathExists = require('path-exists')
 const { dir: getTmpDir, tmpName } = require('tmp-promise')
 
 const { zipFunction, listFunctions, listFunctionsFiles } = require('..')
-const {
-  JS_BUNDLER_ESBUILD: ESBUILD,
-  JS_BUNDLER_ESBUILD_ZISI: ESBUILD_ZISI,
-  JS_BUNDLER_ZISI: ZISI,
-} = require('../src/utils/consts')
+const { JS_BUNDLER_ESBUILD: ESBUILD, JS_BUNDLER_ESBUILD_ZISI: ESBUILD_ZISI } = require('../src/utils/consts')
 
 const { getRequires, zipNode, zipFixture, unzipFiles, zipCheckFunctions, FIXTURES_DIR } = require('./helpers/main')
 const { computeSha1 } = require('./helpers/sha')
@@ -53,12 +49,12 @@ test.after.always(async () => {
 // Convenience method for running a test for each JS bundler.
 const testBundlers = makeTestBundlers(test)
 
-testBundlers('Zips Node.js function files', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Zips Node.js function files', [ESBUILD, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   const { files } = await zipNode(t, 'simple', { opts: { jsBundler: bundler } })
   t.true(files.every(({ runtime }) => runtime === 'js'))
 })
 
-testBundlers('Handles Node module with native bindings', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Handles Node module with native bindings', [ESBUILD, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   const jsExternalModules = bundler === ESBUILD || bundler === ESBUILD ? ['test'] : undefined
   const { files } = await zipNode(t, 'node-module-native', {
     opts: { jsBundler: bundler, jsExternalModules },
@@ -66,89 +62,73 @@ testBundlers('Handles Node module with native bindings', [ESBUILD, ZISI, ESBUILD
   t.true(files.every(({ runtime }) => runtime === 'js'))
 })
 
-testBundlers('Can require node modules', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Can require node modules', [ESBUILD, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   await zipNode(t, 'local-node-module', { opts: { jsBundler: bundler } })
 })
 
-testBundlers('Can require scoped node modules', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Can require scoped node modules', [ESBUILD, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   await zipNode(t, 'node-module-scope', { opts: { jsBundler: bundler } })
 })
 
-testBundlers('Can require node modules nested files', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Can require node modules nested files', [ESBUILD, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   await zipNode(t, 'node-module-path', { opts: { jsBundler: bundler } })
 })
 
-testBundlers(
-  'Can require dynamically generated node modules',
-  [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT],
-  async (bundler, t) => {
-    await zipNode(t, 'side-module', { opts: { jsBundler: bundler } })
-  },
-)
+testBundlers('Can require dynamically generated node modules', [ESBUILD, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
+  await zipNode(t, 'side-module', { opts: { jsBundler: bundler } })
+})
 
-testBundlers('Ignore some excluded node modules', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Ignore some excluded node modules', [ESBUILD, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   const { tmpDir } = await zipNode(t, 'node-module-excluded', { opts: { jsBundler: bundler } })
   t.false(await pathExists(`${tmpDir}/src/node_modules/aws-sdk`))
 })
 
-testBundlers('Ignore TypeScript types', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Ignore TypeScript types', [ESBUILD, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   const { tmpDir } = await zipNode(t, 'node-module-typescript-types', {
     opts: { jsBundler: bundler },
   })
   t.false(await pathExists(`${tmpDir}/src/node_modules/@types/node`))
 })
 
-testBundlers('Throws on runtime errors', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Throws on runtime errors', [ESBUILD, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   await t.throwsAsync(zipNode(t, 'node-module-error', { opts: { jsBundler: bundler } }))
 })
 
-testBundlers('Throws on missing dependencies', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Throws on missing dependencies', [ESBUILD, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   await t.throwsAsync(zipNode(t, 'node-module-missing', { opts: { jsBundler: bundler } }))
 })
 
 testBundlers(
   'Throws on missing dependencies with no optionalDependencies',
-  [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT],
+  [ESBUILD, ESBUILD_ZISI, DEFAULT],
   async (bundler, t) => {
     await t.throwsAsync(zipNode(t, 'node-module-missing-package', { opts: { jsBundler: bundler } }))
   },
 )
 
-testBundlers(
-  'Throws on missing conditional dependencies',
-  [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT],
-  async (bundler, t) => {
-    await t.throwsAsync(zipNode(t, 'node-module-missing-conditional', { opts: { jsBundler: bundler } }))
-  },
-)
+testBundlers('Throws on missing conditional dependencies', [ESBUILD, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
+  await t.throwsAsync(zipNode(t, 'node-module-missing-conditional', { opts: { jsBundler: bundler } }))
+})
 
-testBundlers(
-  "Throws on missing dependencies' dependencies",
-  [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT],
-  async (bundler, t) => {
-    await t.throwsAsync(zipNode(t, 'node-module-missing-deep', { opts: { jsBundler: bundler } }))
-  },
-)
+testBundlers("Throws on missing dependencies' dependencies", [ESBUILD, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
+  await t.throwsAsync(zipNode(t, 'node-module-missing-deep', { opts: { jsBundler: bundler } }))
+})
 
-testBundlers('Ignore missing optional dependencies', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Ignore missing optional dependencies', [ESBUILD, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   await zipNode(t, 'node-module-missing-optional', { opts: { jsBundler: bundler } })
 })
 
-testBundlers('Ignore modules conditional dependencies', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Ignore modules conditional dependencies', [ESBUILD, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   await zipNode(t, 'node-module-deep-conditional', { opts: { jsBundler: bundler } })
 })
 
-testBundlers(
-  'Ignore missing optional peer dependencies',
-  [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT],
-  async (bundler, t) => {
-    await zipNode(t, 'node-module-peer-optional', { opts: { jsBundler: bundler } })
-  },
-)
+testBundlers('Ignore missing optional peer dependencies', [ESBUILD, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
+  await zipNode(t, 'node-module-peer-optional', { opts: { jsBundler: bundler } })
+})
 
 testBundlers(
   'Throws on missing optional peer dependencies with no peer dependencies',
-  [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT],
+  [ESBUILD, ESBUILD_ZISI, DEFAULT],
   async (bundler, t) => {
     await t.throwsAsync(zipNode(t, 'node-module-peer-optional-none', { opts: { jsBundler: bundler } }))
   },
@@ -156,7 +136,7 @@ testBundlers(
 
 testBundlers(
   'Throws on missing non-optional peer dependencies',
-  [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT],
+  [ESBUILD, ESBUILD_ZISI, DEFAULT],
   async (bundler, t) => {
     await t.throwsAsync(zipNode(t, 'node-module-peer-not-optional', { opts: { jsBundler: bundler } }))
   },
@@ -164,7 +144,7 @@ testBundlers(
 
 testBundlers(
   'Resolves dependencies from .netlify/plugins/node_modules',
-  [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT],
+  [ESBUILD, ESBUILD_ZISI, DEFAULT],
   async (bundler, t) => {
     await zipNode(t, 'node-module-next-image', { opts: { jsBundler: bundler } })
   },
@@ -173,7 +153,7 @@ testBundlers(
 // We persist `package.json` as `package.json.txt` in git. Otherwise ESLint
 // tries to load when linting sibling JavaScript files. In this test, we
 // temporarily rename it to an actual `package.json`.
-testBundlers('Throws on invalid package.json', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Throws on invalid package.json', [ESBUILD, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   const fixtureDir = await tmpName({ prefix: `zip-it-test-bundler-${bundler}` })
   await cpy('**', `${fixtureDir}/invalid-package-json`, {
     cwd: `${FIXTURES_DIR}/invalid-package-json`,
@@ -184,7 +164,7 @@ testBundlers('Throws on invalid package.json', [ESBUILD, ZISI, ESBUILD_ZISI, DEF
   const srcPackageJson = `${invalidPackageJsonDir}/package.json.txt`
   const distPackageJson = `${invalidPackageJsonDir}/package.json`
   const expectedErrorRegex =
-    bundler === ZISI || bundler === DEFAULT ? /invalid JSON/ : /package.json:1:1: error: Expected string but found "{"/
+    bundler === DEFAULT ? /invalid JSON/ : /package.json:1:1: error: Expected string but found "{"/
 
   await pRename(srcPackageJson, distPackageJson)
   try {
@@ -197,21 +177,21 @@ testBundlers('Throws on invalid package.json', [ESBUILD, ZISI, ESBUILD_ZISI, DEF
   }
 })
 
-testBundlers('Ignore invalid require()', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Ignore invalid require()', [ESBUILD, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   await zipNode(t, 'invalid-require', { opts: { jsBundler: bundler } })
 })
 
-testBundlers('Can require local files', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Can require local files', [ESBUILD, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   await zipNode(t, 'local-require', { opts: { jsBundler: bundler } })
 })
 
-testBundlers('Can require local files deeply', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Can require local files deeply', [ESBUILD, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   await zipNode(t, 'local-deep-require', { opts: { jsBundler: bundler } })
 })
 
 testBundlers(
   'Can require local files in the parent directories',
-  [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT],
+  [ESBUILD, ESBUILD_ZISI, DEFAULT],
   async (bundler, t) => {
     await zipNode(t, 'local-parent-require', { opts: { jsBundler: bundler } })
   },
@@ -219,7 +199,7 @@ testBundlers(
 
 testBundlers(
   'Ignore missing critters dependency for Next.js 10',
-  [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT],
+  [ESBUILD, ESBUILD_ZISI, DEFAULT],
   async (bundler, t) => {
     await zipNode(t, 'node-module-next10-critters', { opts: { jsBundler: bundler } })
   },
@@ -227,7 +207,7 @@ testBundlers(
 
 testBundlers(
   'Ignore missing critters dependency for Next.js exact version 10.0.5',
-  [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT],
+  [ESBUILD, ESBUILD_ZISI, DEFAULT],
   async (bundler, t) => {
     await zipNode(t, 'node-module-next10-critters-exact', { opts: { jsBundler: bundler } })
   },
@@ -235,7 +215,7 @@ testBundlers(
 
 testBundlers(
   'Ignore missing critters dependency for Next.js with range ^10.0.5',
-  [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT],
+  [ESBUILD, ESBUILD_ZISI, DEFAULT],
   async (bundler, t) => {
     await zipNode(t, 'node-module-next10-critters-10.0.5-range', { opts: { jsBundler: bundler } })
   },
@@ -243,7 +223,7 @@ testBundlers(
 
 testBundlers(
   "Ignore missing critters dependency for Next.js with version='latest'",
-  [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT],
+  [ESBUILD, ESBUILD_ZISI, DEFAULT],
   async (bundler, t) => {
     await zipNode(t, 'node-module-next10-critters-latest', { opts: { jsBundler: bundler } })
   },
@@ -252,7 +232,7 @@ testBundlers(
 // Need to create symlinks dynamically because they sometimes get lost when
 // committed on Windows
 if (platform !== 'win32') {
-  testBundlers('Can require symlinks', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
+  testBundlers('Can require symlinks', [ESBUILD, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
     const fixtureDir = await tmpName({ prefix: `zip-it-test-bundler-${bundler}` })
     await cpy('**', `${fixtureDir}/symlinks`, {
       cwd: `${FIXTURES_DIR}/symlinks`,
@@ -277,26 +257,22 @@ if (platform !== 'win32') {
 
 testBundlers(
   'Can target a directory with a main file with the same name',
-  [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT],
+  [ESBUILD, ESBUILD_ZISI, DEFAULT],
   async (bundler, t) => {
     await zipNode(t, 'directory-handler', { opts: { jsBundler: bundler } })
   },
 )
 
-testBundlers(
-  'Can target a directory with an index.js file',
-  [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT],
-  async (bundler, t) => {
-    const { files, tmpDir } = await zipFixture(t, 'index-handler', { opts: { jsBundler: bundler } })
-    await unzipFiles(files)
-    // eslint-disable-next-line import/no-dynamic-require, node/global-require
-    t.true(require(`${tmpDir}/function.js`))
-  },
-)
+testBundlers('Can target a directory with an index.js file', [ESBUILD, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
+  const { files, tmpDir } = await zipFixture(t, 'index-handler', { opts: { jsBundler: bundler } })
+  await unzipFiles(files)
+  // eslint-disable-next-line import/no-dynamic-require, node/global-require
+  t.true(require(`${tmpDir}/function.js`))
+})
 
 testBundlers(
   'Keeps non-required files inside the target directory',
-  [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT],
+  [ESBUILD, ESBUILD_ZISI, DEFAULT],
   async (bundler, t) => {
     const { tmpDir } = await zipNode(t, 'keep-dir-files', { opts: { jsBundler: bundler } })
     t.true(await pathExists(`${tmpDir}/function.js`))
@@ -305,7 +281,7 @@ testBundlers(
 
 testBundlers(
   'Ignores non-required node_modules inside the target directory',
-  [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT],
+  [ESBUILD, ESBUILD_ZISI, DEFAULT],
   async (bundler, t) => {
     const { tmpDir } = await zipNode(t, 'ignore-dir-node-modules', { opts: { jsBundler: bundler } })
     t.false(await pathExists(`${tmpDir}/src/node_modules`))
@@ -314,7 +290,7 @@ testBundlers(
 
 testBundlers(
   'Ignores deep non-required node_modules inside the target directory',
-  [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT],
+  [ESBUILD, ESBUILD_ZISI, DEFAULT],
   async (bundler, t) => {
     const { tmpDir } = await zipNode(t, 'ignore-deep-dir-node-modules', {
       opts: { jsBundler: bundler },
@@ -323,11 +299,11 @@ testBundlers(
   },
 )
 
-testBundlers('Works with many dependencies', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Works with many dependencies', [ESBUILD, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   await zipNode(t, 'many-dependencies', { opts: { jsBundler: bundler } })
 })
 
-testBundlers('Works with many function files', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Works with many function files', [ESBUILD, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   await zipNode(t, 'many-functions', {
     opts: { jsBundler: bundler },
     length: TEST_FUNCTIONS_LENGTH,
@@ -336,25 +312,18 @@ testBundlers('Works with many function files', [ESBUILD, ZISI, ESBUILD_ZISI, DEF
 
 const TEST_FUNCTIONS_LENGTH = 6
 
-testBundlers('Produces deterministic checksums', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Produces deterministic checksums', [ESBUILD, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   const [checksumOne, checksumTwo] = await Promise.all([getZipChecksum(t, bundler), getZipChecksum(t, bundler)])
   t.is(checksumOne, checksumTwo)
 })
 
-testBundlers(
-  'Throws when the source folder does not exist',
-  [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT],
-  async (bundler, t) => {
-    await t.throwsAsync(
-      zipNode(t, 'does-not-exist', { opts: { jsBundler: bundler } }),
-      /Functions folder does not exist/,
-    )
-  },
-)
+testBundlers('Throws when the source folder does not exist', [ESBUILD, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
+  await t.throwsAsync(zipNode(t, 'does-not-exist', { opts: { jsBundler: bundler } }), /Functions folder does not exist/)
+})
 
 testBundlers(
   'Works even if destination folder does not exist',
-  [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT],
+  [ESBUILD, ESBUILD_ZISI, DEFAULT],
   async (bundler, t) => {
     await zipNode(t, 'simple', { opts: { jsBundler: bundler } })
   },
@@ -362,32 +331,32 @@ testBundlers(
 
 testBundlers(
   'Do not consider node_modules as a function file',
-  [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT],
+  [ESBUILD, ESBUILD_ZISI, DEFAULT],
   async (bundler, t) => {
     await zipNode(t, 'ignore-node-modules', { opts: { jsBundler: bundler } })
   },
 )
 
-testBundlers('Ignore directories without a main file', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Ignore directories without a main file', [ESBUILD, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   await zipNode(t, 'ignore-directories', { opts: { jsBundler: bundler } })
 })
 
-testBundlers('Remove useless files', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Remove useless files', [ESBUILD, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   const { tmpDir } = await zipNode(t, 'useless', { opts: { jsBundler: bundler } })
   t.false(await pathExists(`${tmpDir}/src/Desktop.ini`))
 })
 
-testBundlers('Works on empty directories', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Works on empty directories', [ESBUILD, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   await zipNode(t, 'empty', { opts: { jsBundler: bundler }, length: 0 })
 })
 
-testBundlers('Works when no package.json is present', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Works when no package.json is present', [ESBUILD, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   const fixtureDir = await tmpName({ prefix: `zip-it-test-bundler-${bundler}` })
   await cpy('**', `${fixtureDir}/no-package-json`, { cwd: `${FIXTURES_DIR}/no-package-json`, parents: true })
   await zipNode(t, 'no-package-json', { opts: { jsBundler: bundler }, length: 1, fixtureDir })
 })
 
-testBundlers('Copies already zipped files', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Copies already zipped files', [ESBUILD, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   const tmpDir = await tmpName({ prefix: `zip-it-test-bundler-${bundler}` })
   const { files } = await zipCheckFunctions(t, 'keep-zip', { tmpDir })
 
@@ -399,15 +368,15 @@ testBundlers('Copies already zipped files', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAUL
   )
 })
 
-testBundlers('Ignore unsupported programming languages', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Ignore unsupported programming languages', [ESBUILD, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   await zipFixture(t, 'unsupported', { length: 0, opts: { jsBundler: bundler } })
 })
 
-testBundlers('Can reduce parallelism', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Can reduce parallelism', [ESBUILD, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   await zipNode(t, 'simple', { length: 1, opts: { jsBundler: bundler, parallelLimit: 1 } })
 })
 
-testBundlers('Can use zipFunction()', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Can use zipFunction()', [ESBUILD, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   const { path: tmpDir } = await getTmpDir({ prefix: 'zip-it-test' })
   const { runtime } = await zipFunction(`${FIXTURES_DIR}/simple/function.js`, tmpDir, { jsBundler: bundler })
   t.is(runtime, 'js')
@@ -415,7 +384,7 @@ testBundlers('Can use zipFunction()', [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT], as
 
 testBundlers(
   'Can list function main files with listFunctions()',
-  [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT],
+  [ESBUILD, ESBUILD_ZISI, DEFAULT],
   async (bundler, t) => {
     const fixtureDir = `${FIXTURES_DIR}/list`
     const functions = await listFunctions(fixtureDir)
@@ -435,7 +404,7 @@ testBundlers(
 
 testBundlers(
   'Can list all function files with listFunctionsFiles()',
-  [ESBUILD, ZISI, ESBUILD_ZISI, DEFAULT],
+  [ESBUILD, ESBUILD_ZISI, DEFAULT],
   async (bundler, t) => {
     const fixtureDir = `${FIXTURES_DIR}/list`
     const functions = await listFunctionsFiles(fixtureDir, { jsBundler: bundler })
@@ -456,7 +425,7 @@ testBundlers(
 
         // The JSON file should only be present when using the legacy bundler,
         // since esbuild will inline it within the main file.
-        bundler === ZISI && {
+        bundler === DEFAULT && {
           name: 'two',
           mainFile: 'two/two.js',
           runtime: 'js',
@@ -472,11 +441,11 @@ testBundlers(
   },
 )
 
-testBundlers('Zips node modules', [ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Zips node modules', [DEFAULT], async (bundler, t) => {
   await zipNode(t, 'node-module', { opts: { jsBundler: bundler } })
 })
 
-testBundlers('Include most files from node modules', [ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Include most files from node modules', [DEFAULT], async (bundler, t) => {
   const { tmpDir } = await zipNode(t, 'node-module-included', { opts: { jsBundler: bundler } })
   const [mapExists, htmlExists] = await Promise.all([
     pathExists(`${tmpDir}/src/node_modules/test/test.map`),
@@ -486,45 +455,37 @@ testBundlers('Include most files from node modules', [ZISI, DEFAULT], async (bun
   t.true(htmlExists)
 })
 
-testBundlers('Throws on missing critters dependency for Next.js 9', [ZISI, DEFAULT], async (bundler, t) => {
+testBundlers('Throws on missing critters dependency for Next.js 9', [DEFAULT], async (bundler, t) => {
   await t.throwsAsync(zipNode(t, 'node-module-next9-critters', { opts: { jsBundler: bundler } }))
 })
 
-testBundlers(
-  'Includes specific Next.js dependencies when using next-on-netlify',
-  [ZISI, DEFAULT],
-  async (bundler, t) => {
-    const { tmpDir } = await zipNode(t, 'node-module-next-on-netlify', { opts: { jsBundler: bundler } })
-    const [constantsExists, semverExists, otherExists, indexExists] = await Promise.all([
-      pathExists(`${tmpDir}/src/node_modules/next/dist/next-server/lib/constants.js`),
-      pathExists(`${tmpDir}/src/node_modules/next/dist/compiled/semver.js`),
-      pathExists(`${tmpDir}/src/node_modules/next/dist/other.js`),
-      pathExists(`${tmpDir}/src/node_modules/next/index.js`),
-    ])
-    t.true(constantsExists)
-    t.true(semverExists)
-    t.false(otherExists)
-    t.false(indexExists)
-  },
-)
+testBundlers('Includes specific Next.js dependencies when using next-on-netlify', [DEFAULT], async (bundler, t) => {
+  const { tmpDir } = await zipNode(t, 'node-module-next-on-netlify', { opts: { jsBundler: bundler } })
+  const [constantsExists, semverExists, otherExists, indexExists] = await Promise.all([
+    pathExists(`${tmpDir}/src/node_modules/next/dist/next-server/lib/constants.js`),
+    pathExists(`${tmpDir}/src/node_modules/next/dist/compiled/semver.js`),
+    pathExists(`${tmpDir}/src/node_modules/next/dist/other.js`),
+    pathExists(`${tmpDir}/src/node_modules/next/index.js`),
+  ])
+  t.true(constantsExists)
+  t.true(semverExists)
+  t.false(otherExists)
+  t.false(indexExists)
+})
 
-testBundlers(
-  'Includes all Next.js dependencies when not using next-on-netlify',
-  [ZISI, DEFAULT],
-  async (bundler, t) => {
-    const { tmpDir } = await zipNode(t, 'node-module-next', { opts: { jsBundler: bundler } })
-    const [constantsExists, semverExists, otherExists, indexExists] = await Promise.all([
-      pathExists(`${tmpDir}/src/node_modules/next/dist/next-server/lib/constants.js`),
-      pathExists(`${tmpDir}/src/node_modules/next/dist/compiled/semver.js`),
-      pathExists(`${tmpDir}/src/node_modules/next/dist/other.js`),
-      pathExists(`${tmpDir}/src/node_modules/next/index.js`),
-    ])
-    t.true(constantsExists)
-    t.true(semverExists)
-    t.true(otherExists)
-    t.true(indexExists)
-  },
-)
+testBundlers('Includes all Next.js dependencies when not using next-on-netlify', [DEFAULT], async (bundler, t) => {
+  const { tmpDir } = await zipNode(t, 'node-module-next', { opts: { jsBundler: bundler } })
+  const [constantsExists, semverExists, otherExists, indexExists] = await Promise.all([
+    pathExists(`${tmpDir}/src/node_modules/next/dist/next-server/lib/constants.js`),
+    pathExists(`${tmpDir}/src/node_modules/next/dist/compiled/semver.js`),
+    pathExists(`${tmpDir}/src/node_modules/next/dist/other.js`),
+    pathExists(`${tmpDir}/src/node_modules/next/index.js`),
+  ])
+  t.true(constantsExists)
+  t.true(semverExists)
+  t.true(otherExists)
+  t.true(indexExists)
+})
 
 testBundlers('Inlines node modules in the bundle', [ESBUILD, ESBUILD_ZISI], async (bundler, t) => {
   const { tmpDir } = await zipNode(t, 'node-module-included-try-catch', { opts: { jsBundler: bundler } })


### PR DESCRIPTION
**- Summary**

This PR prepares zip-it-and-ship-it for the public rollout of esbuild. It includes the following breaking changes from the alpha:

1. A `jsBundler` parameter was introduced. Its possible values are:
   - `zisi` (default): Bundle JS functions with the legacy mechanism
   - `esbuild`: Bundle JS functions with esbuild
   - `esbuild_zisi`: Bundle JS functions with esbuild and fallback to the legacy mechanism if it fails

2. The `useEsbuild` parameter was removed in favour of 1.

3. The `externalModules` parameter was renamed to `jsExternalModules`

4. The `ignoredModules` parameter was renamed to `jsIgnoredModules`

**- Test plan**

- Added a test for a module with native bindings
- Introduced a `testBundlers` helper function, which runs a test for each of the specified JS bundlers

**- Description for the changelog**

feat: add JS bundler fallback

**- A picture of a cute animal (not mandatory but encouraged)**

![_114306756_gettyimages-482829557](https://user-images.githubusercontent.com/4162329/108519140-4792f500-72c1-11eb-859c-5e082258cc45.jpg)
