### PR TITLE
fix: add default bundler to listFunctions and listFunctionsFiles calls

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -53,7 +53,17 @@ const getListedFunctionFiles = async function (
   return srcFiles.map((srcFile) => ({ srcFile, name, mainFile, runtime: runtime.name, extension: extname(srcFile) }))
 }
 
-const getSrcFiles = function ({ config, runtime, stat, mainFile, extension, srcPath, srcDir, pluginsModulesPath }) {
+const getSrcFiles = function ({
+  bundler,
+  config,
+  runtime,
+  stat,
+  mainFile,
+  extension,
+  srcPath,
+  srcDir,
+  pluginsModulesPath,
+}) {
   const { getSrcFiles: getRuntimeSrcFiles } = runtime
 
   if (extension === '.zip' || typeof getRuntimeSrcFiles !== 'function') {
@@ -61,6 +71,7 @@ const getSrcFiles = function ({ config, runtime, stat, mainFile, extension, srcP
   }
 
   return getRuntimeSrcFiles({
+    bundler,
     config,
     extension,
     srcPath,

--- a/src/runtimes/node/index.js
+++ b/src/runtimes/node/index.js
@@ -13,6 +13,14 @@ const { zipZisi } = require('./zip_zisi')
 // exception of TypeScript files, for which the only option is esbuild.
 const getDefaultBundler = ({ extension }) => (extension === '.ts' ? JS_BUNDLER_ESBUILD : JS_BUNDLER_ZISI)
 
+// A proxy for the `getSrcFiles` function which adds a default `bundler` using
+// the `getDefaultBundler` function.
+const getSrcFilesWithBundler = (parameters) => {
+  const bundler = parameters.config.nodeBundler || getDefaultBundler({ extension: parameters.extension })
+
+  return getSrcFiles({ ...parameters, bundler })
+}
+
 const zipFunction = async function ({
   archiveFormat,
   basePath,
@@ -90,4 +98,9 @@ const zipWithFunctionWithFallback = async ({ config = {}, ...parameters }) => {
   }
 }
 
-module.exports = { findFunctionsInPaths, getSrcFiles, name: RUNTIME_JS, zipFunction: zipWithFunctionWithFallback }
+module.exports = {
+  findFunctionsInPaths,
+  getSrcFiles: getSrcFilesWithBundler,
+  name: RUNTIME_JS,
+  zipFunction: zipWithFunctionWithFallback,
+}

--- a/src/runtimes/node/src_files.js
+++ b/src/runtimes/node/src_files.js
@@ -44,7 +44,6 @@ const getPathsOfIncludedFiles = async (includedFiles, basePath) => {
 const getSrcFiles = async function ({ config, ...parameters }) {
   const { paths } = await getSrcFilesAndExternalModules({
     ...parameters,
-    bundler: config.nodeBundler || JS_BUNDLER_ZISI,
     externalNodeModules: config.externalNodeModules,
   })
 

--- a/tests/fixtures/list/five/index.ts
+++ b/tests/fixtures/list/five/index.ts
@@ -1,0 +1,5 @@
+import { type } from './util'
+
+const obj = { type }
+
+export default obj

--- a/tests/fixtures/list/five/util.ts
+++ b/tests/fixtures/list/five/util.ts
@@ -1,0 +1,5 @@
+type MyType = string
+
+const type: MyType = '❤️ TypeScript'
+
+export { type }

--- a/tests/main.js
+++ b/tests/main.js
@@ -515,6 +515,7 @@ test('Can list function main files with listFunctions()', async (t) => {
     [
       { name: 'test', mainFile: 'test.zip', runtime: 'js', extension: '.zip' },
       { name: 'test', mainFile: 'test.js', runtime: 'js', extension: '.js' },
+      { name: 'five', mainFile: 'five/index.ts', runtime: 'js', extension: '.ts' },
       { name: 'four', mainFile: 'four.js/four.js.js', runtime: 'js', extension: '.js' },
       { name: 'one', mainFile: 'one/index.js', runtime: 'js', extension: '.js' },
       { name: 'two', mainFile: 'two/two.js', runtime: 'js', extension: '.js' },
@@ -534,6 +535,7 @@ testBundlers(
       [
         { name: 'test', mainFile: 'test.zip', runtime: 'js', extension: '.zip', srcFile: 'test.zip' },
         { name: 'test', mainFile: 'test.js', runtime: 'js', extension: '.js', srcFile: 'test.js' },
+        { name: 'five', mainFile: 'five/index.ts', runtime: 'js', extension: '.ts', srcFile: 'five/index.ts' },
         {
           name: 'four',
           mainFile: 'four.js/four.js.js',


### PR DESCRIPTION
Ensures that `listFunctions()` and `listFunctionsFiles()` use the right default bundler based on the extension — e.g. TypeScript files will use esbuild even if not explicitly set in the config. This is in line with the `zipFunction()` and `zipFunctions()` methods.

Closes #512.