### PR TITLE
fix: treat @prisma/client as an external module

### DIFF
--- a/src/node_dependencies/special_cases.js
+++ b/src/node_dependencies/special_cases.js
@@ -1,5 +1,8 @@
 const { getPackageJson } = require('./package_json')
 
+const EXTERNAL_MODULES = ['@prisma/client']
+const IGNORED_MODULES = []
+
 const getPackageJsonIfAvailable = async (srcDir) => {
   try {
     const packageJson = await getPackageJson(srcDir)
@@ -23,7 +26,12 @@ const getModulesForNextJs = ({ dependencies, devDependencies }) => {
 
 const getExternalAndIgnoredModulesFromSpecialCases = async ({ srcDir }) => {
   const { dependencies = {}, devDependencies = {} } = await getPackageJsonIfAvailable(srcDir)
-  const { externalModules, ignoredModules } = getModulesForNextJs({ dependencies, devDependencies })
+  const { externalModules: nextJsExternalModules, ignoredModules: nextJsIgnoredModules } = getModulesForNextJs({
+    dependencies,
+    devDependencies,
+  })
+  const externalModules = [...EXTERNAL_MODULES, ...nextJsExternalModules]
+  const ignoredModules = [...IGNORED_MODULES, ...nextJsIgnoredModules]
 
   return {
     externalModules,

--- a/src/runtimes/node.js
+++ b/src/runtimes/node.js
@@ -86,7 +86,7 @@ const zipFunction = async function ({
     srcDir,
     pluginsModulesPath,
     jsBundler,
-    jsExternalModules: [...externalModulesFromConfig, ...externalModulesFromSpecialCases],
+    jsExternalModules: [...new Set([...externalModulesFromConfig, ...externalModulesFromSpecialCases])],
   })
   const dirnames = srcFiles.map((filePath) => normalize(dirname(filePath)))
 

--- a/src/runtimes/node.js
+++ b/src/runtimes/node.js
@@ -65,6 +65,10 @@ const zipFunction = async function ({
   stat,
 }) {
   const destPath = join(destFolder, `${basename(filename, extension)}.zip`)
+  const {
+    externalModules: externalModulesFromSpecialCases,
+    ignoredModules: ignoredModulesFromSpecialCases,
+  } = await getExternalAndIgnoredModulesFromSpecialCases({ srcDir })
 
   // When a module is added to `externalModules`, we will traverse its main
   // file recursively and look for all its dependencies, so that we can ship
@@ -82,7 +86,7 @@ const zipFunction = async function ({
     srcDir,
     pluginsModulesPath,
     jsBundler,
-    jsExternalModules: externalModulesFromConfig,
+    jsExternalModules: [...externalModulesFromConfig, ...externalModulesFromSpecialCases],
   })
   const dirnames = srcFiles.map((filePath) => normalize(dirname(filePath)))
 
@@ -99,11 +103,6 @@ const zipFunction = async function ({
 
     return { bundler: JS_BUNDLER_ZISI, path: destPath }
   }
-
-  const {
-    externalModules: externalModulesFromSpecialCases,
-    ignoredModules: ignoredModulesFromSpecialCases,
-  } = await getExternalAndIgnoredModulesFromSpecialCases({ srcDir })
 
   const { bundlePath, data, cleanTempFiles } = await bundleJsFile({
     additionalModulePaths: pluginsModulesPath ? [pluginsModulesPath] : [],

--- a/tests/main.js
+++ b/tests/main.js
@@ -163,14 +163,12 @@ testBundlers('Throws on invalid package.json', [ESBUILD, ESBUILD_ZISI, DEFAULT],
   const invalidPackageJsonDir = `${fixtureDir}/invalid-package-json`
   const srcPackageJson = `${invalidPackageJsonDir}/package.json.txt`
   const distPackageJson = `${invalidPackageJsonDir}/package.json`
-  const expectedErrorRegex =
-    bundler === DEFAULT ? /invalid JSON/ : /package.json:1:1: error: Expected string but found "{"/
 
   await pRename(srcPackageJson, distPackageJson)
   try {
     await t.throwsAsync(
       zipNode(t, 'invalid-package-json', { opts: { jsBundler: bundler }, fixtureDir }),
-      expectedErrorRegex,
+      /(invalid JSON|package.json:1:1: error: Expected string but found "{")/,
     )
   } finally {
     await pRename(distPackageJson, srcPackageJson)


### PR DESCRIPTION
**- Summary**

This PR adds `@prisma/client` as a special case, treating it as an external module.

It also moves the evaluation of special cases a bit upstream, so that their external modules can be part of the traversal procedure.

**- Test plan**

N/A

**- Description for the changelog**

fix: treat @prisma/client as an external module

**- A picture of a cute animal (not mandatory but encouraged)**

![download](https://user-images.githubusercontent.com/4162329/109330174-4c245400-7853-11eb-9ab7-cba98528b8b3.jpg)
