### PR TITLE
fix: normalise input paths

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-const { extname } = require('path')
+const { extname, resolve } = require('path')
 
 require('./utils/polyfills')
 const { getPluginsModulesPath } = require('./node_dependencies')
@@ -8,7 +8,8 @@ const { listFunctionsDirectory } = require('./utils/fs')
 const { zipFunction, zipFunctions } = require('./zip')
 
 // List all Netlify Functions main entry files for a specific directory
-const listFunctions = async function (srcFolder) {
+const listFunctions = async function (relativeSrcFolder) {
+  const srcFolder = resolve(relativeSrcFolder)
   const paths = await listFunctionsDirectory(srcFolder)
   const functions = await getFunctionsFromPaths(paths)
   const listedFunctions = [...functions.values()].map(getListedFunction)
@@ -17,9 +18,10 @@ const listFunctions = async function (srcFolder) {
 
 // List all Netlify Functions files for a specific directory
 const listFunctionsFiles = async function (
-  srcFolder,
+  relativeSrcFolder,
   { jsBundler = JS_BUNDLER_ZISI, jsExternalModules, jsIgnoredModules } = {},
 ) {
+  const srcFolder = resolve(relativeSrcFolder)
   const paths = await listFunctionsDirectory(srcFolder)
   const [functions, pluginsModulesPath] = await Promise.all([
     getFunctionsFromPaths(paths),

--- a/src/zip.js
+++ b/src/zip.js
@@ -1,3 +1,5 @@
+const { resolve } = require('path')
+
 const makeDir = require('make-dir')
 const pMap = require('p-map')
 
@@ -19,7 +21,7 @@ const formatZipResult = (result) => {
 // used by AWS Lambda
 // TODO: remove `skipGo` option in next major release
 const zipFunctions = async function (
-  srcFolder,
+  relativeSrcFolder,
   destFolder,
   {
     jsBundler,
@@ -30,6 +32,7 @@ const zipFunctions = async function (
     zipGo,
   } = {},
 ) {
+  const srcFolder = resolve(relativeSrcFolder)
   const [paths] = await Promise.all([listFunctionsDirectory(srcFolder), makeDir(destFolder)])
   const [functions, pluginsModulesPath] = await Promise.all([
     getFunctionsFromPaths(paths, { dedupe: true }),
@@ -64,7 +67,7 @@ const zipFunctions = async function (
 }
 
 const zipFunction = async function (
-  srcPath,
+  relativeSrcPath,
   destFolder,
   {
     jsBundler,
@@ -75,6 +78,7 @@ const zipFunction = async function (
     zipGo = !skipGo,
   } = {},
 ) {
+  const srcPath = resolve(relativeSrcPath)
   const functions = await getFunctionsFromPaths([srcPath], { dedupe: true })
 
   if (functions.size === 0) {


### PR DESCRIPTION
**- Summary**

Currently, if `srcFolder` is a relative path, the generated bundle might have incorrectly computed paths to node modules.

**Example:**

Imagine a `functions` directory with a `foo.js` file inside it. This function requires some node modules.

If we run `./zip-it-and-ship-it functions functions-out`. the `srcPath` property of the function will be `functions/foo.js`.

When the time comes to calculate the common path with the accompanying node modules (e.g. `/Users/janedoe/project/node_modules/module-one/index.js`), the common path will be an empty string because we'll be comparing relative with absolute paths.

This PR normalises `srcFolder` on the `listFunctions`, `listFunctionsFiles`, `zipFunction` and `zipFunctions` entry points, so that the paths are always converted to absolute paths.


**- Description for the changelog**

fix: normalise input paths

**- A picture of a cute animal (not mandatory but encouraged)**

![b47286c4fbaccdad318b5748bfd90396](https://user-images.githubusercontent.com/4162329/110491665-68dd4900-80e9-11eb-9c03-4093e7ee3514.jpg)

