### PR TITLE
fix: modify `type` field of transpiled ESM packages

### DIFF
--- a/src/runtimes/node/bundlers/index.ts
+++ b/src/runtimes/node/bundlers/index.ts
@@ -1,3 +1,5 @@
+import type { Buffer } from 'buffer'
+
 import type { Message } from '@netlify/esbuild'
 
 import type { NodeBundlerName } from '..'
@@ -26,7 +28,25 @@ type BundleFunction = (
     repositoryRoot?: string
   } & FunctionSource,
 ) => Promise<{
+  // Aliases are used to change the path that a file should take inside the
+  // generated archive. For example:
+  //
+  // "/my-transpiled-function.js" => "/my-function.js"
+  //
+  // When "/my-transpiled-function.js" is found in the list of files, it will
+  // be added to the archive with the "/my-function.js" path.
   aliases?: Map<string, string>
+
+  // Rewrites are used to change the source file associated with a given path.
+  // For example:
+  //
+  // "/my-function.js" => "console.log(`Hello!`)"
+  //
+  // When "/my-function.js" is found in the list of files, it will be added to
+  // the archive with "console.log(`Hello!`)" as its source, replacing whatever
+  // the file at "/my-function.js" contains.
+  rewrites?: Map<string, string>
+
   basePath: string
   bundlerWarnings?: BundlerWarning[]
   cleanupFunction?: CleanupFunction

--- a/src/runtimes/node/bundlers/index.ts
+++ b/src/runtimes/node/bundlers/index.ts
@@ -1,5 +1,3 @@
-import type { Buffer } from 'buffer'
-
 import type { Message } from '@netlify/esbuild'
 
 import type { NodeBundlerName } from '..'

--- a/src/runtimes/node/bundlers/nft/es_modules.ts
+++ b/src/runtimes/node/bundlers/nft/es_modules.ts
@@ -1,0 +1,52 @@
+import { resolve } from 'path'
+
+import { NodeFileTraceReasons } from '@vercel/nft'
+
+import { cachedReadFile, FsCache } from '../../../../utils/fs'
+import { PackageJson } from '../../utils/package_json'
+
+const getESMPackageJsons = (esmPaths: Set<string>, reasons: NodeFileTraceReasons, basePath?: string) => {
+  const packageJsons: string[] = [...reasons.entries()]
+    .filter(([, reason]) => {
+      if (reason.type !== 'resolve') {
+        return false
+      }
+
+      const hasESMParent = [...reason.parents].some((parentPath) => esmPaths.has(parentPath))
+
+      return hasESMParent
+    })
+    .map(([path]) => (basePath ? resolve(basePath, path) : resolve(path)))
+
+  return packageJsons
+}
+
+const getPatchedESMPackages = async (
+  esmPaths: Set<string>,
+  reasons: NodeFileTraceReasons,
+  fsCache: FsCache,
+  basePath?: string,
+) => {
+  const packages = getESMPackageJsons(esmPaths, reasons, basePath)
+  const patchedPackages = await Promise.all(packages.map((path) => patchESMPackage(path, fsCache)))
+  const patchedPackagesMap = new Map()
+
+  packages.forEach((packagePath, index) => {
+    patchedPackagesMap.set(packagePath, patchedPackages[index])
+  })
+
+  return patchedPackagesMap
+}
+
+const patchESMPackage = async (path: string, fsCache: FsCache) => {
+  const file = (await cachedReadFile(fsCache, path, 'utf8')) as string
+  const packageJson: PackageJson = JSON.parse(file)
+  const patchedPackageJson = {
+    ...packageJson,
+    type: 'commonjs',
+  }
+
+  return JSON.stringify(patchedPackageJson)
+}
+
+export { getPatchedESMPackages }

--- a/src/runtimes/node/index.ts
+++ b/src/runtimes/node/index.ts
@@ -96,6 +96,7 @@ const zipFunction: ZipFunction = async function ({
     mainFile: finalMainFile = mainFile,
     nativeNodeModules,
     nodeModulesWithDynamicImports,
+    rewrites,
     srcFiles,
   } = await bundler.bundle({
     basePath,
@@ -122,6 +123,7 @@ const zipFunction: ZipFunction = async function ({
     filename,
     mainFile: finalMainFile,
     pluginsModulesPath,
+    rewrites,
     srcFiles,
   })
 

--- a/src/runtimes/node/utils/package_json.ts
+++ b/src/runtimes/node/utils/package_json.ts
@@ -11,6 +11,7 @@ interface PackageJson {
   files?: string[]
   gypfile?: boolean
   binary?: boolean
+  type?: string
 }
 
 // Retrieve the `package.json` of a specific project or module

--- a/src/runtimes/node/utils/zip.ts
+++ b/src/runtimes/node/utils/zip.ts
@@ -70,16 +70,16 @@ const createDirectory = async function ({
   await pMap(
     srcFiles,
     (srcFile) => {
-      const srcPath = aliases.get(srcFile) || srcFile
-      const normalizedSrcPath = normalizeFilePath({
+      const destPath = aliases.get(srcFile) || srcFile
+      const normalizedDestPath = normalizeFilePath({
         commonPrefix: basePath,
-        path: srcPath,
+        path: destPath,
         pluginsModulesPath,
         userNamespace: DEFAULT_USER_SUBDIRECTORY,
       })
-      const destPath = join(functionFolder, normalizedSrcPath)
+      const absoluteDestPath = join(functionFolder, normalizedDestPath)
 
-      return copyFile(srcFile, destPath)
+      return copyFile(srcFile, absoluteDestPath)
     },
     { concurrency: COPY_FILE_CONCURRENCY },
   )
@@ -195,10 +195,10 @@ const zipJsFile = function ({
   srcFile: string
   userNamespace: string
 }) {
-  const filename = aliases.get(srcFile) || srcFile
-  const normalizedFilename = normalizeFilePath({ commonPrefix, path: filename, pluginsModulesPath, userNamespace })
+  const destPath = aliases.get(srcFile) || srcFile
+  const normalizedDestPath = normalizeFilePath({ commonPrefix, path: destPath, pluginsModulesPath, userNamespace })
 
-  addZipFile(archive, srcFile, normalizedFilename, stat)
+  addZipFile(archive, srcFile, normalizedDestPath, stat)
 }
 
 // `adm-zip` and `require()` expect Unix paths.

--- a/tests/fixtures/local-require-esm/function/file.js
+++ b/tests/fixtures/local-require-esm/function/file.js
@@ -1,3 +1,5 @@
+import esm from 'esm-module'
+
 export default function getZero() {
-  return 0
+  return esm() && 0
 }

--- a/tests/fixtures/local-require-esm/node_modules/esm-module/index.js
+++ b/tests/fixtures/local-require-esm/node_modules/esm-module/index.js
@@ -1,0 +1,3 @@
+const handler = () => true
+
+export default handler

--- a/tests/fixtures/local-require-esm/node_modules/esm-module/package.json
+++ b/tests/fixtures/local-require-esm/node_modules/esm-module/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "esm-module",
+  "version": "1.0.0",
+  "exports": "./index.js",
+  "type": "module"
+}

--- a/tests/main.js
+++ b/tests/main.js
@@ -425,18 +425,23 @@ testMany(
   'Can bundle functions with `.js` extension using ES Modules and feature flag OFF',
   ['bundler_esbuild', 'bundler_default', 'bundler_nft'],
   async (options, t) => {
+    const fixtureName = 'local-require-esm'
+    const opts = merge(options, {
+      basePath: `${FIXTURES_DIR}/${fixtureName}`,
+      featureFlags: { defaultEsModulesToEsbuild: false },
+    })
     const bundler = options.config['*'].nodeBundler
 
     await (bundler === undefined
       ? t.throwsAsync(
           zipNode(t, 'local-require-esm', {
             length: 3,
-            opts: merge(options, { featureFlags: { defaultEsModulesToEsbuild: false } }),
+            opts,
           }),
         )
       : zipNode(t, 'local-require-esm', {
           length: 3,
-          opts: merge(options, { featureFlags: { defaultEsModulesToEsbuild: false } }),
+          opts,
         }))
   },
 )


### PR DESCRIPTION
**- Summary**

When transpiling ESM packages to CJS, we should also modify their `package.json` so that the `type` field is set to `commonjs`, not `module`.

**- Test plan**

Existing tests reused.

**- A picture of a cute animal (not mandatory but encouraged)**

![7f175148-2ad8-4170-a34f-6356948a6870-medium16x9_feat_6cd9db36ca604a249b8949fdb2de2df8](https://user-images.githubusercontent.com/4162329/139876311-648750e0-e536-433c-bb68-9d85c6f01e1f.jpg)

