### PR TITLE
feat: upgrade esbuild to @netlify/esbuild@0.13.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.3.0",
       "license": "MIT",
       "dependencies": {
-        "@netlify/esbuild": "^0.13.4",
+        "@netlify/esbuild": "^0.13.5",
         "archiver": "^5.3.0",
         "array-flat-polyfill": "^1.0.1",
         "common-path-prefix": "^3.0.0",
@@ -878,9 +878,9 @@
       }
     },
     "node_modules/@netlify/esbuild": {
-      "version": "0.13.4",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild/-/esbuild-0.13.4.tgz",
-      "integrity": "sha512-VEnlGIBlqUWtzKhbV5RdQLcaMp4QRMNqLZ5yHTEYMmTeETV9Sn/q610MAhoWkbYjBfg8eEuLRgvmYeLABbuHbg==",
+      "version": "0.13.5",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild/-/esbuild-0.13.5.tgz",
+      "integrity": "sha512-412V+fUhQagmQ6gw/SqvFU1Gi06n+7M9Rug6+Fr4Qzpiq7To2iMS0myYOyyFs1UfmVM6a3erXKfhPQsBzo4CQQ==",
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
@@ -12274,9 +12274,9 @@
       }
     },
     "@netlify/esbuild": {
-      "version": "0.13.4",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild/-/esbuild-0.13.4.tgz",
-      "integrity": "sha512-VEnlGIBlqUWtzKhbV5RdQLcaMp4QRMNqLZ5yHTEYMmTeETV9Sn/q610MAhoWkbYjBfg8eEuLRgvmYeLABbuHbg=="
+      "version": "0.13.5",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild/-/esbuild-0.13.5.tgz",
+      "integrity": "sha512-412V+fUhQagmQ6gw/SqvFU1Gi06n+7M9Rug6+Fr4Qzpiq7To2iMS0myYOyyFs1UfmVM6a3erXKfhPQsBzo4CQQ=="
     },
     "@netlify/eslint-config-node": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "url": "https://github.com/netlify/zip-it-and-ship-it/issues"
   },
   "dependencies": {
-    "@netlify/esbuild": "^0.13.4",
+    "@netlify/esbuild": "^0.13.5",
     "archiver": "^5.3.0",
     "array-flat-polyfill": "^1.0.1",
     "common-path-prefix": "^3.0.0",

--- a/tests/fixtures/node-typescript-tsconfig-target/functions/function.ts
+++ b/tests/fixtures/node-typescript-tsconfig-target/functions/function.ts
@@ -1,0 +1,5 @@
+import testModule from 'module-name'
+
+const { foo, bar, ...others } = testModule
+
+export { foo, bar, others }

--- a/tests/fixtures/node-typescript-tsconfig-target/node_modules/module-name/index.js
+++ b/tests/fixtures/node-typescript-tsconfig-target/node_modules/module-name/index.js
@@ -1,0 +1,1 @@
+module.exports = {foo: true, bar: false, baz: true}

--- a/tests/fixtures/node-typescript-tsconfig-target/node_modules/module-name/package.json
+++ b/tests/fixtures/node-typescript-tsconfig-target/node_modules/module-name/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "module-name",
+  "version": "1.0.0",
+  "main": "main.js"
+}

--- a/tests/fixtures/node-typescript-tsconfig-target/tsconfig.json
+++ b/tests/fixtures/node-typescript-tsconfig-target/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "target": "es5"
+  }
+}


### PR DESCRIPTION
**- Summary**

Upgrades esbuild to version 0.13.5 of the Netlify fork, which includes changes introduced in upstream version 0.12.8.

**- Test plan**

Includes an additional test to ensure that the compilation target that we define overrides any value set in a tsconfig.

**- A picture of a cute animal (not mandatory but encouraged)**

👀 
🐽 
👄 
