### PR TITLE
chore: automate npm publishing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,7 +8,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: GoogleCloudPlatform/release-please-action@v2
+        id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.NODE_PKG_RELEASE_TOKEN }}
           release-type: node
           package-name: '@netlify/@netlify/zip-it-and-ship-it'
+      - uses: actions/checkout@v2
+        if: ${{ steps.release.outputs.release_created }}
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '15'
+          registry-url: 'https://registry.npmjs.org'
+        if: ${{ steps.release.outputs.release_created }}
+      - run: npm publish
+        if: ${{ steps.release.outputs.release_created }}
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,10 +25,7 @@ The following things are tested for:
 
 ## Releasing
 
-1. Merge the release PR
-2. Switch to the default branch `git checkout master`
-3. Pull latest changes `git pull`
-4. Publish the package `npm publish`
+Merge the release PR
 
 ## License
 


### PR DESCRIPTION
This automates npm publishing.

We would need to add a GitHub personal access token named `NODE_PKG_RELEASE_TOKEN` from `netlify-bot` with `public_repo` scope and also an `npm` token named `NPM_TOKEN`.

### Update
I've added the secrets and also remove a `CODE_COVERAGE` one that wasn't used in the repo