### PR TITLE
fix: add aws-sdk to ignored_node_modules

### DIFF
--- a/src/node_dependencies/special_cases.js
+++ b/src/node_dependencies/special_cases.js
@@ -1,7 +1,7 @@
 const { getPackageJson } = require('./package_json')
 
 const EXTERNAL_MODULES = ['@prisma/client']
-const IGNORED_MODULES = []
+const IGNORED_MODULES = ['aws-sdk']
 
 const getPackageJsonIfAvailable = async (srcDir) => {
   try {

--- a/tests/fixtures/node-module-excluded/function.js
+++ b/tests/fixtures/node-module-excluded/function.js
@@ -1,6 +1,6 @@
-try {
-  // eslint-disable-next-line import/no-unassigned-import, import/no-unresolved, node/global-require
-  require('aws-sdk')
-} catch (error) {}
+module.exports = () => {
+  // eslint-disable-next-line node/global-require, node/no-extraneous-require
+  const AWS = require('aws-sdk')
 
-module.exports = true
+  return AWS
+}

--- a/tests/fixtures/node-module-excluded/node_modules/aws-sdk/index.js
+++ b/tests/fixtures/node-module-excluded/node_modules/aws-sdk/index.js
@@ -1,0 +1,1 @@
+module.exports = 'fake module'

--- a/tests/fixtures/node-module-excluded/node_modules/aws-sdk/package.json
+++ b/tests/fixtures/node-module-excluded/node_modules/aws-sdk/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "aws-sdk",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/tests/main.js
+++ b/tests/main.js
@@ -150,7 +150,19 @@ testBundlers('Can require dynamically generated node modules', [ESBUILD, ESBUILD
 
 testBundlers('Ignore some excluded node modules', [ESBUILD, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   const { tmpDir } = await zipNode(t, 'node-module-excluded', { opts: { config: { '*': { nodeBundler: bundler } } } })
+
   t.false(await pathExists(`${tmpDir}/src/node_modules/aws-sdk`))
+
+  try {
+    // eslint-disable-next-line import/no-dynamic-require, node/global-require
+    const func = require(`${tmpDir}/function.js`)
+
+    func()
+
+    t.fail('Running the function should fail due to the missing module')
+  } catch (error) {
+    t.is(error.code, 'MODULE_NOT_FOUND')
+  }
 })
 
 testBundlers('Ignore TypeScript types', [ESBUILD, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {


### PR DESCRIPTION
**- Summary**

The `aws-sdk` Node module is a special case. Because the module is injected automatically in the AWS Lambda environment, we want to leave any `require`/`import` calls untouched, but also we don't want to include its supporting files in the bundle.

This behaviour is being respected when using the ZISI bundler, but not with esbuild. We missed this even though we have a test specifically targeting this case, because the assertion was simply checking that `aws-sdk` was not part of the function's `node_modules`:

```js
t.false(await pathExists(`${tmpDir}/src/node_modules/aws-sdk`))
```

This is sufficient for ZISI, but not for esbuild, since the bundled modules will be inlined into the main file anyway.

This PR adds `aws-sdk` to the list of ignored modules and verifies that the module doesn't exist in the generated bundle by trying to `require` it at runtime.

**- Test plan**

Adjusted an existing test.

**- A picture of a cute animal (not mandatory but encouraged)**

![2020-Animal-Kingdom-Baby-Zebra](https://user-images.githubusercontent.com/4162329/122387879-3b652e80-cf67-11eb-916c-c9fc6813ad9f.jpg)

