### PR TITLE
feat: reinstate ESM transpilation for NFT

### DIFF
--- a/src/feature_flags.ts
+++ b/src/feature_flags.ts
@@ -4,6 +4,7 @@ const FLAGS: Record<string, boolean> = {
   buildGoSource: Boolean(env.NETLIFY_EXPERIMENTAL_BUILD_GO_SOURCE),
   buildRustSource: Boolean(env.NETLIFY_EXPERIMENTAL_BUILD_RUST_SOURCE),
   defaultEsModulesToEsbuild: Boolean(env.NETLIFY_EXPERIMENTAL_DEFAULT_ES_MODULES_TO_ESBUILD),
+  nftTranspile: false,
   parseWithEsbuild: false,
   traceWithNft: false,
 }

--- a/src/runtimes/node/bundlers/nft/es_modules.ts
+++ b/src/runtimes/node/bundlers/nft/es_modules.ts
@@ -31,6 +31,10 @@ const patchESMPackage = async (path: string, fsCache: FsCache) => {
 }
 
 const shouldTranspile = (path: string, cache: Map<string, boolean>, reasons: NodeFileTraceReasons): boolean => {
+  if (cache.has(path)) {
+    return cache.get(path) as boolean
+  }
+
   const reason = reasons.get(path)
 
   // This isn't an expected case, but if the path doesn't exist in `reasons` we

--- a/src/runtimes/node/bundlers/nft/es_modules.ts
+++ b/src/runtimes/node/bundlers/nft/es_modules.ts
@@ -1,35 +1,16 @@
-import { resolve } from 'path'
+import { basename, resolve } from 'path'
 
 import { NodeFileTraceReasons } from '@vercel/nft'
 
+import type { FunctionConfig } from '../../../../config'
 import { cachedReadFile, FsCache } from '../../../../utils/fs'
 import { PackageJson } from '../../utils/package_json'
 
-const getESMPackageJsons = (esmPaths: Set<string>, reasons: NodeFileTraceReasons, basePath?: string) => {
-  const packageJsons: string[] = [...reasons.entries()]
-    .filter(([, reason]) => {
-      if (reason.type !== 'resolve') {
-        return false
-      }
+import { transpile } from './transpile'
 
-      const hasESMParent = [...reason.parents].some((parentPath) => esmPaths.has(parentPath))
-
-      return hasESMParent
-    })
-    .map(([path]) => (basePath ? resolve(basePath, path) : resolve(path)))
-
-  return packageJsons
-}
-
-const getPatchedESMPackages = async (
-  esmPaths: Set<string>,
-  reasons: NodeFileTraceReasons,
-  fsCache: FsCache,
-  basePath?: string,
-) => {
-  const packages = getESMPackageJsons(esmPaths, reasons, basePath)
+const getPatchedESMPackages = async (packages: string[], fsCache: FsCache) => {
   const patchedPackages = await Promise.all(packages.map((path) => patchESMPackage(path, fsCache)))
-  const patchedPackagesMap = new Map()
+  const patchedPackagesMap: Map<string, string> = new Map()
 
   packages.forEach((packagePath, index) => {
     patchedPackagesMap.set(packagePath, patchedPackages[index])
@@ -49,4 +30,63 @@ const patchESMPackage = async (path: string, fsCache: FsCache) => {
   return JSON.stringify(patchedPackageJson)
 }
 
-export { getPatchedESMPackages }
+const shouldTranspile = (path: string, cache: Map<string, boolean>, reasons: NodeFileTraceReasons) => {
+  const reason = reasons.get(path)
+
+  if (reason === undefined) {
+    return false
+  }
+
+  const { parents } = reason
+
+  // The path should be transpiled if every parent will also be transpiled, or
+  // if there is no parent.
+  const shouldTranspilePath = [...parents].every((parentPath) => cache.get(parentPath) === true)
+
+  cache.set(path, shouldTranspilePath)
+
+  return shouldTranspilePath
+}
+
+const transpileESM = async ({
+  basePath,
+  config,
+  esmPaths,
+  fsCache,
+  reasons,
+}: {
+  basePath: string | undefined
+  config: FunctionConfig
+  esmPaths: Set<string>
+  fsCache: FsCache
+  reasons: NodeFileTraceReasons
+}) => {
+  const cache: Map<string, boolean> = new Map()
+  const paths = [...esmPaths].filter((path) => shouldTranspile(path, cache, reasons))
+  const pathsSet = new Set(paths)
+  const packageJsonPaths: string[] = [...reasons.entries()]
+    .filter(([path, reason]) => {
+      if (basename(path) !== 'package.json') {
+        return false
+      }
+
+      const needsPatch = [...reason.parents].some((parentPath) => pathsSet.has(parentPath))
+
+      return needsPatch
+    })
+    .map(([path]) => (basePath ? resolve(basePath, path) : resolve(path)))
+  const rewrites = await getPatchedESMPackages(packageJsonPaths, fsCache)
+
+  await Promise.all(
+    paths.map(async (path) => {
+      const absolutePath = basePath ? resolve(basePath, path) : resolve(path)
+      const transpiled = await transpile(absolutePath, config)
+
+      rewrites.set(absolutePath, transpiled)
+    }),
+  )
+
+  return rewrites
+}
+
+export { transpileESM }

--- a/src/runtimes/node/bundlers/nft/es_modules.ts
+++ b/src/runtimes/node/bundlers/nft/es_modules.ts
@@ -10,7 +10,7 @@ import { transpile } from './transpile'
 
 const getPatchedESMPackages = async (packages: string[], fsCache: FsCache) => {
   const patchedPackages = await Promise.all(packages.map((path) => patchESMPackage(path, fsCache)))
-  const patchedPackagesMap: Map<string, string> = new Map()
+  const patchedPackagesMap = new Map<string, string>()
 
   packages.forEach((packagePath, index) => {
     patchedPackagesMap.set(packagePath, patchedPackages[index])

--- a/src/runtimes/node/bundlers/nft/es_modules.ts
+++ b/src/runtimes/node/bundlers/nft/es_modules.ts
@@ -32,7 +32,7 @@ const patchESMPackage = async (path: string, fsCache: FsCache) => {
 
 const shouldTranspile = (path: string, cache: Map<string, boolean>, reasons: NodeFileTraceReasons): boolean => {
   if (cache.has(path)) {
-    return cache.get(path) as boolean
+    return cache.get(path)!
   }
 
   const reason = reasons.get(path)

--- a/src/runtimes/node/bundlers/nft/es_modules.ts
+++ b/src/runtimes/node/bundlers/nft/es_modules.ts
@@ -32,7 +32,7 @@ const patchESMPackage = async (path: string, fsCache: FsCache) => {
 
 const shouldTranspile = (path: string, cache: Map<string, boolean>, reasons: NodeFileTraceReasons): boolean => {
   if (cache.has(path)) {
-    return cache.get(path)!
+    return cache.get(path) as boolean
   }
 
   const reason = reasons.get(path)

--- a/src/runtimes/node/bundlers/nft/transpile.ts
+++ b/src/runtimes/node/bundlers/nft/transpile.ts
@@ -20,18 +20,4 @@ const transpile = async (path: string, config: FunctionConfig) => {
   return transpiled.outputFiles[0].text
 }
 
-const transpileMany = async (paths: string[], config: FunctionConfig) => {
-  const transpiledPaths: Map<string, string> = new Map()
-
-  await Promise.all(
-    paths.map(async (path) => {
-      const transpiled = await transpile(path, config)
-
-      transpiledPaths.set(path, transpiled)
-    }),
-  )
-
-  return transpiledPaths
-}
-
-export { transpileMany }
+export { transpile }

--- a/tests/fixtures/local-require-esm/function_cjs/function_cjs.js
+++ b/tests/fixtures/local-require-esm/function_cjs/function_cjs.js
@@ -1,0 +1,5 @@
+module.exports = async function getZero() {
+  const esm = import('esm-module')
+
+  return esm && 0
+}

--- a/tests/helpers/main.js
+++ b/tests/helpers/main.js
@@ -59,14 +59,15 @@ const requireExtractedFiles = async function (t, files) {
   t.true(jsFiles.every(Boolean))
 }
 
-const unzipFiles = async function (files) {
-  await Promise.all(files.map(unzipFile))
+const unzipFiles = async function (files, targetPathGenerator) {
+  await Promise.all(files.map(({ path }) => unzipFile({ path, targetPathGenerator })))
 }
 
-const unzipFile = async function ({ path }) {
+const unzipFile = async function ({ path, targetPathGenerator }) {
   const zip = new AdmZip(path)
   const pExtractAll = promisify(zip.extractAllToAsync.bind(zip))
-  await pExtractAll(`${path}/..`, false)
+  const targetPath = targetPathGenerator ? targetPathGenerator(path) : `${path}/..`
+  await pExtractAll(targetPath, false)
 }
 
 const replaceUnzipPath = function ({ path }) {

--- a/tests/main.js
+++ b/tests/main.js
@@ -452,7 +452,7 @@ testMany(
     const func4 = () => require(join(tmpDir, 'function_import_only.zip_out', 'function_import_only.js'))
 
     // Dynamic imports are not supported in Node <13.2.0.
-    if (semver.gte(nodeVersion.slice(1), '13.2.0')) {
+    if (semver.gte(nodeVersion, '13.2.0')) {
       t.is(await func2()(), 0)
     }
 

--- a/tests/main.js
+++ b/tests/main.js
@@ -1,7 +1,7 @@
 const { readFile, chmod, symlink, unlink, rename, stat, writeFile } = require('fs')
 const { tmpdir } = require('os')
 const { basename, dirname, isAbsolute, join, normalize, resolve, sep } = require('path')
-const { arch, env, platform } = require('process')
+const { arch, env, platform, version: nodeVersion } = require('process')
 const { promisify } = require('util')
 
 const test = require('ava')
@@ -11,6 +11,7 @@ const del = require('del')
 const execa = require('execa')
 const makeDir = require('make-dir')
 const pathExists = require('path-exists')
+const semver = require('semver')
 const sinon = require('sinon')
 const sortOn = require('sort-on')
 const { dir: getTmpDir, tmpName } = require('tmp-promise')
@@ -428,7 +429,7 @@ testMany(
   },
 )
 
-testMany(
+testMany.only(
   'Can bundle functions with `.js` extension using ES Modules',
   ['bundler_esbuild', 'bundler_nft', 'bundler_nft_transpile'],
   async (options, t, variation) => {
@@ -450,7 +451,9 @@ testMany(
     const func3 = () => require(join(tmpDir, 'function_export_only.zip_out', 'function_export_only.js'))
     const func4 = () => require(join(tmpDir, 'function_import_only.zip_out', 'function_import_only.js'))
 
-    t.is(await func2()(), 0)
+    if (semver.gte(nodeVersion.slice(1), '13.2.0')) {
+      t.is(await func2()(), 0)
+    }
 
     if (variation === 'bundler_nft') {
       t.throws(func1)

--- a/tests/main.js
+++ b/tests/main.js
@@ -451,6 +451,7 @@ testMany.only(
     const func3 = () => require(join(tmpDir, 'function_export_only.zip_out', 'function_export_only.js'))
     const func4 = () => require(join(tmpDir, 'function_import_only.zip_out', 'function_import_only.js'))
 
+    // Dynamic imports are not supported in Node <13.2.0.
     if (semver.gte(nodeVersion.slice(1), '13.2.0')) {
       t.is(await func2()(), 0)
     }

--- a/tests/main.js
+++ b/tests/main.js
@@ -429,7 +429,7 @@ testMany(
   },
 )
 
-testMany.only(
+testMany(
   'Can bundle functions with `.js` extension using ES Modules',
   ['bundler_esbuild', 'bundler_nft', 'bundler_nft_transpile'],
   async (options, t, variation) => {


### PR DESCRIPTION
**- Summary**

Reinstates ESM transpilation when using NFT, which was temporarily disabled in https://github.com/netlify/zip-it-and-ship-it/pull/786. It's sitting behind a `nftTranspile` feature flag.

Unlike the initial implementation introduced by https://github.com/netlify/zip-it-and-ship-it/pull/759, this PR only transpiles a file to ESM (and patches any corresponding `package.json`) if all its parents are ESM files themselves, also candidates for transpilation.

**- Test plan**

Existing tests adjusted accordingly.

**- A picture of a cute animal (not mandatory but encouraged)**

![gettyimages-144862048](https://user-images.githubusercontent.com/4162329/140310975-bfa504e2-8048-46d3-b971-2f0075043bd3.jpg)


