### PR TITLE
feat: add `repositoryRoot` property

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,14 @@ Format of the archive created for each function. Defaults to ZIP archives.
 
 If set to `none`, the output of each function will be a directory containing all the bundled files.
 
+#### `basePath`
+
+- _Type_: `string`
+- _Default value_: `undefined`
+
+The directory which all relative paths will be resolved from. These include paths in the `includedFiles` config
+property, as well as imports using dynamic expressions such as `require(\`./files/${name}\`)`.
+
 #### `config`
 
 - _Type_: `object`
@@ -171,6 +179,14 @@ JSON-formatted string with the following properties:
 - _Default value_: `5`
 
 Maximum number of functions to bundle at the same time.
+
+#### `repositoryRoot`
+
+- _Type_: `string`
+- _Default value_: The value of `basePath`
+
+The path of the project's repository root. This defines the boundary where Node modules can be found. It usually is the
+same value as the `basePath` property, but may be a parent directory in the case of a monorepo setup.
 
 ### Return value
 

--- a/src/zip.js
+++ b/src/zip.js
@@ -62,6 +62,7 @@ const zipFunctions = async function (
     featureFlags: inputFeatureFlags,
     manifest,
     parallelLimit = DEFAULT_PARALLEL_LIMIT,
+    repositoryRoot = basePath,
   } = {},
 ) {
   validateArchiveFormat(archiveFormat)
@@ -90,6 +91,7 @@ const zipFunctions = async function (
         mainFile: func.mainFile,
         name: func.name,
         pluginsModulesPath,
+        repositoryRoot,
         runtime: func.runtime,
         srcDir: func.srcDir,
         srcPath: func.srcPath,
@@ -121,6 +123,7 @@ const zipFunction = async function (
     config: inputConfig = {},
     featureFlags: inputFeatureFlags,
     pluginsModulesPath: defaultModulesPath,
+    repositoryRoot = basePath,
   } = {},
 ) {
   validateArchiveFormat(archiveFormat)
@@ -143,16 +146,17 @@ const zipFunction = async function (
     archiveFormat,
     basePath,
     config,
-    srcPath,
     destFolder,
-    mainFile,
-    filename,
     extension,
-    srcDir,
-    stat,
-    runtime,
-    pluginsModulesPath,
     featureFlags,
+    filename,
+    mainFile,
+    pluginsModulesPath,
+    repositoryRoot,
+    runtime,
+    srcDir,
+    srcPath,
+    stat,
   })
 
   return formatZipResult({ ...zipResult, mainFile, name, runtime })


### PR DESCRIPTION
**- Summary**

Adds a new `repositoryRoot` property to `zipFunction` and `zipFunctions`. It's not yet being used anywhere, hence the lack of tests, but it will be used by #713.