### PR TITLE
chore: add rate limiting to CI

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -41,6 +41,8 @@ jobs:
         if: "${{ matrix.node-version == '*' }}"
       - name: Tests
         run: npm run test:ci
+        env:
+          ZISI_TEST_RATE_LIMIT: 3
       - name: Get test coverage flags
         id: test-coverage-flags
         run: |-

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
         "nyc": "^15.0.0",
         "sinon": "^11.1.1",
         "sort-on": "^4.1.1",
+        "throat": "^6.0.1",
         "typescript": "^4.4.3"
       },
       "engines": {
@@ -11778,6 +11779,12 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
+    "node_modules/throat": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.1.tgz",
+      "integrity": "sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==",
+      "dev": true
+    },
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -21440,6 +21447,12 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "throat": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.1.tgz",
+      "integrity": "sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==",
       "dev": true
     },
     "through": {

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "nyc": "^15.0.0",
     "sinon": "^11.1.1",
     "sort-on": "^4.1.1",
+    "throat": "^6.0.1",
     "typescript": "^4.4.3"
   },
   "engines": {


### PR DESCRIPTION
**- Summary**

We're seeing lots of `EMFILE: too many open files` errors in the CI. This PR adds a rate limiter to the tests whenever the `ZISI_TEST_RATE_LIMIT` environment variable is present. It also sets this environment variable in our workflow file — I set it to 3, but we can experiment with this value.

**- Test plan**

N/A
