### PR TITLE
chore(ci): fix our npm caching strategy for our e2e nextjs tests

### DIFF
--- a/.github/workflows/e2e-nextjs.yml
+++ b/.github/workflows/e2e-nextjs.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [main, 'chore/fix-ci-npm-cache']
     # Run on release PRs only, or changes to this same file
-    paths: ['CHANGELOG.md', '.github/workflows-e2e-nextjs.yml']
+    paths: ['CHANGELOG.md', '.github/workflows/e2e-nextjs.yml']
 
 jobs:
   integration:

--- a/.github/workflows/e2e-nextjs.yml
+++ b/.github/workflows/e2e-nextjs.yml
@@ -2,7 +2,7 @@ name: Next.js Integration test
 
 on:
   pull_request:
-    branches: [main, 'chore/fix-ci-npm-cache']
+    branches: [main, 'chore/ci-e2e-nextjs']
     # Run on release PRs only, or changes to this same file
     paths: ['CHANGELOG.md', '.github/workflows/e2e-nextjs.yml']
 

--- a/.github/workflows/e2e-nextjs.yml
+++ b/.github/workflows/e2e-nextjs.yml
@@ -32,6 +32,11 @@ jobs:
         with:
           node-version: '*'
           cache: 'npm'
+          # We need to add each of the lockfile paths so that the global npm cache is populated accordingly
+          cache-dependency-path: |
+            zip-it-and-ship-it/package-lock.json
+            netlify-plugin-nextjs/package-lock.json
+            netlify-cli/npm-shrinkwrap.json
       - name: Installing netlify-cli
         run: npm ci
         working-directory: netlify-cli

--- a/.github/workflows/e2e-nextjs.yml
+++ b/.github/workflows/e2e-nextjs.yml
@@ -2,9 +2,9 @@ name: Next.js Integration test
 
 on:
   pull_request:
-    branches: [main]
-    # Run on release PRs only
-    paths: ['CHANGELOG.md']
+    branches: [main, 'chore/fix-ci-npm-cache']
+    # Run on release PRs only, or changes to this same file
+    paths: ['CHANGELOG.md', '.github/workflows-e2e-nextjs.yml']
 
 jobs:
   integration:


### PR DESCRIPTION
**- Summary**

Similar to - https://github.com/netlify/cli/pull/3277 - for our e2e tests seems like we clone a total of 3 projects. We need to make use of the `cache-dependency-path`property to point to each of the lockfiles individually (see [here](https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies)).

**- Test plan**

- https://github.com/netlify/zip-it-and-ship-it/runs/3588927992?check_suite_focus=true

**- A picture of a cute animal (not mandatory but encouraged)**

![wombat-chore](https://i.giphy.com/media/6ltdfzUvMpKqA/giphy.webp)
