### PR TITLE
chore: add test for `node:` prefix

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "p-map": "^4.0.0",
     "path-exists": "^4.0.0",
     "pkg-dir": "^5.0.0",
-    "precinct": "^8.0.0",
+    "precinct": "^8.2.0",
     "read-package-json-fast": "^2.0.2",
     "require-package-name": "^2.0.1",
     "resolve": "^2.0.0-next.1",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "p-map": "^4.0.0",
     "path-exists": "^4.0.0",
     "pkg-dir": "^5.0.0",
-    "precinct": "^8.2.0",
+    "precinct": "^8.0.0",
     "read-package-json-fast": "^2.0.2",
     "require-package-name": "^2.0.1",
     "resolve": "^2.0.0-next.1",

--- a/tests/fixtures/node-force-builtin/function.js
+++ b/tests/fixtures/node-force-builtin/function.js
@@ -1,4 +1,4 @@
-const fs = require('node:fs')
+const fs = require('node:stream/web')
 
 module.exports = () => {
   const stats = fs.statSync(__dirname)

--- a/tests/fixtures/node-force-builtin/function.js
+++ b/tests/fixtures/node-force-builtin/function.js
@@ -1,0 +1,7 @@
+const fs = require('node:fs')
+
+module.exports = () => {
+  const stats = fs.statSync(__dirname)
+
+  return stats.isDirectory()
+}

--- a/tests/fixtures/node-force-builtin/function.js
+++ b/tests/fixtures/node-force-builtin/function.js
@@ -1,7 +1,5 @@
-const fs = require('node:stream/web')
+const stream = require('node:stream/web')
 
 module.exports = () => {
-  const stats = fs.statSync(__dirname)
-
-  return stats.isDirectory()
+  return Boolean(stream.ReadableStream)
 }

--- a/tests/main.js
+++ b/tests/main.js
@@ -2263,3 +2263,17 @@ testMany(
     files.every(({ size }) => Number.isInteger(size) && size > 0)
   },
 )
+
+testMany(
+  'Handles built-in modules imported with the `node:` prefix',
+  ['bundler_default', 'bundler_esbuild', 'bundler_esbuild_zisi'],
+  async (options, t) => {
+    const { tmpDir } = await zipNode(t, 'node-force-builtin', {
+      opts: { config: { '*': { ...options } } },
+    })
+
+    // eslint-disable-next-line import/no-dynamic-require, node/global-require
+    const func = require(`${tmpDir}/function`)
+    t.true(func())
+  },
+)

--- a/tests/main.js
+++ b/tests/main.js
@@ -2272,7 +2272,7 @@ testMany(
           error.message,
           semver.satisfies(nodeVersion, '>10')
             ? 'No such built-in module: node:stream/web'
-            : "Cannot find module: 'node:stream/web'",
+            : "Cannot find module 'node:stream/web'",
         )
       }
     }

--- a/tests/main.js
+++ b/tests/main.js
@@ -2272,7 +2272,7 @@ testMany(
           error.message,
           semver.satisfies(nodeVersion, '>10')
             ? 'No such built-in module: node:stream/web'
-            : "Cannot find module: 'node:fs'",
+            : "Cannot find module: 'node:stream/web'",
         )
       }
     }


### PR DESCRIPTION
Adds a test asserting that we can handle imports with the `node:` prefix.