### PR TITLE
feat: add esbuild support for `.gql` and `.graphql` files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,10 +5,11 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "@netlify/zip-it-and-ship-it",
       "version": "4.6.0",
       "license": "MIT",
       "dependencies": {
+        "@graphql-tools/optimize": "^1.0.1",
+        "@luckycatfactory/esbuild-graphql-loader": "^3.6.0",
         "@netlify/esbuild": "^0.13.6",
         "acorn": "^8.4.0",
         "archiver": "^5.3.0",
@@ -21,6 +22,7 @@
         "filter-obj": "^2.0.1",
         "find-up": "^5.0.0",
         "glob": "^7.1.6",
+        "graphql-tag": "^2.12.5",
         "junk": "^3.1.0",
         "locate-path": "^6.0.0",
         "make-dir": "^3.1.0",
@@ -861,6 +863,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@graphql-tools/optimize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/optimize/-/optimize-1.0.1.tgz",
+      "integrity": "sha512-cRlUNsbErYoBtzzS6zXahXeTBZGPVlPHXCpnEZ0XiK/KY/sQL96cyzak0fM/Gk6qEI9/l32MYEICjasiBQrl5w==",
+      "dependencies": {
+        "tslib": "~2.0.1"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/optimize/node_modules/tslib": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+      "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -936,6 +954,15 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@luckycatfactory/esbuild-graphql-loader": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@luckycatfactory/esbuild-graphql-loader/-/esbuild-graphql-loader-3.6.0.tgz",
+      "integrity": "sha512-QRFiOvlOBJlXl3msbHiheLAX/TnX9ZnXjAf66t4efhgqP2hKzdHBqjmz0OFjb1yRc/JOGZNuomiqJywSmKmQWw==",
+      "peerDependencies": {
+        "esbuild": "^0.8.26",
+        "graphql-tag": "^2.11.0"
       }
     },
     "node_modules/@mrmlnc/readdir-enhanced": {
@@ -3677,6 +3704,16 @@
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
       "dev": true
     },
+    "node_modules/esbuild": {
+      "version": "0.8.57",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.8.57.tgz",
+      "integrity": "sha512-j02SFrUwFTRUqiY0Kjplwjm1psuzO1d6AjaXKuOR9hrY0HuPsT6sV42B6myW34h1q4CRy+Y3g4RU/cGJeI/nNA==",
+      "hasInstallScript": true,
+      "peer": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -5593,6 +5630,34 @@
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
       "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+    },
+    "node_modules/graphql": {
+      "version": "15.5.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.1.tgz",
+      "integrity": "sha512-FeTRX67T3LoE3LWAxxOlW2K3Bz+rMYAC18rRguK4wgXaTZMiJwSUwDmPFo3UadAKbzirKIg5Qy+sNJXbpPRnQw==",
+      "peer": true,
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/graphql-tag": {
+      "version": "2.12.5",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.5.tgz",
+      "integrity": "sha512-5xNhP4063d16Pz3HBtKprutsPrmHZi5IdUGOWRxA2B6VF7BIRGOHZ5WQvDmJXZuPcBg7rYwaFxvQYjqkSdR3TQ==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
+      }
+    },
+    "node_modules/graphql-tag/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
     },
     "node_modules/hard-rejection": {
       "version": "2.1.0",
@@ -12286,6 +12351,21 @@
         }
       }
     },
+    "@graphql-tools/optimize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/optimize/-/optimize-1.0.1.tgz",
+      "integrity": "sha512-cRlUNsbErYoBtzzS6zXahXeTBZGPVlPHXCpnEZ0XiK/KY/sQL96cyzak0fM/Gk6qEI9/l32MYEICjasiBQrl5w==",
+      "requires": {
+        "tslib": "~2.0.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+        }
+      }
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -12343,6 +12423,12 @@
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "dev": true
+    },
+    "@luckycatfactory/esbuild-graphql-loader": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@luckycatfactory/esbuild-graphql-loader/-/esbuild-graphql-loader-3.6.0.tgz",
+      "integrity": "sha512-QRFiOvlOBJlXl3msbHiheLAX/TnX9ZnXjAf66t4efhgqP2hKzdHBqjmz0OFjb1yRc/JOGZNuomiqJywSmKmQWw==",
+      "requires": {}
     },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
@@ -14428,6 +14514,12 @@
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
       "dev": true
     },
+    "esbuild": {
+      "version": "0.8.57",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.8.57.tgz",
+      "integrity": "sha512-j02SFrUwFTRUqiY0Kjplwjm1psuzO1d6AjaXKuOR9hrY0HuPsT6sV42B6myW34h1q4CRy+Y3g4RU/cGJeI/nNA==",
+      "peer": true
+    },
     "escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -15841,6 +15933,27 @@
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
       "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+    },
+    "graphql": {
+      "version": "15.5.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.1.tgz",
+      "integrity": "sha512-FeTRX67T3LoE3LWAxxOlW2K3Bz+rMYAC18rRguK4wgXaTZMiJwSUwDmPFo3UadAKbzirKIg5Qy+sNJXbpPRnQw==",
+      "peer": true
+    },
+    "graphql-tag": {
+      "version": "2.12.5",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.5.tgz",
+      "integrity": "sha512-5xNhP4063d16Pz3HBtKprutsPrmHZi5IdUGOWRxA2B6VF7BIRGOHZ5WQvDmJXZuPcBg7rYwaFxvQYjqkSdR3TQ==",
+      "requires": {
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
     },
     "hard-rejection": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,8 @@
     "url": "https://github.com/netlify/zip-it-and-ship-it/issues"
   },
   "dependencies": {
+    "@graphql-tools/optimize": "^1.0.1",
+    "@luckycatfactory/esbuild-graphql-loader": "^3.6.0",
     "@netlify/esbuild": "^0.13.6",
     "acorn": "^8.4.0",
     "archiver": "^5.3.0",
@@ -66,6 +68,7 @@
     "filter-obj": "^2.0.1",
     "find-up": "^5.0.0",
     "glob": "^7.1.6",
+    "graphql-tag": "^2.12.5",
     "junk": "^3.1.0",
     "locate-path": "^6.0.0",
     "make-dir": "^3.1.0",

--- a/src/runtimes/node/bundler.js
+++ b/src/runtimes/node/bundler.js
@@ -1,6 +1,8 @@
 const { basename, dirname, extname, resolve, join } = require('path')
 const process = require('process')
 
+const { optimizeDocumentNode } = require('@graphql-tools/optimize')
+const graphqlLoaderPlugin = require('@luckycatfactory/esbuild-graphql-loader')
 const esbuild = require('@netlify/esbuild')
 const semver = require('semver')
 const { tmpName } = require('tmp-promise')
@@ -66,6 +68,10 @@ const bundleJsFile = async function ({
       includedPaths: dynamicImportsIncludedPaths,
       moduleNames: nodeModulesWithDynamicImports,
       srcDir,
+    }),
+    graphqlLoaderPlugin({
+      filterRegex: /\.(gql|graphql)$/,
+      mapDocumentNode: (documentNode) => optimizeDocumentNode(documentNode),
     }),
   ]
 


### PR DESCRIPTION
Adds [https://github.com/luckycatfactory/esbuild-graphql-loader](https://github.com/luckycatfactory/esbuild-graphql-loader) to the esbuild plugins list to enable loading of `.gql` and `.graphql` files.

As suggested in the plugin's docs, [@graphql-tools/optimize](https://www.graphql-tools.com/docs/api/modules/optimize/) is used to further reduce the output bundle size.

This change is required to support graphql server functions that use a [SDL-first approach for defining their schemas (as opposed to Code-first)](https://blog.logrocket.com/code-first-vs-schema-first-development-graphql/#:~:text=To%20code%20the%20schema%2C%20we,the%20widespread%20popularity%20of%20GraphQL.).

Because esbuild does not support user configuration files, nor does `zip-it-and-ship-it` or `netlify-cli` provide a way for users to customize the esbuild configuration, the only option to support additional file types like this is through submitting a PR which adds support for it.

The only other alternative is to use the old method of using webpack to bundle functions.