### PR TITLE
chore: add packageRules to Renovate config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -8,6 +8,9 @@
     {
       // These cannot be upgraded to a major version until we drop support for Node 10
       packageNames: ['p-map', 'yargs'],
+      major: {
+        enabled: false,
+      },
     },
     {
       // Fake dependencies used in tests

--- a/renovate.json5
+++ b/renovate.json5
@@ -6,6 +6,10 @@
   automerge: false,
   packageRules: [
     {
+      // These cannot be upgraded to a major version until we drop support for Node 10
+      packageNames: ['p-map', 'yargs'],
+    },
+    {
       // Fake dependencies used in tests
       packageNames: ['test'],
       enabled: false,

--- a/renovate.json5
+++ b/renovate.json5
@@ -13,6 +13,14 @@
       },
     },
     {
+      matchPackageNames: ['p-map'],
+      allowedVersions: '<5',
+    },
+    {
+      matchPackageNames: ['yargs'],
+      allowedVersions: '<17',
+    },
+    {
       // Fake dependencies used in tests
       packageNames: ['test'],
       enabled: false,


### PR DESCRIPTION
**- Summary**

Some packages can't be upgraded until we drop support for Node 10. This PR updates the Renovate config to that effect.

**- Test plan**

N/A

**- A picture of a cute animal (not mandatory but encouraged)**

🐘 