### PR TITLE
feat: add `size` property to output

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,10 @@ properties.
 
   Either `"js"`, `"go"`, or `"rs"`.
 
+- `size`: `number`
+
+  The size of the generated archive, in bytes.
+
 Additionally, the following properties also exist for Node.js functions:
 
 - `bundler`: `string`

--- a/src/zip.js
+++ b/src/zip.js
@@ -1,4 +1,4 @@
-const { resolve } = require('path')
+const { extname, resolve } = require('path')
 
 const makeDir = require('make-dir')
 const pMap = require('p-map')
@@ -8,15 +8,23 @@ const { createManifest } = require('./manifest')
 const { getPluginsModulesPath } = require('./node_dependencies')
 const { getFunctionsFromPaths } = require('./runtimes')
 const { ARCHIVE_FORMAT_NONE, ARCHIVE_FORMAT_ZIP } = require('./utils/consts')
-const { listFunctionsDirectories, resolveFunctionsDirectories } = require('./utils/fs')
+const { listFunctionsDirectories, lstat, resolveFunctionsDirectories } = require('./utils/fs')
 const { removeFalsy } = require('./utils/remove_falsy')
 
 const DEFAULT_PARALLEL_LIMIT = 5
 
-const validateArchiveFormat = (archiveFormat) => {
-  if (![ARCHIVE_FORMAT_NONE, ARCHIVE_FORMAT_ZIP].includes(archiveFormat)) {
-    throw new Error(`Invalid archive format: ${archiveFormat}`)
+// Returns the input object with an additional `size` property containing the
+// size of the file at `path` when it is a ZIP archive.
+const addArchiveSize = async (result) => {
+  const { path } = result
+
+  if (extname(path) !== '.zip') {
+    return result
   }
+
+  const { size } = await lstat(path)
+
+  return { ...result, size }
 }
 
 // Takes the result of zipping a function and formats it for output.
@@ -33,6 +41,7 @@ const formatZipResult = (result) => {
     nodeModulesWithDynamicImports,
     path,
     runtime,
+    size,
   } = result
 
   return removeFalsy({
@@ -47,7 +56,14 @@ const formatZipResult = (result) => {
     nodeModulesWithDynamicImports,
     path,
     runtime: runtime.name,
+    size,
   })
+}
+
+const validateArchiveFormat = (archiveFormat) => {
+  if (![ARCHIVE_FORMAT_NONE, ARCHIVE_FORMAT_ZIP].includes(archiveFormat)) {
+    throw new Error(`Invalid archive format: ${archiveFormat}`)
+  }
 }
 
 // Zip `srcFolder/*` (Node.js or Go files) to `destFolder/*.zip` so it can be
@@ -103,7 +119,13 @@ const zipFunctions = async function (
       concurrency: parallelLimit,
     },
   )
-  const formattedResults = results.filter(Boolean).map(formatZipResult)
+  const formattedResults = await Promise.all(
+    results.filter(Boolean).map(async (result) => {
+      const resultWithSize = await addArchiveSize(result)
+
+      return formatZipResult(resultWithSize)
+    }),
+  )
 
   if (manifest !== undefined) {
     await createManifest({ functions: formattedResults, path: resolve(manifest) })

--- a/tests/main.js
+++ b/tests/main.js
@@ -1553,7 +1553,7 @@ test('The dynamic import runtime shim handles files in nested directories', asyn
   t.throws(() => func('fr'))
 })
 
-test('The dynamic import runtime shim handles files in nested directories when using `archiveType: "none"`', async (t) => {
+test('The dynamic import runtime shim handles files in nested directories when using `archiveFormat: "none"`', async (t) => {
   const fixtureName = 'node-module-dynamic-import-4'
   const { tmpDir } = await zipNode(t, fixtureName, {
     opts: {
@@ -1945,4 +1945,13 @@ test('Creates a manifest file with the list of created functions if the `manifes
     t.is(fn.runtime, file.runtime)
     t.is(fn.path, file.path)
   })
+})
+
+test('Returns a `size` property with the size of each generated archive', async (t) => {
+  const FUNCTIONS_COUNT = 6
+  const { files } = await zipNode(t, 'many-functions', {
+    length: FUNCTIONS_COUNT,
+  })
+
+  files.every(({ size }) => Number.isInteger(size) && size > 0)
 })


### PR DESCRIPTION
**- Summary**

Adds a `size` property to the output of `zipFunction` and `zipFunctions`, containing the number of bytes of the generated archive.

Closes #620.

**- Test plan**

Added new test.

**- A picture of a cute animal (not mandatory but encouraged)**

![Chinchillas-Great-Pets](https://user-images.githubusercontent.com/4162329/134659943-facaca4e-baf2-4dc1-a187-aed01655ba90.jpg)