### PR TITLE
feat: add sourcemap support to NFT

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
         "nyc": "^15.0.0",
         "sinon": "^12.0.0",
         "sort-on": "^4.1.1",
+        "source-map-support": "^0.5.20",
         "throat": "^6.0.1",
         "typescript": "^4.4.3"
       },

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "nyc": "^15.0.0",
     "sinon": "^12.0.0",
     "sort-on": "^4.1.1",
+    "source-map-support": "^0.5.20",
     "throat": "^6.0.1",
     "typescript": "^4.4.3"
   },

--- a/src/runtimes/node/bundlers/nft/transpile.ts
+++ b/src/runtimes/node/bundlers/nft/transpile.ts
@@ -13,6 +13,7 @@ const transpile = async (path: string, config: FunctionConfig) => {
     format: 'cjs',
     logLevel: 'error',
     platform: 'node',
+    sourcemap: Boolean(config.nodeSourcemap),
     target: [nodeTarget],
     write: false,
   })

--- a/tests/fixtures/esm-throwing-error/.eslintrc
+++ b/tests/fixtures/esm-throwing-error/.eslintrc
@@ -1,0 +1,3 @@
+{
+  "parserOptions": { "sourceType": "module" }
+}

--- a/tests/fixtures/esm-throwing-error/function.js
+++ b/tests/fixtures/esm-throwing-error/function.js
@@ -1,0 +1,5 @@
+const handler = () => {
+  throw new Error('uh-oh')
+}
+
+export { handler }

--- a/tests/main.js
+++ b/tests/main.js
@@ -2373,6 +2373,8 @@ test('Generates a sourcemap for any transpiled files when `nodeSourcemap: true`'
   } catch (error) {
     const filePath = join(files[0].path, 'src', 'tests', 'fixtures', fixtureName, 'function.js')
 
+    // Asserts that the line/column of the error match the position of the
+    // original source file, not the transpiled one.
     t.true(error.stack.includes(`${filePath}:2:9`))
   }
 })

--- a/tests/main.js
+++ b/tests/main.js
@@ -17,6 +17,8 @@ const sortOn = require('sort-on')
 const { dir: getTmpDir, tmpName } = require('tmp-promise')
 const unixify = require('unixify')
 
+require('source-map-support').install()
+
 // We must require this file first because we need to stub it before the main
 // functions are required.
 // eslint-disable-next-line import/order
@@ -2350,3 +2352,27 @@ testMany(
     files.every(({ size }) => Number.isInteger(size) && size > 0)
   },
 )
+
+test('Generates a sourcemap for any transpiled files when `nodeSourcemap: true`', async (t) => {
+  const fixtureName = 'esm-throwing-error'
+  const basePath = join(FIXTURES_DIR, fixtureName)
+  const { files } = await zipFixture(t, fixtureName, {
+    opts: {
+      archiveFormat: 'none',
+      basePath,
+      config: { '*': { nodeBundler: 'nft', nodeSourcemap: true } },
+      featureFlags: { nftTranspile: true },
+    },
+  })
+  const func = require(join(files[0].path, 'function.js'))
+
+  try {
+    func.handler()
+
+    t.fail()
+  } catch (error) {
+    const filePath = join(files[0].path, 'src', 'tests', 'fixtures', fixtureName, 'function.js')
+
+    t.true(error.stack.includes(`${filePath}:2:9`))
+  }
+})


### PR DESCRIPTION
**- Summary**

When using NFT, generates a sourcemap for any transpiled files, whenever the `nodeSourcemap` property is set to `true`.

**- Test plan**

Added a new test.