### PR TITLE
fix: ignore undefined values when computing function config

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -27,7 +27,7 @@ const getConfigForFunction = ({ config, func }) => {
     .sort(({ weight: weightA }, { weight: weightB }) => weightA - weightB)
     .map(({ expression }) => config[expression])
 
-  return mergeOptions.apply({ concatArrays: true }, matches)
+  return mergeOptions.apply({ concatArrays: true, ignoreUndefined: true }, matches)
 }
 
 module.exports = { getConfigForFunction }


### PR DESCRIPTION
**- Summary**

This PR changes the logic for computing the function configuration objects such that `undefined` values are ignored.

**- Test plan**

Added a new test.

**- Description for the changelog**

fix: ignore undefined values when computing function config

**- A picture of a cute animal (not mandatory but encouraged)**

![main-qimg-bea9ae821736573bf7bec505354303f6](https://user-images.githubusercontent.com/4162329/111641748-594eb600-87f5-11eb-9bef-b7f24adf4287.jpg)
