### PR TITLE
feat: resolve modules from `pluginsModulesPath` in NFT

### DIFF
--- a/tests/main.js
+++ b/tests/main.js
@@ -335,7 +335,7 @@ testMany(
 
 testMany(
   'Resolves dependencies from .netlify/plugins/node_modules',
-  ['bundler_default', 'bundler_esbuild', 'bundler_esbuild_zisi', 'bundler_default_parse_esbuild', 'todo:bundler_nft'],
+  ['bundler_default', 'bundler_esbuild', 'bundler_esbuild_zisi', 'bundler_default_parse_esbuild', 'bundler_nft'],
   async (options, t) => {
     await zipNode(t, 'node-module-next-image', { opts: options })
   },


### PR DESCRIPTION
**- Summary**

Allows us to load modules from `.netlify/plugins/` using NFT.

https://netlify.slack.com/archives/C023PC3D08J/p1634898052033200

**- Test plan**

Added the NFT variation to an existing test.

**- A picture of a cute animal (not mandatory but encouraged)**

![_120655236_4_llama_getty](https://user-images.githubusercontent.com/4162329/138435639-73a6cbf0-8045-4ddf-a435-daacaa3efd46.jpg)

