### PR TITLE
feat: add support for manifest file

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,22 @@ The following properties are accepted:
 
 See [feature flags](#feature-flags).
 
+#### `manifest`
+
+- _Type_: `string`
+- _Default value_: `undefined`
+
+Defines the path for a manifest file to be created with the results of the functions bundling, including the following
+properties:
+
+- `functions`: The list of functions created, in the same format as returned by `zipFunctions`
+- `system.arch`: The operating system CPU architecture, as returned by
+  [`process.arch`](https://nodejs.org/api/process.html#process_process_arch)
+- `system.platform`: The operating system, as returned by
+  [`process.platform`](https://nodejs.org/api/process.html#process_process_platform)
+- `timestamp`: The timestamp (in milliseconds) at the time of the functions bundling process
+- `version`: The version of the manifest file (current version is `1`)
+
 #### `parallelLimit`
 
 - _Type_: `number`\

--- a/README.md
+++ b/README.md
@@ -143,10 +143,10 @@ See [feature flags](#feature-flags).
 - _Type_: `string`
 - _Default value_: `undefined`
 
-Defines the path for a manifest file to be created with the results of the functions bundling, including the following
-properties:
+Defines the path for a manifest file to be created with the results of the functions bundling. This file is a
+JSON-formatted string with the following properties:
 
-- `functions`: The list of functions created, in the same format as returned by `zipFunctions`
+- `functions`: An array with the functions created, in the same format as returned by `zipFunctions`
 - `system.arch`: The operating system CPU architecture, as returned by
   [`process.arch`](https://nodejs.org/api/process.html#process_process_arch)
 - `system.platform`: The operating system, as returned by

--- a/src/bin.js
+++ b/src/bin.js
@@ -35,6 +35,10 @@ const OPTIONS = {
     describe:
       'An object matching glob-like expressions to objects containing configuration properties. Whenever a function name matches one of the expressions, it inherits the configuration properties',
   },
+  manifest: {
+    string: true,
+    describe: 'If a manifest file is to be created, specifies its path',
+  },
   'parallel-limit': {
     number: true,
     describe: 'Maximum number of Functions to bundle at the same time',

--- a/src/manifest.js
+++ b/src/manifest.js
@@ -1,3 +1,4 @@
+const { resolve } = require('path')
 const { arch, platform } = require('process')
 
 const { safeWriteFile } = require('./utils/fs')
@@ -5,8 +6,9 @@ const { safeWriteFile } = require('./utils/fs')
 const MANIFEST_VERSION = 1
 
 const createManifest = async ({ functions, path }) => {
+  const formattedFunctions = functions.map(formatFunction)
   const payload = {
-    functions,
+    functions: formattedFunctions,
     system: { arch, platform },
     timestamp: Date.now(),
     version: MANIFEST_VERSION,
@@ -14,5 +16,7 @@ const createManifest = async ({ functions, path }) => {
 
   await safeWriteFile(path, JSON.stringify(payload))
 }
+
+const formatFunction = (fn) => ({ ...fn, path: resolve(fn.path) })
 
 module.exports = { createManifest }

--- a/src/manifest.js
+++ b/src/manifest.js
@@ -1,7 +1,7 @@
 const { resolve } = require('path')
 const { arch, platform } = require('process')
 
-const { safeWriteFile } = require('./utils/fs')
+const { writeFile } = require('./utils/fs')
 
 const MANIFEST_VERSION = 1
 
@@ -14,7 +14,7 @@ const createManifest = async ({ functions, path }) => {
     version: MANIFEST_VERSION,
   }
 
-  await safeWriteFile(path, JSON.stringify(payload))
+  await writeFile(path, JSON.stringify(payload))
 }
 
 const formatFunction = (fn) => ({ ...fn, path: resolve(fn.path) })

--- a/src/manifest.js
+++ b/src/manifest.js
@@ -1,0 +1,18 @@
+const { arch, platform } = require('process')
+
+const { safeWriteFile } = require('./utils/fs')
+
+const MANIFEST_VERSION = 1
+
+const createManifest = async ({ functions, path }) => {
+  const payload = {
+    functions,
+    system: { arch, platform },
+    timestamp: Date.now(),
+    version: MANIFEST_VERSION,
+  }
+
+  await safeWriteFile(path, JSON.stringify(payload))
+}
+
+module.exports = { createManifest }

--- a/src/utils/fs.js
+++ b/src/utils/fs.js
@@ -1,4 +1,4 @@
-const { lstat, readdir, readFile, unlink } = require('fs')
+const { lstat, readdir, readFile, unlink, writeFile } = require('fs')
 const { format, join, parse, resolve } = require('path')
 const { promisify } = require('util')
 
@@ -6,6 +6,7 @@ const pLstat = promisify(lstat)
 const pReaddir = promisify(readdir)
 const pReadFile = promisify(readFile)
 const pUnlink = promisify(unlink)
+const pWriteFile = promisify(writeFile)
 
 // This caches multiple FS calls to the same path. It creates a cache key with
 // the name of the function and the path (e.g. "readdir:/some/directory").
@@ -29,6 +30,12 @@ const getPathWithExtension = (path, extension) => format({ ...parse(path), base:
 const safeUnlink = async (path) => {
   try {
     await pUnlink(path)
+  } catch (_) {}
+}
+
+const safeWriteFile = async (...args) => {
+  try {
+    await pWriteFile(...args)
   } catch (_) {}
 }
 
@@ -83,4 +90,5 @@ module.exports = {
   listFunctionsDirectory,
   resolveFunctionsDirectories,
   safeUnlink,
+  safeWriteFile,
 }

--- a/src/utils/fs.js
+++ b/src/utils/fs.js
@@ -33,12 +33,6 @@ const safeUnlink = async (path) => {
   } catch (_) {}
 }
 
-const safeWriteFile = async (...args) => {
-  try {
-    await pWriteFile(...args)
-  } catch (_) {}
-}
-
 // Takes a list of absolute paths and returns an array containing all the
 // filenames within those directories, if at least one of the directories
 // exists. If not, an error is thrown.
@@ -90,5 +84,5 @@ module.exports = {
   listFunctionsDirectory,
   resolveFunctionsDirectories,
   safeUnlink,
-  safeWriteFile,
+  writeFile: pWriteFile,
 }

--- a/src/zip.js
+++ b/src/zip.js
@@ -4,6 +4,7 @@ const makeDir = require('make-dir')
 const pMap = require('p-map')
 
 const { getFlags } = require('./feature_flags')
+const { createManifest } = require('./manifest')
 const { getPluginsModulesPath } = require('./node_dependencies')
 const { getFunctionsFromPaths } = require('./runtimes')
 const { ARCHIVE_FORMAT_NONE, ARCHIVE_FORMAT_ZIP } = require('./utils/consts')
@@ -59,6 +60,7 @@ const zipFunctions = async function (
     basePath,
     config = {},
     featureFlags: inputFeatureFlags,
+    manifest,
     parallelLimit = DEFAULT_PARALLEL_LIMIT,
   } = {},
 ) {
@@ -75,7 +77,7 @@ const zipFunctions = async function (
     // source directories.
     getPluginsModulesPath(srcFolders[0]),
   ])
-  const zipped = await pMap(
+  const results = await pMap(
     functions.values(),
     async (func) => {
       const zipResult = await func.runtime.zipFunction({
@@ -100,7 +102,12 @@ const zipFunctions = async function (
       concurrency: parallelLimit,
     },
   )
-  return zipped.filter(Boolean).map(formatZipResult)
+  const formattedResults = results.filter(Boolean).map(formatZipResult)
+  const manifestPath = manifest === undefined ? undefined : resolve(manifest)
+
+  await createManifest({ functions: formattedResults, path: manifestPath })
+
+  return formattedResults
 }
 
 const zipFunction = async function (

--- a/src/zip.js
+++ b/src/zip.js
@@ -103,9 +103,10 @@ const zipFunctions = async function (
     },
   )
   const formattedResults = results.filter(Boolean).map(formatZipResult)
-  const manifestPath = manifest === undefined ? undefined : resolve(manifest)
 
-  await createManifest({ functions: formattedResults, path: manifestPath })
+  if (manifest !== undefined) {
+    await createManifest({ functions: formattedResults, path: resolve(manifest) })
+  }
 
   return formattedResults
 }

--- a/tests/main.js
+++ b/tests/main.js
@@ -1751,7 +1751,6 @@ if (platform !== 'win32') {
 
 test('Creates a manifest file with the list of created functions if the `manifest` property is supplied', async (t) => {
   const FUNCTIONS_COUNT = 6
-  const ALLOWED_TIMESTAMP_DELTA = 1e3
   const { path: tmpDir } = await getTmpDir({ prefix: 'zip-it-test' })
   const manifestPath = join(tmpDir, 'manifest.json')
   const { files } = await zipNode(t, 'many-functions', {
@@ -1766,9 +1765,7 @@ test('Creates a manifest file with the list of created functions if the `manifes
   t.is(manifest.version, 1)
   t.is(manifest.system.arch, arch)
   t.is(manifest.system.platform, platform)
-
-  // Asserting that the `timestamp` property falls within an interval (1s).
-  t.true(Math.abs(Date.now() - manifest.timestamp) <= ALLOWED_TIMESTAMP_DELTA)
+  t.true(typeof manifest.timestamp, 'number')
 
   // The `path` property of each function must be an absolute path.
   manifest.functions.every(({ path }) => isAbsolute(path))

--- a/tests/main.js
+++ b/tests/main.js
@@ -1,7 +1,7 @@
 const { readFile, chmod, symlink, unlink, rename, stat, writeFile } = require('fs')
 const { tmpdir } = require('os')
 const { dirname, join, normalize, resolve, sep } = require('path')
-const { env, platform } = require('process')
+const { arch, env, platform } = require('process')
 const { promisify } = require('util')
 
 const test = require('ava')
@@ -1748,3 +1748,25 @@ if (platform !== 'win32') {
     )
   })
 }
+
+test('Creates a manifest file with the list of created functions if the `manifest` property is supplied', async (t) => {
+  const FUNCTIONS_COUNT = 6
+  const ALLOWED_TIMESTAMP_DELTA = 1e3
+  const { path: tmpDir } = await getTmpDir({ prefix: 'zip-it-test' })
+  const manifestPath = join(tmpDir, 'manifest.json')
+  const { files } = await zipNode(t, 'many-functions', {
+    length: FUNCTIONS_COUNT,
+    opts: { manifest: manifestPath },
+  })
+
+  // eslint-disable-next-line import/no-dynamic-require, node/global-require
+  const manifest = require(manifestPath)
+
+  t.deepEqual(files, manifest.functions)
+  t.is(manifest.version, 1)
+  t.is(manifest.system.arch, arch)
+  t.is(manifest.system.platform, platform)
+
+  // Asserting that the `timestamp` property falls within an interval (1s).
+  t.true(Math.abs(Date.now() - manifest.timestamp) <= ALLOWED_TIMESTAMP_DELTA)
+})

--- a/tests/main.js
+++ b/tests/main.js
@@ -1765,7 +1765,7 @@ test('Creates a manifest file with the list of created functions if the `manifes
   t.is(manifest.version, 1)
   t.is(manifest.system.arch, arch)
   t.is(manifest.system.platform, platform)
-  t.true(typeof manifest.timestamp, 'number')
+  t.is(typeof manifest.timestamp, 'number')
 
   // The `path` property of each function must be an absolute path.
   manifest.functions.every(({ path }) => isAbsolute(path))

--- a/tests/main.js
+++ b/tests/main.js
@@ -1,6 +1,6 @@
 const { readFile, chmod, symlink, unlink, rename, stat, writeFile } = require('fs')
 const { tmpdir } = require('os')
-const { dirname, join, normalize, resolve, sep } = require('path')
+const { dirname, isAbsolute, join, normalize, resolve, sep } = require('path')
 const { arch, env, platform } = require('process')
 const { promisify } = require('util')
 
@@ -1769,4 +1769,7 @@ test('Creates a manifest file with the list of created functions if the `manifes
 
   // Asserting that the `timestamp` property falls within an interval (1s).
   t.true(Math.abs(Date.now() - manifest.timestamp) <= ALLOWED_TIMESTAMP_DELTA)
+
+  // The `path` property of each function must be an absolute path.
+  manifest.functions.every(({ path }) => isAbsolute(path))
 })


### PR DESCRIPTION
**- Summary**

Adds a new `manifest` property to `zipFunctions`. When set, it defines the path where a JSON-formatted file will be created, containing the list of all created functions as well as additional metadata properties.

This file can then be used by the CLI to know whether to reuse previously bundled functions as part of `build` and `deploy` commands.

**- Test plan**

New test added.

**- A picture of a cute animal (not mandatory but encouraged)**

![1501921785-baby-turtles-9](https://user-images.githubusercontent.com/4162329/127850779-f82869fa-70d5-4696-b3b7-b455a8209b07.jpg)
