### PR TITLE
fix: disable ESM transpilation in NFT

### DIFF
--- a/src/runtimes/node/bundlers/nft/index.ts
+++ b/src/runtimes/node/bundlers/nft/index.ts
@@ -32,7 +32,7 @@ const bundle: BundleFunction = async ({
     includedFiles,
     includedFilesBasePath || basePath,
   )
-  const { paths: dependencyPaths, rewrites } = await traceFilesAndTranspile({
+  const { paths: dependencyPaths } = await traceFilesAndTranspile({
     basePath: repositoryRoot,
     config,
     mainFile,
@@ -48,7 +48,6 @@ const bundle: BundleFunction = async ({
     basePath: getBasePath(dirnames),
     inputs: dependencyPaths,
     mainFile,
-    rewrites,
     srcFiles,
   }
 }

--- a/tests/main.js
+++ b/tests/main.js
@@ -410,7 +410,7 @@ testMany(
 
 testMany(
   'Can bundle functions with `.js` extension using ES Modules and feature flag ON',
-  ['bundler_esbuild', 'bundler_default', 'bundler_nft'],
+  ['bundler_esbuild', 'bundler_default', 'todo:bundler_nft'],
   async (options, t) => {
     const opts = merge(options, { featureFlags: { defaultEsModulesToEsbuild: true } })
 
@@ -423,7 +423,7 @@ testMany(
 
 testMany(
   'Can bundle functions with `.js` extension using ES Modules and feature flag OFF',
-  ['bundler_esbuild', 'bundler_default', 'bundler_nft'],
+  ['bundler_esbuild', 'bundler_default', 'todo:bundler_nft'],
   async (options, t) => {
     const fixtureName = 'local-require-esm'
     const opts = merge(options, {


### PR DESCRIPTION
**- Summary**

Temporarily reverts https://github.com/netlify/zip-it-and-ship-it/pull/759 and https://github.com/netlify/zip-it-and-ship-it/pull/783.