### PR TITLE
chore: run build step in Next e2e workflow

### DIFF
--- a/.github/workflows/e2e-nextjs.yml
+++ b/.github/workflows/e2e-nextjs.yml
@@ -63,7 +63,7 @@ jobs:
           $GITHUB_WORKSPACE/zip-it-and-ship-it
           $GITHUB_WORKSPACE/netlify-cli/node_modules/@netlify/build/node_modules/@netlify/zip-it-and-ship-it
       - name: Installing zip-it-and-ship-it
-        run: npm install
+        run: npm install && npm run build
         working-directory: zip-it-and-ship-it
       - name: Building and deploying site
         run:


### PR DESCRIPTION
**- Summary**

Includes the build step introduced in https://github.com/netlify/zip-it-and-ship-it/pull/675 when running the Next.js E2E tests.