### PR TITLE
fix: esm imports with node: prefix on esbuild

### DIFF
--- a/src/runtimes/node/bundlers/esbuild/bundler.ts
+++ b/src/runtimes/node/bundlers/esbuild/bundler.ts
@@ -11,6 +11,7 @@ import type { RuntimeName } from '../../../runtime'
 import { getBundlerTarget } from './bundler_target'
 import { getDynamicImportsPlugin } from './plugin_dynamic_imports'
 import { getNativeModulesPlugin } from './plugin_native_modules'
+import { getNodeBuiltinPlugin } from './plugin_node_builtin'
 
 // Maximum number of log messages that an esbuild instance will produce. This
 // limit is important to avoid out-of-memory errors due to too much data being
@@ -71,6 +72,7 @@ const bundleJsFile = async function ({
       processImports: config.processDynamicNodeImports !== false,
       srcDir,
     }),
+    getNodeBuiltinPlugin(),
   ]
 
   // The version of ECMAScript to use as the build target. This will determine

--- a/src/runtimes/node/bundlers/esbuild/bundler.ts
+++ b/src/runtimes/node/bundlers/esbuild/bundler.ts
@@ -64,6 +64,7 @@ const bundleJsFile = async function ({
 
   // The list of esbuild plugins to enable for this build.
   const plugins = [
+    getNodeBuiltinPlugin(),
     getNativeModulesPlugin(nativeNodeModules),
     getDynamicImportsPlugin({
       basePath,
@@ -72,7 +73,6 @@ const bundleJsFile = async function ({
       processImports: config.processDynamicNodeImports !== false,
       srcDir,
     }),
-    getNodeBuiltinPlugin(),
   ]
 
   // The version of ECMAScript to use as the build target. This will determine

--- a/src/runtimes/node/bundlers/esbuild/plugin_native_modules.ts
+++ b/src/runtimes/node/bundlers/esbuild/plugin_native_modules.ts
@@ -39,6 +39,10 @@ const getNativeModulesPlugin = (externalizedModules: NativeNodeModules): Plugin 
 
       if (!pkg) return
 
+      if (pkg[1].startsWith('node:')) {
+        return { external: true }
+      }
+
       let directory = args.resolveDir
 
       while (true) {

--- a/src/runtimes/node/bundlers/esbuild/plugin_native_modules.ts
+++ b/src/runtimes/node/bundlers/esbuild/plugin_native_modules.ts
@@ -39,10 +39,6 @@ const getNativeModulesPlugin = (externalizedModules: NativeNodeModules): Plugin 
 
       if (!pkg) return
 
-      if (pkg[1].startsWith('node:')) {
-        return { external: true }
-      }
-
       let directory = args.resolveDir
 
       while (true) {

--- a/src/runtimes/node/bundlers/esbuild/plugin_node_builtin.ts
+++ b/src/runtimes/node/bundlers/esbuild/plugin_node_builtin.ts
@@ -1,0 +1,10 @@
+import type { Plugin } from '@netlify/esbuild'
+
+const getNodeBuiltinPlugin = (): Plugin => ({
+  name: 'builtin-modules',
+  setup(build) {
+    build.onResolve({ filter: /^node:/ }, () => ({ external: true }))
+  },
+})
+
+export { getNodeBuiltinPlugin }

--- a/tests/fixtures/node-force-builtin-esm/function.js
+++ b/tests/fixtures/node-force-builtin-esm/function.js
@@ -1,0 +1,5 @@
+import console from 'node:console'
+
+export const handler = () => {
+  console.log('hello world')
+}

--- a/tests/main.js
+++ b/tests/main.js
@@ -2251,7 +2251,7 @@ testMany(
 )
 
 testMany(
-  'Handles built-in modules imported with the `node:` prefix',
+  'Handles built-in modules required with the `node:` prefix',
   ['bundler_default', 'bundler_default_nft', 'bundler_nft', 'bundler_esbuild', 'bundler_esbuild_zisi'],
   async (options, t) => {
     t.plan(3)
@@ -2276,6 +2276,16 @@ testMany(
         )
       }
     }
+  },
+)
+
+testMany(
+  'Handles built-in modules imported with the `node:` prefix',
+  ['bundler_default', 'bundler_default_nft', 'bundler_nft', 'bundler_esbuild', 'bundler_esbuild_zisi'],
+  async (options, t) => {
+    await zipFixture(t, 'node-force-builtin-esm', {
+      opts: options,
+    })
   },
 )
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/zip-it-and-ship-it/blob/main/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

fixes a bundling error that occurs when esbuild bundles a `node:`-namespaced  esm import.

cc https://github.com/nuxt/framework/issues/1826

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- A picture of a cute animal (not mandatory but encouraged)**
