### PR TITLE
fix: fix and test dynamic import()

### DIFF
--- a/src/node_dependencies/index.js
+++ b/src/node_dependencies/index.js
@@ -69,9 +69,11 @@ const getFileDependencies = async function ({ path, packageJson, pluginsModulesP
   // but should use `fs.readFile()` instead
   const dependencies = precinct.paperwork(path, { includeCore: false })
   const depsPaths = await Promise.all(
-    dependencies.map((dependency) =>
-      getImportDependencies({ dependency, basedir, packageJson, state, treeShakeNext, pluginsModulesPath }),
-    ),
+    dependencies
+      .filter(Boolean)
+      .map((dependency) =>
+        getImportDependencies({ dependency, basedir, packageJson, state, treeShakeNext, pluginsModulesPath }),
+      ),
   )
   // TODO: switch to Array.flat() once we drop support for Node.js < 11.0.0
   // eslint-disable-next-line unicorn/prefer-spread

--- a/tests/fixtures/dynamic-import/.eslintrc
+++ b/tests/fixtures/dynamic-import/.eslintrc
@@ -1,0 +1,6 @@
+{
+  "parserOptions": { "sourceType": "module" },
+  "rules": {
+    "node/no-unsupported-features/es-syntax": 0
+  }
+}

--- a/tests/fixtures/dynamic-import/function.js
+++ b/tests/fixtures/dynamic-import/function.js
@@ -1,0 +1,4 @@
+export const handler = async function () {
+  const variable = 'test'
+  await import(variable)
+}

--- a/tests/main.js
+++ b/tests/main.js
@@ -181,6 +181,14 @@ testBundlers('Ignore invalid require()', [ESBUILD, ESBUILD_ZISI, DEFAULT], async
   await zipNode(t, 'invalid-require', { opts: { jsBundler: bundler } })
 })
 
+testBundlers('Can use dynamic import() with esbuild', [ESBUILD, ESBUILD_ZISI], async (bundler, t) => {
+  await zipNode(t, 'dynamic-import', { opts: { jsBundler: bundler } })
+})
+
+testBundlers('Bundling does not crash with dynamic import() with zisi', [DEFAULT], async (bundler, t) => {
+  await t.throwsAsync(zipNode(t, 'dynamic-import', { opts: { jsBundler: bundler } }), /export/)
+})
+
 testBundlers('Can require local files', [ESBUILD, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   await zipNode(t, 'local-require', { opts: { jsBundler: bundler } })
 })


### PR DESCRIPTION
When using an `import()` with a variable argument (as opposed to a string), `precint` returns `[undefined]` instead of `[]`. This leads the following function to fail:

https://github.com/netlify/zip-it-and-ship-it/blob/a437e74ea543b3cf2e51085ee9a3a86a9afba723/src/node_dependencies/index.js#L104-L106

This PR filters out `undefined`. This ensures bundling works. 

This only applies to the ZISI bundler. `esbuild` handles this case correctly.

This also adds tests for both ZISI and `esbuild` bundlers.