### PR TITLE
feat: allow JS functions with `.mjs` extension

### DIFF
--- a/src/runtimes/node/finder.js
+++ b/src/runtimes/node/finder.js
@@ -74,6 +74,8 @@ const getMainFile = function (srcPath, filename, stat) {
       [
         join(srcPath, `${filename}.js`),
         join(srcPath, 'index.js'),
+        join(srcPath, `${filename}.mjs`),
+        join(srcPath, 'index.mjs'),
         join(srcPath, `${filename}.ts`),
         join(srcPath, 'index.ts'),
       ],

--- a/src/runtimes/node/index.js
+++ b/src/runtimes/node/index.js
@@ -9,9 +9,10 @@ const { getSrcFiles } = require('./src_files')
 const { zipEsbuild } = require('./zip_esbuild')
 const { zipZisi } = require('./zip_zisi')
 
-// We use ZISI as the default bundler until the next major release, with the
-// exception of TypeScript files, for which the only option is esbuild.
-const getDefaultBundler = ({ extension }) => (extension === '.ts' ? JS_BUNDLER_ESBUILD : JS_BUNDLER_ZISI)
+// We use ZISI as the default bundler, except for certain extensions, for which
+// esbuild is the only option.
+const getDefaultBundler = ({ extension }) =>
+  ['.mjs', '.ts'].includes(extension) ? JS_BUNDLER_ESBUILD : JS_BUNDLER_ZISI
 
 // A proxy for the `getSrcFiles` function which adds a default `bundler` using
 // the `getDefaultBundler` function.

--- a/tests/fixtures/node-mjs/func1.mjs
+++ b/tests/fixtures/node-mjs/func1.mjs
@@ -1,0 +1,1 @@
+export const handler = () => true

--- a/tests/fixtures/node-mjs/func2/func2.mjs
+++ b/tests/fixtures/node-mjs/func2/func2.mjs
@@ -1,0 +1,1 @@
+export const handler = () => true

--- a/tests/fixtures/node-mjs/func3/index.mjs
+++ b/tests/fixtures/node-mjs/func3/index.mjs
@@ -1,0 +1,1 @@
+export const handler = () => true

--- a/tests/main.js
+++ b/tests/main.js
@@ -953,6 +953,30 @@ testBundlers('Handles a TypeScript function with imports', [ESBUILD, ESBUILD_ZIS
 })
 
 testBundlers(
+  'Handles a JavaScript function ({name}.mjs, {name}/{name}.mjs, {name}/index.mjs)',
+  [ESBUILD, ESBUILD_ZISI, DEFAULT],
+  async (bundler, t) => {
+    const { files, tmpDir } = await zipFixture(t, 'node-mjs', {
+      length: 3,
+      opts: { config: { '*': { nodeBundler: bundler } } },
+    })
+
+    await unzipFiles(files)
+
+    t.is(files.length, 3)
+    files.forEach((file) => {
+      t.is(file.bundler, 'esbuild')
+    })
+
+    /* eslint-disable import/no-dynamic-require, node/global-require */
+    t.true(require(`${tmpDir}/func1.js`).handler())
+    t.true(require(`${tmpDir}/func2.js`).handler())
+    t.true(require(`${tmpDir}/func3.js`).handler())
+    /* eslint-enable import/no-dynamic-require, node/global-require */
+  },
+)
+
+testBundlers(
   'Loads a tsconfig.json placed in the same directory as the function',
   [ESBUILD, ESBUILD_ZISI, DEFAULT],
   async (bundler, t) => {


### PR DESCRIPTION
**- Summary**

Adds support for JavaScript functions using a `.mjs` extension. These functions will use the esbuild bundler.

Closes #588.

**- Test plan**

New test added.

**- A picture of a cute animal (not mandatory but encouraged)**

![maxresdefault](https://user-images.githubusercontent.com/4162329/130224756-132939e7-70d6-4398-901e-91c35a0243fd.jpg)
