### PR TITLE
feat: add support for feature flags

### DIFF
--- a/src/feature_flags.js
+++ b/src/feature_flags.js
@@ -1,0 +1,13 @@
+// List of supported flags and their default value.
+const FLAGS = {}
+
+const getFlags = (input = {}, flags = FLAGS) =>
+  Object.entries(flags).reduce(
+    (result, [key, defaultValue]) => ({
+      ...result,
+      [key]: input[key] === undefined ? defaultValue : input[key],
+    }),
+    {},
+  )
+
+module.exports = { FLAGS, getFlags }

--- a/tests/feature_flags.js
+++ b/tests/feature_flags.js
@@ -1,0 +1,26 @@
+const test = require('ava')
+
+const { getFlags } = require('../src/feature_flags')
+
+test('Respects default value of flags', (t) => {
+  const flags = getFlags({}, { someFlag: false })
+
+  t.is(flags.someFlag, false)
+})
+
+test('Ignores undeclared flags', (t) => {
+  const flags = getFlags({ unknownFlag: true }, { someFlag: false })
+
+  t.is(flags.unknownFlag, undefined)
+})
+
+test('Supplied flag values override defaults', (t) => {
+  const flags = getFlags({ someFlag: true, otherFlag: false }, { someFlag: false, otherFlag: true })
+
+  t.is(flags.someFlag, true)
+  t.is(flags.otherFlag, false)
+})
+
+test('Uses built-in defaults', (t) => {
+  t.notThrows(() => getFlags({ someFlag: true, otherFlag: false }))
+})


### PR DESCRIPTION
**- Summary**

Unlike Netlify Build, zip-it-and-ship-it doesn't have an official feature flag mechanism. We've been using the functions configuration object to that effect, but that falls short in some situations.

For example, the config is only evaluated when a function is being processed, but we might want to have a feature flag that determines whether a function is even created or not, meaning the feature flag needs to come earlier in the process.

This PR adds a `featureFlags` property that is passed to both `zipFunction` and `zipFunctions` and subsequently supplied to  `getFunctionsFromPaths`.

**- Test plan**

New tests added.

**- A picture of a cute animal (not mandatory but encouraged)**

![main_xkdhX3G](https://user-images.githubusercontent.com/4162329/124385760-fb27df00-dcce-11eb-9a37-a80d688a69a6.jpg)

