### PR TITLE
feat: pass config through to manifest file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "adm-zip": "0.5.5",
         "ava": "^3.0.0",
         "cpy": "^8.0.0",
+        "fromentries": "^1.3.2",
         "get-stream": "^6.0.0",
         "husky": "^4.3.8",
         "npm-run-all": "^4.1.5",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "adm-zip": "0.5.5",
     "ava": "^3.0.0",
     "cpy": "^8.0.0",
+    "fromentries": "^1.3.2",
     "get-stream": "^6.0.0",
     "husky": "^4.3.8",
     "npm-run-all": "^4.1.5",

--- a/src/manifest.js
+++ b/src/manifest.js
@@ -17,6 +17,13 @@ const createManifest = async ({ functions, path }) => {
   await writeFile(path, JSON.stringify(payload))
 }
 
-const formatFunction = ({ mainFile, name, path, runtime }) => ({ mainFile, name, path: resolve(path), runtime })
+const formatFunction = ({ mainFile, name, path, runtime, schedule, config }) => ({
+  mainFile,
+  name,
+  path: resolve(path),
+  runtime,
+  schedule,
+  config,
+})
 
 module.exports = { createManifest }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/zip-it-and-ship-it/blob/main/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

- passes through the `config` property to the manifest file

Motivation: Allows ntl/build to associate properties to functions, and read them back from the manifest file.

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

Test plan: Unit test added.

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->
![](https://i.pinimg.com/originals/79/77/0a/79770a940be72480b940537a800b42a3.jpg)
