### PR TITLE
feat: add more expressions to dynamic import parser

### DIFF
--- a/tests/fixtures/node-module-dynamic-import-template-literal/function.js
+++ b/tests/fixtures/node-module-dynamic-import-template-literal/function.js
@@ -1,0 +1,1 @@
+module.exports = require('@org/test')

--- a/tests/fixtures/node-module-dynamic-import-template-literal/node_modules/@org/test/files/one.js
+++ b/tests/fixtures/node-module-dynamic-import-template-literal/node_modules/@org/test/files/one.js
@@ -1,0 +1,1 @@
+module.exports = true

--- a/tests/fixtures/node-module-dynamic-import-template-literal/node_modules/@org/test/index.js
+++ b/tests/fixtures/node-module-dynamic-import-template-literal/node_modules/@org/test/index.js
@@ -1,0 +1,13 @@
+module.exports = (number) => {
+  const parent = {
+    child: number
+  }
+  const arr = [number]
+  const require1 = require(`./files/${number}.js`)
+  const require2 = require(`./files/${number}`)
+  const require3 = require(`./files/${parent.child}`)
+  const require4 = require(`./files/${arr[0]}`)
+  const require5 = require(`./files/${number.length > 0 ? number : 'uh-oh'}`)
+
+  return [require1, require2, require3, require4, require5]
+}

--- a/tests/fixtures/node-module-dynamic-import-template-literal/node_modules/@org/test/package.json
+++ b/tests/fixtures/node-module-dynamic-import-template-literal/node_modules/@org/test/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@org/test",
+  "version": "1.0.0"
+}

--- a/tests/fixtures/node-module-dynamic-import-template-literal/package.json
+++ b/tests/fixtures/node-module-dynamic-import-template-literal/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "node-module-dynamic-import-template-literal",
+  "version": "1.0.0",
+  "dependencies": {
+    "@org/test": "1.0.0"
+  }
+}

--- a/tests/fixtures/node-module-dynamic-import-unresolvable/function.js
+++ b/tests/fixtures/node-module-dynamic-import-unresolvable/function.js
@@ -1,0 +1,1 @@
+module.exports = require('@org/test')

--- a/tests/fixtures/node-module-dynamic-import-unresolvable/node_modules/@org/test/files/one.js
+++ b/tests/fixtures/node-module-dynamic-import-unresolvable/node_modules/@org/test/files/one.js
@@ -1,0 +1,1 @@
+module.exports = true

--- a/tests/fixtures/node-module-dynamic-import-unresolvable/node_modules/@org/test/index.js
+++ b/tests/fixtures/node-module-dynamic-import-unresolvable/node_modules/@org/test/index.js
@@ -1,0 +1,7 @@
+module.exports = (number) => {
+  const require1 = require(number)
+  const require2 = require(`${number}.json`)
+  const require3 = require(foo(number))
+
+  return [require1, require2, require3]
+}

--- a/tests/fixtures/node-module-dynamic-import-unresolvable/node_modules/@org/test/package.json
+++ b/tests/fixtures/node-module-dynamic-import-unresolvable/node_modules/@org/test/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@org/test",
+  "version": "1.0.0"
+}

--- a/tests/fixtures/node-module-dynamic-import-unresolvable/package.json
+++ b/tests/fixtures/node-module-dynamic-import-unresolvable/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "node-module-dynamic-import-template-literal",
+  "version": "1.0.0",
+  "dependencies": {
+    "@org/test": "1.0.0"
+  }
+}

--- a/tests/fixtures/node-module-dynamic-import/node_modules/@org/test/index.js
+++ b/tests/fixtures/node-module-dynamic-import/node_modules/@org/test/index.js
@@ -2,7 +2,7 @@ const test2 = require('test-two')
 
 module.exports = (number) => {
   try {
-    test2()
+    test2(number)
   } catch (_) {}
 
   const file = require(`./files/${number}.json`)

--- a/tests/fixtures/node-module-dynamic-import/node_modules/test-two/index.js
+++ b/tests/fixtures/node-module-dynamic-import/node_modules/test-two/index.js
@@ -1,5 +1,4 @@
-module.exports = () => {
-  const number = 'one'
+module.exports = (number) => {
   const file = require.resolve(`./files/${number}.json`)
 
   return require(file)


### PR DESCRIPTION
**- Summary**

Adds support for more expression types when parsing dynamic import expressions.

**- Test plan**

Adjusted existing tests. Also added a new test which asserts that we leave alone any imports whose expressions we can't convert at build time.