### PR TITLE
fix: force esbuild target in zisi

### DIFF
--- a/src/runtimes/node/list_imports.js
+++ b/src/runtimes/node/list_imports.js
@@ -4,6 +4,11 @@ const { tmpName } = require('tmp-promise')
 
 const { safeUnlink } = require('../../utils/fs')
 
+// Maximum number of log messages that an esbuild instance will produce. This
+// limit is important to avoid out-of-memory errors due to too much data being
+// sent in the Go<>Node IPC channel.
+const ESBUILD_LOG_LIMIT = 10
+
 const getListImportsPlugin = ({ imports, path }) => ({
   name: 'list-imports',
   setup(build) {
@@ -38,7 +43,7 @@ const listImports = async ({ path }) => {
       bundle: true,
       entryPoints: [path],
       logLevel: 'error',
-      logLimit: 1,
+      logLimit: ESBUILD_LOG_LIMIT,
       outfile: targetPath,
       platform: 'node',
       plugins: [getListImportsPlugin({ imports, path })],

--- a/src/runtimes/node/list_imports.js
+++ b/src/runtimes/node/list_imports.js
@@ -4,11 +4,6 @@ const { tmpName } = require('tmp-promise')
 
 const { safeUnlink } = require('../../utils/fs')
 
-// Maximum number of log messages that an esbuild instance will produce. This
-// limit is important to avoid out-of-memory errors due to too much data being
-// sent in the Go<>Node IPC channel.
-const ESBUILD_LOG_LIMIT = 10
-
 const getListImportsPlugin = ({ imports, path }) => ({
   name: 'list-imports',
   setup(build) {
@@ -43,7 +38,7 @@ const listImports = async ({ path }) => {
       bundle: true,
       entryPoints: [path],
       logLevel: 'error',
-      logLimit: ESBUILD_LOG_LIMIT,
+      logLimit: 1,
       outfile: targetPath,
       platform: 'node',
       plugins: [getListImportsPlugin({ imports, path })],

--- a/tests/fixtures/local-node-module-destructure-require/function.js
+++ b/tests/fixtures/local-node-module-destructure-require/function.js
@@ -1,0 +1,3 @@
+const { stack } = require('@netlify/mock-package/stack')
+
+module.exports = { stack }

--- a/tests/fixtures/local-node-module-destructure-require/node_modules/@netlify/mock-package/index.js
+++ b/tests/fixtures/local-node-module-destructure-require/node_modules/@netlify/mock-package/index.js
@@ -1,0 +1,3 @@
+const stack = require('./stack')
+
+module.exports = { stack }

--- a/tests/fixtures/local-node-module-destructure-require/node_modules/@netlify/mock-package/package.json
+++ b/tests/fixtures/local-node-module-destructure-require/node_modules/@netlify/mock-package/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@netlify/mock-package",
+  "version": "1.0.0"
+}

--- a/tests/fixtures/local-node-module-destructure-require/node_modules/@netlify/mock-package/stack.js
+++ b/tests/fixtures/local-node-module-destructure-require/node_modules/@netlify/mock-package/stack.js
@@ -1,0 +1,1 @@
+module.exports = 'jam'

--- a/tests/fixtures/local-node-module-destructure-require/package.json
+++ b/tests/fixtures/local-node-module-destructure-require/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "local-node-module-destructure-require",
+  "version": "1.0.0",
+  "dependencies": {
+    "@netlify/mock-package": "1.0.0"
+  }
+}

--- a/tests/fixtures/local-node-module-destructure-require/tsconfig.json
+++ b/tests/fixtures/local-node-module-destructure-require/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "target": "ES5"
+  }
+}

--- a/tests/main.js
+++ b/tests/main.js
@@ -173,6 +173,21 @@ testBundlers('Can require deep paths in node modules', [ESBUILD, ESBUILD_ZISI, D
   }
 })
 
+testBundlers(
+  'Can require Node modules with destructuring expressions',
+  [ESBUILD, ESBUILD_ZISI, DEFAULT],
+  async (bundler, t) => {
+    await zipNode(t, `local-node-module-destructure-require`, {
+      opts: { config: { '*': { nodeBundler: bundler } } },
+    })
+
+    // TO DO: Remove when `parseWithEsbuild` feature flag is decommissioned.
+    await zipNode(t, `local-node-module-destructure-require`, {
+      opts: { config: { '*': { nodeBundler: bundler } }, featureFlags: { parseWithEsbuild: true } },
+    })
+  },
+)
+
 testBundlers('Can require scoped node modules', [ESBUILD, ESBUILD_ZISI, DEFAULT], async (bundler, t) => {
   await zipNode(t, 'node-module-scope', { opts: { config: { '*': { nodeBundler: bundler } } } })
 })


### PR DESCRIPTION
**- Summary**

When parsing files with esbuild to find dependencies, we rely on the default `target` property set by esbuild, which is `esnext`. However, this is overridden by any `compilerOptions.target` property set in a `tsconfig.json`. When this value is set to `es5`, parsing with esbuild can fail because some expressions can't be lowered to ES5.

This PR explicitly sets `target: "esnext"` in esbuild so that no transpiling is required.

**- Test plan**

Added a new test.

**- A picture of a cute animal (not mandatory but encouraged)**

![f03a349219e07c262f961a9afefb9a66](https://user-images.githubusercontent.com/4162329/134943242-ed567194-67a1-4340-82bc-eaff0e5b846a.jpg)


