### PR TITLE
fix: use URLs in sourceRoot

### DIFF
--- a/src/runtimes/node/bundler.js
+++ b/src/runtimes/node/bundler.js
@@ -34,6 +34,11 @@ const bundleJsFile = async function ({
   const plugins = [externalNativeModulesPlugin(nativeNodeModules)]
   const nodeTarget = getBundlerTarget(config.nodeVersion)
 
+  // esbuild will format `sources` relative to the sourcemap file, which is a
+  // sibling of `bundlePath`. We use `sourceRoot` to establish that relation.
+  // They are URLs, so even on Windows they should use forward slashes.
+  const sourceRoot = dirname(bundlePath).replace(/\\/g, '/')
+
   try {
     const { metafile, warnings } = await buildFunction({
       bundle: true,
@@ -47,11 +52,7 @@ const bundleJsFile = async function ({
       plugins: supportsAsyncAPI ? plugins : [],
       resolveExtensions: ['.js', '.jsx', '.mjs', '.cjs', '.ts', '.json'],
       sourcemap: Boolean(config.nodeSourcemap),
-
-      // esbuild will format `sources` relative to the sourcemap file, which is
-      // a sibling of `bundlePath`. We `sourceRoot` to establish that relation.
-      // They are URLs, so even on Windows they should use forward slashes.
-      sourceRoot: dirname(bundlePath).replace(/\\/g, '/'),
+      sourceRoot,
       target: [nodeTarget],
     })
     const sourcemapPath = getSourcemapPath(metafile.outputs)

--- a/src/runtimes/node/bundler.js
+++ b/src/runtimes/node/bundler.js
@@ -47,7 +47,11 @@ const bundleJsFile = async function ({
       plugins: supportsAsyncAPI ? plugins : [],
       resolveExtensions: ['.js', '.jsx', '.mjs', '.cjs', '.ts', '.json'],
       sourcemap: Boolean(config.nodeSourcemap),
-      sourceRoot: dirname(bundlePath),
+
+      // esbuild will format `sources` relative to the sourcemap file, which is
+      // a sibling of `bundlePath`. We `sourceRoot` to establish that relation.
+      // They are URLs, so even on Windows they should use forward slashes.
+      sourceRoot: dirname(bundlePath).replace(/\\/g, '/'),
       target: [nodeTarget],
     })
     const sourcemapPath = getSourcemapPath(metafile.outputs)


### PR DESCRIPTION
**- Summary**

Currently `sourceRoot` is set to an absolute path, which on Windows contains backslashes. However, this property is supposed to be a URL, so it needs to be converted to use forward-slashes. 

**- Test plan**

N/A

**- A picture of a cute animal (not mandatory but encouraged)**

![4923ec849aeff7e1a7dc189dfd284ddb](https://user-images.githubusercontent.com/4162329/116978228-56335a80-acbb-11eb-8259-3b321bcb2a70.jpg)
