### PR TITLE
chore: remove CLI feature flag from Next.js E2E workflow

### DIFF
--- a/.github/workflows/e2e-nextjs.yml
+++ b/.github/workflows/e2e-nextjs.yml
@@ -61,9 +61,8 @@ jobs:
         working-directory: zip-it-and-ship-it
       - name: Building and deploying site
         run:
-          NETLIFY_EXPERIMENTAL_FUNCTION_HANDLER_V2=true $GITHUB_WORKSPACE/netlify-cli/bin/run deploy --build --json
-          --site ${{ secrets.NETLIFY_SITE_ID }} --auth ${{ secrets.NETLIFY_TOKEN }} --functions .netlify/functions >
-          .netlify-deploy-log.json
+          $GITHUB_WORKSPACE/netlify-cli/bin/run deploy --build --json --site ${{ secrets.NETLIFY_SITE_ID }} --auth ${{
+          secrets.NETLIFY_TOKEN }} --functions .netlify/functions > .netlify-deploy-log.json
         working-directory: netlify-plugin-nextjs
       - name: Parsing deploy result
         run: |


### PR DESCRIPTION
**- Summary**

The `NETLIFY_EXPERIMENTAL_FUNCTION_HANDLER_V2` environment variable has been decommissioned.