### PR TITLE
chore: pin version of adm-zip

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
   },
   "devDependencies": {
     "@netlify/eslint-config-node": "^3.2.6",
-    "adm-zip": "^0.5.0",
+    "adm-zip": "0.5.5",
     "ava": "^3.0.0",
     "cpy": "^8.0.0",
     "get-stream": "^6.0.0",

--- a/renovate.json5
+++ b/renovate.json5
@@ -13,6 +13,12 @@
       matchPackageNames: ['yargs'],
       allowedVersions: '<17',
     },
+    // Version 0.5.6 of adm-zip is breaking tests. See:
+    // https://github.com/netlify/zip-it-and-ship-it/pull/651/checks?check_run_id=3587767454
+    {
+      matchPackageNames: ['adm-zip'],
+      allowedVersions: '<=0.5.5',
+    },
     {
       // Fake dependencies used in tests
       packageNames: ['test'],


### PR DESCRIPTION
**- Summary**

Version 0.5.6 of `adm-zip` causes tests to fail (see https://github.com/netlify/zip-it-and-ship-it/pull/651/checks?check_run_id=3587767454). This locks the version to <=0.5.5.