### PR TITLE
chore: keep pkg-dir at v5 (closes #694)

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -24,5 +24,9 @@
       packageNames: ['test'],
       enabled: false,
     },
+    {
+      matchPackageNames: ['pkg-dir'],
+      allowedVersions: '<=5',
+    },
   ],
 }


### PR DESCRIPTION
cc https://github.com/netlify/zip-it-and-ship-it/pull/694#issuecomment-933334715