### PR TITLE
fix: set `customErrorInfo` on zisi/esbuild errors

### DIFF
--- a/src/runtimes/node/bundler.js
+++ b/src/runtimes/node/bundler.js
@@ -3,7 +3,7 @@ const { basename, dirname, extname, resolve, join } = require('path')
 const esbuild = require('@netlify/esbuild')
 const { tmpName } = require('tmp-promise')
 
-const { RUNTIME_JS } = require('../../utils/consts')
+const { JS_BUNDLER_ESBUILD, RUNTIME_JS } = require('../../utils/consts')
 const { getPathWithExtension, safeUnlink } = require('../../utils/fs')
 
 const { getBundlerTarget } = require('./bundler_target')
@@ -106,7 +106,10 @@ const bundleJsFile = async function ({
       warnings,
     }
   } catch (error) {
-    error.customErrorInfo = { type: 'functionsBundling', location: { functionName: name, runtime: RUNTIME_JS } }
+    error.customErrorInfo = {
+      type: 'functionsBundling',
+      location: { bundler: JS_BUNDLER_ESBUILD, functionName: name, runtime: RUNTIME_JS },
+    }
 
     throw error
   }

--- a/src/runtimes/node/list_imports.js
+++ b/src/runtimes/node/list_imports.js
@@ -2,6 +2,7 @@ const esbuild = require('@netlify/esbuild')
 const isBuiltinModule = require('is-builtin-module')
 const { tmpName } = require('tmp-promise')
 
+const { JS_BUNDLER_ZISI, RUNTIME_JS } = require('../../utils/consts')
 const { safeUnlink } = require('../../utils/fs')
 
 // Maximum number of log messages that an esbuild instance will produce. This
@@ -49,6 +50,13 @@ const listImports = async ({ path }) => {
       plugins: [getListImportsPlugin({ imports, path })],
       target: 'esnext',
     })
+  } catch (error) {
+    error.customErrorInfo = {
+      type: 'functionsBundling',
+      location: { bundler: JS_BUNDLER_ZISI, path, runtime: RUNTIME_JS },
+    }
+
+    throw error
   } finally {
     await safeUnlink(targetPath)
   }


### PR DESCRIPTION
**- Summary**

Adds a `customErrorInfo` property to errors arising from esbuild in ZISI.