### PR TITLE
fix: remove esbuild plugin

### DIFF
--- a/src/node_bundler/index.js
+++ b/src/node_bundler/index.js
@@ -6,13 +6,10 @@ const { promisify } = require('util')
 const esbuild = require('esbuild')
 const semver = require('semver')
 
-const { getPlugins } = require('./plugins')
-
 const pUnlink = promisify(fs.unlink)
 
 const bundleJsFile = async function ({
   additionalModulePaths,
-  basePath,
   destFilename,
   destFolder,
   externalModules = [],
@@ -31,9 +28,6 @@ const bundleJsFile = async function ({
   // version for that version range.
   const supportsAsyncAPI = semver.satisfies(process.version, '>=9.x')
 
-  // The sync API does not support plugins.
-  const plugins = supportsAsyncAPI ? getPlugins({ additionalModulePaths, basePath, context: pluginContext }) : undefined
-
   // eslint-disable-next-line node/no-sync
   const buildFunction = supportsAsyncAPI ? esbuild.build : esbuild.buildSync
   const data = await buildFunction({
@@ -44,7 +38,6 @@ const bundleJsFile = async function ({
     outfile: bundlePath,
     nodePaths: additionalModulePaths,
     platform: 'node',
-    plugins,
     resolveExtensions: ['.js', '.jsx', '.mjs', '.cjs', '.json'],
     target: ['es2017'],
   })


### PR DESCRIPTION
**- Summary**

This PR removes the esbuild plugin for handling `.node` files added in #353, because it doesn't cover all cases (e.g. where a library might require additional binary files) and actually prevents the ZISI fallback from kicking in.

**- Test plan**

Tests adjusted accordingly.

**- Description for the changelog**

fix: remove esbuild plugin for detecting native bindings

**- A picture of a cute animal (not mandatory but encouraged)**

![facepalm20-20copy](https://user-images.githubusercontent.com/4162329/109840797-5b831300-7c40-11eb-8798-85b4d3a50bf3.jpg)
