### PR TITLE
feat: simplify manifest format

### DIFF
--- a/src/manifest.js
+++ b/src/manifest.js
@@ -17,6 +17,6 @@ const createManifest = async ({ functions, path }) => {
   await writeFile(path, JSON.stringify(payload))
 }
 
-const formatFunction = (fn) => ({ ...fn, path: resolve(fn.path) })
+const formatFunction = ({ mainFile, name, path, runtime }) => ({ mainFile, name, path: resolve(path), runtime })
 
 module.exports = { createManifest }

--- a/tests/main.js
+++ b/tests/main.js
@@ -1789,12 +1789,18 @@ test('Creates a manifest file with the list of created functions if the `manifes
   // eslint-disable-next-line import/no-dynamic-require, node/global-require
   const manifest = require(manifestPath)
 
-  t.deepEqual(files, manifest.functions)
   t.is(manifest.version, 1)
   t.is(manifest.system.arch, arch)
   t.is(manifest.system.platform, platform)
   t.is(typeof manifest.timestamp, 'number')
 
-  // The `path` property of each function must be an absolute path.
-  manifest.functions.every(({ path }) => isAbsolute(path))
+  manifest.functions.forEach((fn, index) => {
+    const file = files[index]
+
+    t.true(isAbsolute(fn.path))
+    t.is(fn.mainFile, file.mainFile)
+    t.is(fn.name, file.name)
+    t.is(fn.runtime, file.runtime)
+    t.is(fn.path, file.path)
+  })
 })


### PR DESCRIPTION
**- Summary**

Currently, the manifest file includes the entire output from `zipFunctions`, which can get quite large. The `inputs` property is particularly lengthy and is currently not required by the CLI when reading the manifest. This PR limits the manifest file to include only these properties:

- `mainFile`
- `name`
- `path`
- `runtime`

**- Test plan**

Existing test updated.

**- A picture of a cute animal (not mandatory but encouraged)**

![photo-1531989417401-0f85f7e673f8](https://user-images.githubusercontent.com/4162329/130059018-7e88d084-5130-4896-949b-22d2366f438d.jpg)
