### PR TITLE
feat!: remove `includedFilesBasePath` config property

### DIFF
--- a/src/runtimes/node/bundlers/esbuild/index.js
+++ b/src/runtimes/node/bundlers/esbuild/index.js
@@ -56,11 +56,11 @@ const bundle = async ({ basePath, config = {}, filename, mainFile, name, plugins
   })
   const bundlerWarnings = warnings.length === 0 ? undefined : warnings
   const srcFiles = await getSrcFiles({
+    basePath,
     config: {
       ...config,
       externalNodeModules: [...externalModules, ...Object.keys(nativeNodeModules)],
       includedFiles: [...(config.includedFiles || []), ...additionalPaths],
-      includedFilesBasePath: config.includedFilesBasePath || basePath,
     },
     mainFile,
     pluginsModulesPath,

--- a/src/runtimes/node/bundlers/esbuild/src_files.js
+++ b/src/runtimes/node/bundlers/esbuild/src_files.js
@@ -3,12 +3,9 @@ const { getPackageJson } = require('../../utils/package_json')
 const { getNewCache } = require('../../utils/traversal_cache')
 const { getDependencyPathsForDependency } = require('../zisi/traverse')
 
-const getSrcFiles = async ({ config, mainFile, pluginsModulesPath, srcDir }) => {
-  const { externalNodeModules = [], includedFiles = [], includedFilesBasePath } = config
-  const { exclude: excludedPaths, paths: includedFilePaths } = await getPathsOfIncludedFiles(
-    includedFiles,
-    includedFilesBasePath,
-  )
+const getSrcFiles = async ({ basePath, config, mainFile, pluginsModulesPath, srcDir }) => {
+  const { externalNodeModules = [], includedFiles = [] } = config
+  const { exclude: excludedPaths, paths: includedFilePaths } = await getPathsOfIncludedFiles(includedFiles, basePath)
   const dependencyPaths = await getSrcFilesForDependencies({
     dependencies: externalNodeModules,
     basedir: srcDir,

--- a/src/runtimes/node/bundlers/zisi/index.js
+++ b/src/runtimes/node/bundlers/zisi/index.js
@@ -16,10 +16,8 @@ const bundle = async ({
   stat,
 }) => {
   const srcFiles = await getSrcFiles({
-    config: {
-      ...config,
-      includedFilesBasePath: config.includedFilesBasePath || basePath,
-    },
+    basePath,
+    config,
     featureFlags,
     mainFile,
     name,

--- a/src/runtimes/node/bundlers/zisi/src_files.js
+++ b/src/runtimes/node/bundlers/zisi/src_files.js
@@ -17,6 +17,7 @@ const { shouldTreeShake } = require('./tree_shake')
 // We only include the files actually needed by the function because AWS Lambda
 // has a size limit for the zipped file. It also makes cold starts faster.
 const getSrcFiles = async function ({
+  basePath,
   config,
   featureFlags,
   mainFile,
@@ -26,11 +27,8 @@ const getSrcFiles = async function ({
   srcPath,
   stat,
 }) {
-  const { includedFiles = [], includedFilesBasePath } = config
-  const { exclude: excludedPaths, paths: includedFilePaths } = await getPathsOfIncludedFiles(
-    includedFiles,
-    includedFilesBasePath,
-  )
+  const { includedFiles = [] } = config
+  const { exclude: excludedPaths, paths: includedFilePaths } = await getPathsOfIncludedFiles(includedFiles, basePath)
   const [treeFiles, depFiles] = await Promise.all([
     getTreeFiles(srcPath, stat),
     getDependencies({ featureFlags, functionName: name, mainFile, pluginsModulesPath, srcDir }),

--- a/tests/main.js
+++ b/tests/main.js
@@ -1368,10 +1368,10 @@ testMany(
   async (options, t) => {
     const fixtureName = 'included_files'
     const opts = merge(options, {
+      basePath: join(FIXTURES_DIR, fixtureName),
       config: {
         '*': {
           includedFiles: ['content/*', '!content/post3.md'],
-          includedFilesBasePath: join(FIXTURES_DIR, fixtureName),
         },
       },
     })


### PR DESCRIPTION
**- Summary**

The `includedFilesBasePath` config property was introduced in #441, when we added support for the `includedFiles` property.

A `basePath` property was then introduced in #474, making `includedFilesBasePath` redundant. This PR removes the latter in favour of the former.

This is technically a breaking change.

**- Test plan**

Adjusted existing test.

**- A picture of a cute animal (not mandatory but encouraged)**
![depositphotos_12883889-stock-photo-wombat-close-up](https://user-images.githubusercontent.com/4162329/136951694-17c52310-4280-45b0-9172-981744483ec6.jpg)

