### PR TITLE
chore: add test

### DIFF
--- a/tests/main.js
+++ b/tests/main.js
@@ -1283,6 +1283,23 @@ test('Adds a runtime shim and includes the files needed for dynamic imports usin
   t.throws(() => func('fr'))
 })
 
+test('Negated files in `included_files` are excluded from the bundle even if they match a dynamic import expression', async (t) => {
+  const fixtureName = 'node-module-dynamic-import-2'
+  const { tmpDir } = await zipNode(t, fixtureName, {
+    opts: {
+      basePath: join(FIXTURES_DIR, fixtureName),
+      config: { '*': { includedFiles: ['!lang/en.*'], nodeBundler: ESBUILD } },
+    },
+  })
+
+  // eslint-disable-next-line import/no-dynamic-require, node/global-require
+  const func = require(`${tmpDir}/function.js`)
+
+  t.deepEqual(func('pt')[0], ['sim', 'não'])
+  t.deepEqual(func('pt')[1], ['sim', 'não'])
+  t.throws(() => func('en'))
+})
+
 test('Creates dynamic import shims for functions with the same name and same shim contents with no naming conflicts', async (t) => {
   const FUNCTION_COUNT = 30
   const fixtureName = 'node-module-dynamic-import-3'


### PR DESCRIPTION
**- Summary**

Adds a test asserting that negating files in the `included_files` will take precedence over any files included automatically in the bundle as part of processing a dynamic import.

For example, imagine the following import:

```js
const lang = require(`./lang-files/${myLang}.json`)
```

This would include all `.json` files inside `lang-files`. But if you happen to have files inside that directory that you don't want to include for some reason (e.g. maybe you know that `myLang` will never match them), you can exclude them from the bundle like so:

```toml
[functions]
  included_files = ["!lang-files/not-a-lang.json", "!lang-files/*.not-a-lang.json"]
```