### PR TITLE
fix: add .ts to the list of esbuild resolved extensions

### DIFF
--- a/src/runtimes/node/bundler.js
+++ b/src/runtimes/node/bundler.js
@@ -54,7 +54,7 @@ const bundleJsFile = async function ({
       nodePaths: additionalModulePaths,
       platform: 'node',
       plugins: supportsAsyncAPI ? plugins : [],
-      resolveExtensions: ['.js', '.jsx', '.mjs', '.cjs', '.json'],
+      resolveExtensions: ['.js', '.jsx', '.mjs', '.cjs', '.ts', '.json'],
       target: [nodeTarget],
     })
 

--- a/tests/fixtures/node-typescript-with-imports/function.ts
+++ b/tests/fixtures/node-typescript-with-imports/function.ts
@@ -1,0 +1,3 @@
+import { type } from './lib/util'
+
+export { type }

--- a/tests/fixtures/node-typescript-with-imports/lib/util.ts
+++ b/tests/fixtures/node-typescript-with-imports/lib/util.ts
@@ -1,0 +1,5 @@
+type MyType = string
+
+const type: MyType = '❤️ TypeScript'
+
+export { type }

--- a/tests/main.js
+++ b/tests/main.js
@@ -788,6 +788,15 @@ testBundlers(
   },
 )
 
+testBundlers('Handles a TypeScript function with imports', [ESBUILD, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
+  const { files, tmpDir } = await zipFixture(t, 'node-typescript-with-imports', {
+    opts: { config: { '*': { nodeBundler: bundler } } },
+  })
+  await unzipFiles(files)
+  // eslint-disable-next-line import/no-dynamic-require, node/global-require
+  t.true(typeof require(`${tmpDir}/function.js`).type === 'string')
+})
+
 testBundlers(
   'Loads a tsconfig.json placed in the same directory as the function',
   [ESBUILD, ESBUILD_ZISI, DEFAULT],


### PR DESCRIPTION
**- Summary**

Adds `.ts` to the list of extensions that esbuild resolves automatically when resolving an import statement.

Fixes https://github.com/netlify/cli/issues/2183.

**- Test plan**

Added new test.

**- Description for the changelog**

fix: add .ts to the list of esbuild resolved extensions

**- A picture of a cute animal (not mandatory but encouraged)**

![5bb62995849376e0e0a0ed0e449ebd59_a6e31fbb0810e9fec012e4f85e8c6057](https://user-images.githubusercontent.com/4162329/115531123-5465a200-a28c-11eb-95a8-d3d174512079.jpg)
