### PR TITLE
feat: add support for multiple src directories to list methods

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,27 +1,27 @@
-const { extname, resolve } = require('path')
+const { extname } = require('path')
 
 require('./utils/polyfills')
 const { getPluginsModulesPath } = require('./node_dependencies')
 const { getFunctionsFromPaths } = require('./runtimes')
-const { listFunctionsDirectory } = require('./utils/fs')
+const { listFunctionsDirectories, resolveFunctionsDirectories } = require('./utils/fs')
 const { zipFunction, zipFunctions } = require('./zip')
 
 // List all Netlify Functions main entry files for a specific directory
-const listFunctions = async function (relativeSrcFolder) {
-  const srcFolder = resolve(relativeSrcFolder)
-  const paths = await listFunctionsDirectory(srcFolder)
+const listFunctions = async function (relativeSrcFolders) {
+  const srcFolders = resolveFunctionsDirectories(relativeSrcFolders)
+  const paths = await listFunctionsDirectories(srcFolders)
   const functions = await getFunctionsFromPaths(paths)
   const listedFunctions = [...functions.values()].map(getListedFunction)
   return listedFunctions
 }
 
 // List all Netlify Functions files for a specific directory
-const listFunctionsFiles = async function (relativeSrcFolder, { config } = {}) {
-  const srcFolder = resolve(relativeSrcFolder)
-  const paths = await listFunctionsDirectory(srcFolder)
+const listFunctionsFiles = async function (relativeSrcFolders, { config } = {}) {
+  const srcFolders = resolveFunctionsDirectories(relativeSrcFolders)
+  const paths = await listFunctionsDirectories(srcFolders)
   const [functions, pluginsModulesPath] = await Promise.all([
     getFunctionsFromPaths(paths, { config }),
-    getPluginsModulesPath(srcFolder),
+    getPluginsModulesPath(srcFolders[0]),
   ])
   const listedFunctionsFiles = await Promise.all(
     [...functions.values()].map((func) => getListedFunctionFiles(func, { pluginsModulesPath })),

--- a/tests/main.js
+++ b/tests/main.js
@@ -537,6 +537,29 @@ test('Can list function main files with listFunctions()', async (t) => {
   )
 })
 
+test('Can list function main files from multiple source directories with listFunctions()', async (t) => {
+  const fixtureDir = `${FIXTURES_DIR}/multiple-src-directories`
+  const functions = await listFunctions([
+    join(fixtureDir, '.netlify', 'internal-functions'),
+    join(fixtureDir, 'netlify', 'functions'),
+  ])
+
+  t.deepEqual(
+    functions,
+    [
+      { name: 'function', mainFile: '.netlify/internal-functions/function.js', runtime: 'js', extension: '.js' },
+      {
+        name: 'function_internal',
+        mainFile: '.netlify/internal-functions/function_internal.js',
+        runtime: 'js',
+        extension: '.js',
+      },
+      { name: 'function', mainFile: 'netlify/functions/function.js', runtime: 'js', extension: '.js' },
+      { name: 'function_user', mainFile: 'netlify/functions/function_user.js', runtime: 'js', extension: '.js' },
+    ].map(normalizeFiles.bind(null, fixtureDir)),
+  )
+})
+
 testBundlers(
   'Can list all function files with listFunctionsFiles()',
   [ESBUILD, ESBUILD_ZISI, DEFAULT],
@@ -569,6 +592,122 @@ testBundlers(
         },
         { name: 'two', mainFile: 'two/two.js', runtime: 'js', extension: '.js', srcFile: 'two/two.js' },
         { name: 'test', mainFile: 'test', runtime: 'go', extension: '', srcFile: 'test' },
+      ]
+        .filter(Boolean)
+        .map(normalizeFiles.bind(null, fixtureDir)),
+    )
+  },
+)
+
+testBundlers(
+  'Can list all function files from multiple source directorires with listFunctionsFiles()',
+  [ESBUILD, ESBUILD_ZISI, DEFAULT],
+  // eslint-disable-next-line complexity
+  async (bundler, t) => {
+    const fixtureDir = `${FIXTURES_DIR}/multiple-src-directories`
+    const functions = await listFunctionsFiles(
+      [join(fixtureDir, '.netlify', 'internal-functions'), join(fixtureDir, 'netlify', 'functions')],
+      { config: { '*': { nodeBundler: bundler } } },
+    )
+
+    t.deepEqual(
+      functions,
+      [
+        {
+          name: 'function',
+          mainFile: '.netlify/internal-functions/function.js',
+          runtime: 'js',
+          extension: '.js',
+          srcFile: '.netlify/internal-functions/function.js',
+        },
+
+        bundler === DEFAULT && {
+          name: 'function',
+          mainFile: '.netlify/internal-functions/function.js',
+          runtime: 'js',
+          extension: '.js',
+          srcFile: 'node_modules/test/index.js',
+        },
+
+        bundler === DEFAULT && {
+          name: 'function',
+          mainFile: '.netlify/internal-functions/function.js',
+          runtime: 'js',
+          extension: '.json',
+          srcFile: 'node_modules/test/package.json',
+        },
+
+        {
+          name: 'function_internal',
+          mainFile: '.netlify/internal-functions/function_internal.js',
+          runtime: 'js',
+          extension: '.js',
+          srcFile: '.netlify/internal-functions/function_internal.js',
+        },
+
+        bundler === DEFAULT && {
+          name: 'function_internal',
+          mainFile: '.netlify/internal-functions/function_internal.js',
+          runtime: 'js',
+          extension: '.js',
+          srcFile: 'node_modules/test/index.js',
+        },
+
+        bundler === DEFAULT && {
+          name: 'function_internal',
+          mainFile: '.netlify/internal-functions/function_internal.js',
+          runtime: 'js',
+          extension: '.json',
+          srcFile: 'node_modules/test/package.json',
+        },
+
+        {
+          name: 'function',
+          mainFile: 'netlify/functions/function.js',
+          runtime: 'js',
+          extension: '.js',
+          srcFile: 'netlify/functions/function.js',
+        },
+
+        bundler === DEFAULT && {
+          name: 'function',
+          mainFile: 'netlify/functions/function.js',
+          runtime: 'js',
+          extension: '.js',
+          srcFile: 'node_modules/test/index.js',
+        },
+
+        bundler === DEFAULT && {
+          name: 'function',
+          mainFile: 'netlify/functions/function.js',
+          runtime: 'js',
+          extension: '.json',
+          srcFile: 'node_modules/test/package.json',
+        },
+
+        {
+          name: 'function_user',
+          mainFile: 'netlify/functions/function_user.js',
+          runtime: 'js',
+          extension: '.js',
+          srcFile: 'netlify/functions/function_user.js',
+        },
+
+        bundler === DEFAULT && {
+          name: 'function_user',
+          mainFile: 'netlify/functions/function_user.js',
+          runtime: 'js',
+          extension: '.js',
+          srcFile: 'node_modules/test/index.js',
+        },
+
+        bundler === DEFAULT && {
+          name: 'function_user',
+          mainFile: 'netlify/functions/function_user.js',
+          runtime: 'js',
+          extension: '.json',
+          srcFile: 'node_modules/test/package.json',
+        },
       ]
         .filter(Boolean)
         .map(normalizeFiles.bind(null, fixtureDir)),


### PR DESCRIPTION
**- Summary**

https://github.com/netlify/zip-it-and-ship-it/pull/537 added support for multiple source directories to the `zipFunction` and `zipFunctions` functions. This PR adds it to `listFunctions` and `listFunctionsFiles`.

**- Test plan**

Adds new tests.

**- A picture of a cute animal (not mandatory but encouraged)**

![maxresdefault](https://user-images.githubusercontent.com/4162329/124491255-f46e9a00-ddaa-11eb-9adb-31c8994aaf51.jpg)
