### PR TITLE
chore: add tsconfig-related tests

### DIFF
--- a/tests/fixtures/node-typescript-tsconfig-parent/functions/function.ts
+++ b/tests/fixtures/node-typescript-tsconfig-parent/functions/function.ts
@@ -1,0 +1,5 @@
+import testModule from 'module-name'
+
+const value = testModule as boolean
+
+export { value }

--- a/tests/fixtures/node-typescript-tsconfig-parent/node_modules/module-alias/index.js
+++ b/tests/fixtures/node-typescript-tsconfig-parent/node_modules/module-alias/index.js
@@ -1,0 +1,1 @@
+module.exports = true

--- a/tests/fixtures/node-typescript-tsconfig-parent/node_modules/module-alias/package.json
+++ b/tests/fixtures/node-typescript-tsconfig-parent/node_modules/module-alias/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "module-name",
+  "version": "1.0.0",
+  "main": "main.js"
+}

--- a/tests/fixtures/node-typescript-tsconfig-parent/tsconfig.json
+++ b/tests/fixtures/node-typescript-tsconfig-parent/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "module-name": ["node_modules/module-alias"]
+    }
+  }
+}

--- a/tests/fixtures/node-typescript-tsconfig-sibling/function.ts
+++ b/tests/fixtures/node-typescript-tsconfig-sibling/function.ts
@@ -1,0 +1,5 @@
+import testModule from 'module-name'
+
+const value = testModule as boolean
+
+export { value }

--- a/tests/fixtures/node-typescript-tsconfig-sibling/node_modules/module-alias/index.js
+++ b/tests/fixtures/node-typescript-tsconfig-sibling/node_modules/module-alias/index.js
@@ -1,0 +1,1 @@
+module.exports = true

--- a/tests/fixtures/node-typescript-tsconfig-sibling/node_modules/module-alias/package.json
+++ b/tests/fixtures/node-typescript-tsconfig-sibling/node_modules/module-alias/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "module-name",
+  "version": "1.0.0",
+  "main": "main.js"
+}

--- a/tests/fixtures/node-typescript-tsconfig-sibling/tsconfig.json
+++ b/tests/fixtures/node-typescript-tsconfig-sibling/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "module-name": ["node_modules/module-alias"]
+    }
+  }
+}

--- a/tests/main.js
+++ b/tests/main.js
@@ -711,6 +711,32 @@ testBundlers(
   },
 )
 
+testBundlers(
+  'Loads a tsconfig.json placed in the same directory as the function',
+  [ESBUILD, ESBUILD_ZISI, DEFAULT],
+  async (bundler, t) => {
+    const { files, tmpDir } = await zipFixture(t, 'node-typescript-tsconfig-sibling', {
+      opts: { config: { '*': { nodeBundler: bundler } } },
+    })
+    await unzipFiles(files)
+    // eslint-disable-next-line import/no-dynamic-require, node/global-require
+    t.true(require(`${tmpDir}/function.js`).value)
+  },
+)
+
+testBundlers(
+  'Loads a tsconfig.json placed in a parent directory',
+  [ESBUILD, ESBUILD_ZISI, DEFAULT],
+  async (bundler, t) => {
+    const { files, tmpDir } = await zipFixture(t, 'node-typescript-tsconfig-parent/functions', {
+      opts: { config: { '*': { nodeBundler: bundler } } },
+    })
+    await unzipFiles(files)
+    // eslint-disable-next-line import/no-dynamic-require, node/global-require
+    t.true(require(`${tmpDir}/function.js`).value)
+  },
+)
+
 // We're not running this test for the `DEFAULT` bundler — not because it's not
 // supported, but because the legacy bundler doesn't use any of the available
 // configuration properties and therefore there is nothing we could test.


### PR DESCRIPTION
**- Summary**

This PR adds some tests for the tsconfig file discovery, when using TypeScript functions.

**- Description for the changelog**

chore: add tsconfig-related tests

**- A picture of a cute animal (not mandatory but encouraged)**

![61o3x6AANUL _AC_SL1000_](https://user-images.githubusercontent.com/4162329/112867712-25a44380-90b3-11eb-839b-075c91d74b08.jpg)
