### PR TITLE
fix: ensure directories are created before writing files

### DIFF
--- a/src/runtimes/node/utils/zip.ts
+++ b/src/runtimes/node/utils/zip.ts
@@ -12,6 +12,7 @@ import pMap from 'p-map'
 import unixify from 'unixify'
 
 import { startZip, addZipFile, addZipContent, endZip, ZipArchive } from '../../../archive'
+import { mkdirAndWriteFile } from '../../../utils/fs'
 
 const pStat = promisify(fs.stat)
 const pWriteFile = promisify(fs.writeFile)
@@ -79,7 +80,7 @@ const createDirectory = async function ({
       const absoluteDestPath = join(functionFolder, normalizedDestPath)
 
       if (rewrites.has(srcFile)) {
-        return pWriteFile(absoluteDestPath, rewrites.get(srcFile) as string)
+        return mkdirAndWriteFile(absoluteDestPath, rewrites.get(srcFile) as string)
       }
 
       return copyFile(srcFile, absoluteDestPath)

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -1,6 +1,8 @@
 import { lstat, readdir, readFile, stat, unlink, writeFile } from 'fs'
-import { format, join, parse, resolve } from 'path'
+import { dirname, format, join, parse, resolve } from 'path'
 import { promisify } from 'util'
+
+import makeDir from 'make-dir'
 
 import { nonNullable } from './non_nullable'
 
@@ -86,6 +88,16 @@ const resolveFunctionsDirectories = (input: string | string[]) => {
   return absoluteDirectories
 }
 
+const mkdirAndWriteFile: typeof pWriteFile = async (path, ...params) => {
+  if (typeof path === 'string') {
+    const directory = dirname(path)
+
+    await makeDir(directory)
+  }
+
+  return pWriteFile(path, ...params)
+}
+
 export {
   cachedLstat,
   cachedReaddir,
@@ -99,5 +111,6 @@ export {
   pStat as stat,
   pWriteFile as writeFile,
   pReadFile as readFile,
+  mkdirAndWriteFile,
 }
 export type { FsCache }


### PR DESCRIPTION
**- Summary**

When using `archiveFormat: "none"`, any files in `rewrites` are written to disk using `writeFile`. When doing this, we must ensure that the directory structure exists prior to the write operation. This PR addresses that.

**- Test plan**

Added a new test.

**- A picture of a cute animal (not mandatory but encouraged)**

![749dc9dfe2559f53aa1e466a9af3c609](https://user-images.githubusercontent.com/4162329/142201811-eaf51cf2-20d7-49a6-bf13-d1849056c915.jpg)


