### PR TITLE
chore: remove ESLint directives from tests file

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,8 +8,10 @@ module.exports = {
       files: 'tests/*.js',
       rules: {
         'import/max-dependencies': 'off',
+        'import/no-dynamic-require': 'off',
         'max-lines-per-function': 'off',
         'max-statements': 'off',
+        'node/global-require': 'off',
       },
     },
   ],

--- a/tests/main.js
+++ b/tests/main.js
@@ -177,7 +177,6 @@ testMany(
       opts: options,
     })
 
-    // eslint-disable-next-line import/no-dynamic-require, node/global-require
     const func = require(`${tmpDir}/function.js`)
 
     t.deepEqual(func, { mock: { stack: 'jam' }, stack: 'jam' })
@@ -227,7 +226,6 @@ testMany(
     t.false(await pathExists(`${tmpDir}/node_modules/aws-sdk`))
 
     try {
-      // eslint-disable-next-line import/no-dynamic-require, node/global-require
       const func = require(`${tmpDir}/function.js`)
 
       func()
@@ -519,7 +517,6 @@ testMany(
       opts: options,
     })
     await unzipFiles(files)
-    // eslint-disable-next-line import/no-dynamic-require, node/global-require
     t.true(require(`${tmpDir}/function.js`))
     t.is(files[0].mainFile, join(FIXTURES_DIR, fixtureName, 'function', 'index.js'))
   },
@@ -1059,7 +1056,6 @@ testMany(
   async (options, t) => {
     const { files, tmpDir } = await zipFixture(t, 'node-fetch', { opts: options })
     await unzipFiles(files)
-    // eslint-disable-next-line import/no-dynamic-require, node/global-require
     t.true(typeof require(`${tmpDir}/function.js`) === 'function')
   },
 )
@@ -1072,7 +1068,6 @@ testMany(
       opts: options,
     })
     await unzipFiles(files)
-    // eslint-disable-next-line import/no-dynamic-require, node/global-require
     t.is(require(`${tmpDir}/function.js`), 'function-js-file-in-directory')
   },
 )
@@ -1085,7 +1080,6 @@ testMany(
       opts: options,
     })
     await unzipFiles(files)
-    // eslint-disable-next-line import/no-dynamic-require, node/global-require
     t.is(require(`${tmpDir}/function.js`), 'index-js-file-in-directory')
   },
 )
@@ -1098,7 +1092,6 @@ testMany(
       opts: options,
     })
     await unzipFiles(files)
-    // eslint-disable-next-line import/no-dynamic-require, node/global-require
     t.is(require(`${tmpDir}/function.js`).type, 'index-js-file-in-directory')
   },
 )
@@ -1111,7 +1104,6 @@ testMany(
       opts: options,
     })
     await unzipFiles(files)
-    // eslint-disable-next-line import/no-dynamic-require, node/global-require
     t.is(require(`${tmpDir}/function.js`).type, 'function-js-file')
   },
 )
@@ -1124,7 +1116,6 @@ testMany(
       opts: options,
     })
     await unzipFiles(files)
-    // eslint-disable-next-line import/no-dynamic-require, node/global-require
     t.is(require(`${tmpDir}/function.js`).type, 'function-js-file')
   },
 )
@@ -1137,7 +1128,6 @@ testMany(
       opts: options,
     })
     await unzipFiles(files)
-    // eslint-disable-next-line import/no-dynamic-require, node/global-require
     t.true(typeof require(`${tmpDir}/function.js`).type === 'string')
   },
 )
@@ -1150,7 +1140,6 @@ testMany(
       opts: options,
     })
     await unzipFiles(files)
-    // eslint-disable-next-line import/no-dynamic-require, node/global-require
     t.true(typeof require(`${tmpDir}/function.js`).type === 'string')
   },
 )
@@ -1163,7 +1152,6 @@ testMany(
       opts: options,
     })
     await unzipFiles(files)
-    // eslint-disable-next-line import/no-dynamic-require, node/global-require
     t.true(typeof require(`${tmpDir}/function.js`).type === 'string')
   },
 )
@@ -1176,7 +1164,6 @@ testMany(
       opts: options,
     })
     await unzipFiles(files)
-    // eslint-disable-next-line import/no-dynamic-require, node/global-require
     t.true(typeof require(`${tmpDir}/function.js`).type === 'string')
   },
 )
@@ -1197,11 +1184,9 @@ testMany(
       t.is(file.bundler, 'esbuild')
     })
 
-    /* eslint-disable import/no-dynamic-require, node/global-require */
     t.true(require(`${tmpDir}/func1.js`).handler())
     t.true(require(`${tmpDir}/func2.js`).handler())
     t.true(require(`${tmpDir}/func3.js`).handler())
-    /* eslint-enable import/no-dynamic-require, node/global-require */
   },
 )
 
@@ -1213,7 +1198,6 @@ testMany(
       opts: options,
     })
     await unzipFiles(files)
-    // eslint-disable-next-line import/no-dynamic-require, node/global-require
     t.true(require(`${tmpDir}/function.js`).value)
   },
 )
@@ -1226,7 +1210,6 @@ testMany(
       opts: options,
     })
     await unzipFiles(files)
-    // eslint-disable-next-line import/no-dynamic-require, node/global-require
     t.true(require(`${tmpDir}/function.js`).value)
   },
 )
@@ -1240,7 +1223,6 @@ testMany(
     })
     await unzipFiles(files)
 
-    // eslint-disable-next-line import/no-dynamic-require, node/global-require
     const result = require(`${tmpDir}/function.js`)
 
     // We want to assert that the `target` specified in the tsconfig file (es5)
@@ -1367,7 +1349,6 @@ testMany(
       opts,
     })
 
-    // eslint-disable-next-line import/no-dynamic-require, node/global-require
     const functionEntry = require(`${files[0].path}/function.js`)
 
     t.true(functionEntry)
@@ -1391,7 +1372,6 @@ testMany(
       opts,
     })
 
-    // eslint-disable-next-line import/no-dynamic-require, node/global-require
     const func = require(`${tmpDir}/func1.js`)
 
     const { body: body1 } = await func.handler({ queryStringParameters: { name: 'post1' } })
@@ -1453,7 +1433,6 @@ testMany(
       t.false(files[0].inputs.includes(join(FIXTURES_DIR, fixtureName, 'node_modules', 'test-child', 'unused_file.js')))
     }
 
-    // eslint-disable-next-line import/no-dynamic-require, node/global-require
     const functionEntry = require(`${tmpDir}/function.js`)
 
     t.true(functionEntry)
@@ -1477,7 +1456,6 @@ testMany(
       opts,
     })
 
-    // eslint-disable-next-line import/no-dynamic-require, node/global-require
     const function1Entry = require(`${tmpDir}/func1.js`)
 
     // The function should not be on a `src/` namespace.
@@ -1509,7 +1487,6 @@ testMany(
       opts,
     })
 
-    // eslint-disable-next-line import/no-dynamic-require, node/global-require
     const function2Entry = require(`${tmpDir}/func2.js`)
 
     // The function should be on a `src/` namespace because there's a conflict
@@ -1540,11 +1517,9 @@ testMany(
       opts,
     })
 
-    /* eslint-disable import/no-dynamic-require, node/global-require */
     const functionCommon = require(`${tmpDir}/function.js`)
     const functionInternal = require(`${tmpDir}/function_internal.js`)
     const functionUser = require(`${tmpDir}/function_user.js`)
-    /* eslint-enable import/no-dynamic-require, node/global-require */
 
     // Functions from rightmost directories in the array take precedence.
     t.is(functionCommon, 'user')
@@ -1579,7 +1554,6 @@ test('When generating a directory for a function with `archiveFormat: "none"`, i
     archiveFormat: 'none',
   })
 
-  // eslint-disable-next-line import/no-dynamic-require, node/global-require
   const functionEntry = require(`${functionDirectory}/function.js`)
 
   t.true(functionEntry)
@@ -1658,7 +1632,6 @@ test('Adds a runtime shim and includes the files needed for dynamic imports usin
     },
   })
 
-  // eslint-disable-next-line import/no-dynamic-require, node/global-require
   const func = require(`${tmpDir}/function.js`)
   const values = func('one')
   const expectedLength = 5
@@ -1694,7 +1667,6 @@ test('Adds a runtime shim and includes the files needed for dynamic imports usin
     },
   })
 
-  // eslint-disable-next-line import/no-dynamic-require, node/global-require
   const func = require(`${tmpDir}/function.js`)
 
   t.deepEqual(func('en')[0], ['yes', 'no'])
@@ -1713,7 +1685,6 @@ test('The dynamic import runtime shim handles files in nested directories', asyn
     },
   })
 
-  // eslint-disable-next-line import/no-dynamic-require, node/global-require
   const func = require(`${tmpDir}/function.js`)
 
   t.deepEqual(func('en')[0], ['yes', 'no'])
@@ -1735,7 +1706,6 @@ test('The dynamic import runtime shim handles files in nested directories when u
     },
   })
 
-  // eslint-disable-next-line import/no-dynamic-require, node/global-require
   const func = require(`${tmpDir}/function/function.js`)
 
   t.deepEqual(func('en')[0], ['yes', 'no'])
@@ -1756,7 +1726,6 @@ test('Negated files in `included_files` are excluded from the bundle even if the
     },
   })
 
-  // eslint-disable-next-line import/no-dynamic-require, node/global-require
   const func = require(`${tmpDir}/function.js`)
 
   t.deepEqual(func('pt')[0], ['sim', 'não'])
@@ -1777,7 +1746,6 @@ test('Creates dynamic import shims for functions with the same name and same shi
   })
 
   for (let ind = 1; ind <= FUNCTION_COUNT; ind++) {
-    // eslint-disable-next-line import/no-dynamic-require, node/global-require
     const func = require(`${tmpDir}/function${ind}.js`)
 
     t.deepEqual(func('en')[0], ['yes', 'no'])
@@ -1798,7 +1766,6 @@ test('Creates dynamic import shims for functions using `zipFunction`', async (t)
 
   await unzipFiles([result])
 
-  // eslint-disable-next-line import/no-dynamic-require, node/global-require
   const func = require(`${tmpDir}/function.js`)
 
   t.deepEqual(func('en')[0], ['yes', 'no'])
@@ -2100,7 +2067,6 @@ test('Creates a manifest file with the list of created functions if the `manifes
     opts: { manifest: manifestPath },
   })
 
-  // eslint-disable-next-line import/no-dynamic-require, node/global-require
   const manifest = require(manifestPath)
 
   t.is(manifest.version, 1)
@@ -2124,8 +2090,6 @@ testMany('Correctly follows node_modules via symlink', ['bundler_esbuild'], asyn
     opts: options,
   })
 
-  // eslint-disable-next-line import/no-dynamic-require, node/global-require
   const isEven = require(`${tmpDir}/function`)
-  // eslint-disable-next-line no-magic-numbers
-  t.is(isEven(10), '10 is even')
+  t.is(isEven(2), '2 is even')
 })


### PR DESCRIPTION
**- Summary**

Removes some noise from the main tests file by moving some ESLint disable directives to the `.eslintrc.js` file.