### PR TITLE
feat: add function name to output of zipFunction and zipFunctions

### DIFF
--- a/src/zip.js
+++ b/src/zip.js
@@ -19,9 +19,17 @@ const validateArchiveFormat = (archiveFormat) => {
 
 // Takes the result of zipping a function and formats it for output.
 const formatZipResult = (result) => {
-  const { bundler, bundlerErrors, bundlerWarnings, config = {}, path, runtime } = result
+  const { bundler, bundlerErrors, bundlerWarnings, config = {}, name, path, runtime } = result
 
-  return removeFalsy({ bundler, bundlerErrors, bundlerWarnings, config, path, runtime: runtime.name })
+  return removeFalsy({
+    bundler,
+    bundlerErrors,
+    bundlerWarnings,
+    config,
+    name,
+    path,
+    runtime: runtime.name,
+  })
 }
 
 // Zip `srcFolder/*` (Node.js or Go files) to `destFolder/*.zip` so it can be
@@ -57,7 +65,7 @@ const zipFunctions = async function (
         stat: func.stat,
       })
 
-      return { ...zipResult, runtime: func.runtime }
+      return { ...zipResult, name: func.name, runtime: func.runtime }
     },
     {
       concurrency: parallelLimit,
@@ -80,7 +88,7 @@ const zipFunction = async function (
     return
   }
 
-  const { config, extension, filename, mainFile, runtime, srcDir, stat } = functions.values().next().value
+  const { config, extension, filename, mainFile, name, runtime, srcDir, stat } = functions.values().next().value
   const pluginsModulesPath =
     defaultModulesPath === undefined ? await getPluginsModulesPath(srcPath) : defaultModulesPath
 
@@ -100,7 +108,7 @@ const zipFunction = async function (
     pluginsModulesPath,
   })
 
-  return formatZipResult({ ...zipResult, runtime })
+  return formatZipResult({ ...zipResult, name, runtime })
 }
 
 module.exports = { zipFunction, zipFunctions }

--- a/tests/main.js
+++ b/tests/main.js
@@ -383,9 +383,14 @@ testBundlers('Works with many dependencies', [ESBUILD, ESBUILD_ZISI, DEFAULT], a
 })
 
 testBundlers('Works with many function files', [ESBUILD, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
-  await zipNode(t, 'many-functions', {
+  const names = new Set(['one', 'two', 'three', 'four', 'five', 'six'])
+  const { files } = await zipNode(t, 'many-functions', {
     opts: { config: { '*': { nodeBundler: bundler } } },
     length: TEST_FUNCTIONS_LENGTH,
+  })
+
+  files.forEach(({ name }) => {
+    t.true(names.has(name))
   })
 })
 
@@ -466,6 +471,7 @@ testBundlers('Can use zipFunction()', [ESBUILD, ESBUILD_ZISI, DEFAULT], async (b
   const outBundlers = { [ESBUILD_ZISI]: ESBUILD, [DEFAULT]: JS_BUNDLER_ZISI }
   const outBundler = outBundlers[bundler] || bundler
 
+  t.is(result.name, 'function')
   t.is(result.runtime, 'js')
   t.is(result.bundler, outBundler)
   t.deepEqual(result.config, bundler === DEFAULT ? {} : { nodeBundler: outBundler })


### PR DESCRIPTION
**- Summary**

This PR adds the name of each bundled function to the output of `zipFunction` and `zipFunctions`, under the `name` property.

Closes #383.

**- Test plan**

Adjusted existing tests.

**- Description for the changelog**

feat: add function name to output of zipFunction and zipFunctions

**- A picture of a cute animal (not mandatory but encouraged)**

![How-do-you-call-a-Baby-Gorillaa](https://user-images.githubusercontent.com/4162329/114877338-17665f00-9df7-11eb-9d3c-866b126ce039.jpg)
