### PR TITLE
fix: avoid rewriting `package.json` files unnecessarily

### DIFF
--- a/src/runtimes/node/bundlers/index.ts
+++ b/src/runtimes/node/bundlers/index.ts
@@ -1,3 +1,5 @@
+import type { Buffer } from 'buffer'
+
 import type { Message } from '@netlify/esbuild'
 
 import type { NodeBundlerName } from '..'

--- a/src/runtimes/node/bundlers/index.ts
+++ b/src/runtimes/node/bundlers/index.ts
@@ -1,5 +1,3 @@
-import type { Buffer } from 'buffer'
-
 import type { Message } from '@netlify/esbuild'
 
 import type { NodeBundlerName } from '..'

--- a/src/runtimes/node/bundlers/nft/es_modules.ts
+++ b/src/runtimes/node/bundlers/nft/es_modules.ts
@@ -32,7 +32,11 @@ const getPatchedESMPackages = async (
   const patchedPackagesMap = new Map()
 
   packages.forEach((packagePath, index) => {
-    patchedPackagesMap.set(packagePath, patchedPackages[index])
+    const transpiledPackage = patchedPackages[index]
+
+    if (transpiledPackage !== null) {
+      patchedPackagesMap.set(packagePath, transpiledPackage)
+    }
   })
 
   return patchedPackagesMap
@@ -41,6 +45,11 @@ const getPatchedESMPackages = async (
 const patchESMPackage = async (path: string, fsCache: FsCache) => {
   const file = (await cachedReadFile(fsCache, path, 'utf8')) as string
   const packageJson: PackageJson = JSON.parse(file)
+
+  if (packageJson.type !== 'module') {
+    return null
+  }
+
   const patchedPackageJson = {
     ...packageJson,
     type: 'commonjs',

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -1,6 +1,9 @@
+import type { Buffer } from 'buffer'
 import { lstat, readdir, readFile, stat, unlink, writeFile } from 'fs'
-import { format, join, parse, resolve } from 'path'
+import { dirname, format, join, parse, resolve } from 'path'
 import { promisify } from 'util'
+
+import makeDir from 'make-dir'
 
 import { nonNullable } from './non_nullable'
 
@@ -86,6 +89,12 @@ const resolveFunctionsDirectories = (input: string | string[]) => {
   return absoluteDirectories
 }
 
+const writeFileAndCreateDirectories = async (path: string, contents: string | Buffer) => {
+  await makeDir(dirname(path))
+
+  return pWriteFile(path, contents)
+}
+
 export {
   cachedLstat,
   cachedReaddir,
@@ -98,6 +107,7 @@ export {
   safeUnlink,
   pStat as stat,
   pWriteFile as writeFile,
+  writeFileAndCreateDirectories,
   pReadFile as readFile,
 }
 export type { FsCache }


### PR DESCRIPTION
Follow up to https://github.com/netlify/zip-it-and-ship-it/pull/783 with two things:

1. Adding a test for the `archiveFormat: "none"` setting, used in local development. There's a fix as part of this, ensuring a directory exists before attempting to write `rewrites` files to it.
2. Avoiding rewriting `package.json` files unnecessarily by first checking whether they have `type: "module`. 