### PR TITLE
chore!: remove `zipGo`/`skipGo` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ Creates Zip `archives` from Node.js, Go, and Rust programs. Those `archives` are
 - Sub-directories with a main file called either `index.js` or `{dir}.js` where `{dir}` is the sub-directory name.
 - `.js` files (Node.js)
 - `.zip` archives with Node.js already ready to upload to AWS Lambda.
-- Go programs already compiled. If the `options.zipGo` is `true`, those are zipped. Otherwise, those are copied as is.
-- Rust programs already compiled. These programs are always zipped.
+- Go programs already compiled. Those are copied as is.
+- Rust programs already compiled. Those are zipped.
 
 When using Node.js files, only the dependencies required by the main file are bundled, in order to keep the archive as
 small as possible, which improves the Function runtime performance:
@@ -71,13 +71,6 @@ CI, this is an unspecified temporary directory inside the CI machine. In Netlify
 directory in your build directory.
 
 ### Options
-
-#### zipGo
-
-_Type_: `boolean`\
-_Default value_: `false`
-
-Whether to zip Go files. If `false`, the Go files are copied as is and the filename remains the same.
 
 #### parallelLimit
 
@@ -232,10 +225,6 @@ $ zip-it-and-ship-it srcFolder destFolder
 
 The CLI performs the same logic as [`zipFunctions()`](#zipfunctionssrcfolder-destfolder-options). The archives are
 printed on `stdout` as a JSON array.
-
-The following options are available:
-
-- `--zip-go`: see the [`zipGo`](#zipGo) option
 
 # Troubleshooting
 

--- a/src/bin.js
+++ b/src/bin.js
@@ -23,11 +23,6 @@ const parseArgs = function () {
 }
 
 const OPTIONS = {
-  'zip-go': {
-    boolean: true,
-    default: false,
-    describe: 'Whether Go binaries should be zipped or copied as is',
-  },
   'parallel-limit': {
     number: true,
     describe: 'Maximum number of Functions to bundle at the same time',

--- a/src/runtimes/go.js
+++ b/src/runtimes/go.js
@@ -7,7 +7,6 @@ const pLstat = promisify(lstat)
 const cpFile = require('cp-file')
 
 const { RUNTIME_GO } = require('../utils/consts')
-const { zipBinary } = require('../zip_binary')
 
 const { detectBinaryRuntime } = require('./detect_runtime')
 
@@ -34,13 +33,7 @@ const findFunctionsInPaths = async function (paths) {
   return functions.filter(Boolean)
 }
 
-const zipFunction = async function ({ srcPath, destFolder, stat, zipGo, filename, runtime }) {
-  if (zipGo) {
-    const destPath = join(destFolder, `${filename}.zip`)
-    await zipBinary({ srcPath, destPath, filename, stat, runtime })
-    return { path: destPath }
-  }
-
+const zipFunction = async function ({ srcPath, destFolder, filename }) {
   const destPath = join(destFolder, filename)
   await cpFile(srcPath, destPath)
   return { path: destPath }

--- a/src/zip.js
+++ b/src/zip.js
@@ -19,18 +19,10 @@ const formatZipResult = (result) => {
 
 // Zip `srcFolder/*` (Node.js or Go files) to `destFolder/*.zip` so it can be
 // used by AWS Lambda
-// TODO: remove `skipGo` option in next major release
 const zipFunctions = async function (
   relativeSrcFolder,
   destFolder,
-  {
-    jsBundler,
-    jsExternalModules = [],
-    jsIgnoredModules = [],
-    parallelLimit = DEFAULT_PARALLEL_LIMIT,
-    skipGo = true,
-    zipGo,
-  } = {},
+  { jsBundler, jsExternalModules = [], jsIgnoredModules = [], parallelLimit = DEFAULT_PARALLEL_LIMIT } = {},
 ) {
   const srcFolder = resolve(relativeSrcFolder)
   const [paths] = await Promise.all([listFunctionsDirectory(srcFolder), makeDir(destFolder)])
@@ -54,7 +46,6 @@ const zipFunctions = async function (
         srcDir: func.srcDir,
         srcPath: func.srcPath,
         stat: func.stat,
-        zipGo: zipGo === undefined ? !skipGo : zipGo,
       })
 
       return { ...zipResult, runtime: func.runtime }
@@ -69,14 +60,7 @@ const zipFunctions = async function (
 const zipFunction = async function (
   relativeSrcPath,
   destFolder,
-  {
-    jsBundler,
-    jsExternalModules,
-    jsIgnoredModules,
-    pluginsModulesPath: defaultModulesPath,
-    skipGo = true,
-    zipGo = !skipGo,
-  } = {},
+  { jsBundler, jsExternalModules, jsIgnoredModules, pluginsModulesPath: defaultModulesPath } = {},
 ) {
   const srcPath = resolve(relativeSrcPath)
   const functions = await getFunctionsFromPaths([srcPath], { dedupe: true })
@@ -102,7 +86,6 @@ const zipFunction = async function (
     extension,
     srcDir,
     stat,
-    zipGo,
     runtime,
     pluginsModulesPath,
   })

--- a/tests/main.js
+++ b/tests/main.js
@@ -660,33 +660,7 @@ test('Zips Rust function files', async (t) => {
   t.is(tc, '{"runtime":"rs"}')
 })
 
-test('Zips Go function files', async (t) => {
-  const { files, tmpDir } = await zipFixture(t, 'go-simple', { length: 1, opts: { zipGo: true } })
-
-  t.true(files.every(({ runtime }) => runtime === 'go'))
-
-  await unzipFiles(files)
-
-  const unzippedFile = `${tmpDir}/test`
-  t.true(await pathExists(unzippedFile))
-
-  // The library we use for unzipping does not keep executable permissions.
-  // https://github.com/cthackers/adm-zip/issues/86
-  // However `chmod()` is not cross-platform
-  if (platform === 'linux') {
-    await pChmod(unzippedFile, EXECUTABLE_PERMISSION)
-
-    const { stdout } = await execa(unzippedFile)
-    t.is(stdout, 'test')
-  }
-
-  const tcFile = `${tmpDir}/netlify-toolchain`
-  t.true(await pathExists(tcFile))
-  const tc = (await pReadFile(tcFile, 'utf8')).trim()
-  t.is(tc, '{"runtime":"go"}')
-})
-
-test('Can skip zipping Go function files', async (t) => {
+test('Does not zip Go function files', async (t) => {
   const { files } = await zipFixture(t, 'go-simple', { length: 1 })
 
   t.true(files.every(({ runtime }) => runtime === 'go'))


### PR DESCRIPTION
Fixes #372.

The `skipGo`/`zipGo` parameter does not appear to be used by any user (including us), excepting for the CLI, which uses the default value.

https://github.com/netlify/cli/blob/3d8f1793ed90099152246fd4f69d44864762b55f/src/commands/functions/build.js#L56

We should remove those parameters. This would be a breaking change, i.e. require a major release.