### PR TITLE
feat: add new top-level `schedule` property

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -36,12 +36,12 @@ const createManifest = async ({ functions, path }: { functions: FunctionResult[]
   await writeFile(path, JSON.stringify(payload))
 }
 
-const formatFunctionForManifest = ({ config, mainFile, name, path, runtime }: FunctionResult): ManifestFunction => ({
+const formatFunctionForManifest = ({ mainFile, name, path, runtime, schedule }: FunctionResult): ManifestFunction => ({
   mainFile,
   name,
   path: resolve(path),
   runtime,
-  schedule: config.schedule,
+  schedule,
 })
 
 export { createManifest }

--- a/src/utils/format_result.ts
+++ b/src/utils/format_result.ts
@@ -3,13 +3,14 @@ import { RuntimeName } from '../runtimes/runtime'
 
 import { removeUndefined } from './remove_undefined'
 
-type FunctionResult = Omit<FunctionArchive, 'runtime'> & { runtime: RuntimeName }
+type FunctionResult = Omit<FunctionArchive, 'runtime'> & { runtime: RuntimeName; schedule?: string }
 
 // Takes the result of zipping a function and formats it for output.
 const formatZipResult = (archive: FunctionArchive) => {
   const functionResult: FunctionResult = {
     ...archive,
     runtime: archive.runtime.name,
+    schedule: archive?.config?.schedule,
   }
 
   return removeUndefined(functionResult)

--- a/tests/fixtures/with-schedule/func-1.js
+++ b/tests/fixtures/with-schedule/func-1.js
@@ -1,0 +1,3 @@
+module.exports.handler = () => {
+  return true
+}

--- a/tests/main.js
+++ b/tests/main.js
@@ -2350,3 +2350,32 @@ testMany(
     files.every(({ size }) => Number.isInteger(size) && size > 0)
   },
 )
+
+testMany(
+  'Should surface schedule declarations on a top-level `schedule` property',
+  ['bundler_default', 'bundler_default_nft', 'bundler_esbuild', 'bundler_nft'],
+  async (options, t) => {
+    const schedule = '* * * * *'
+    const fixtureName = 'with-schedule'
+    const { path: tmpDir } = await getTmpDir({ prefix: 'zip-it-test' })
+    const manifestPath = join(tmpDir, 'manifest.json')
+    const opts = merge(options, {
+      basePath: join(FIXTURES_DIR, fixtureName),
+      config: {
+        '*': {
+          schedule,
+        },
+      },
+      manifest: manifestPath,
+    })
+    const { files } = await zipNode(t, fixtureName, { opts })
+
+    files.every((file) => t.is(file.schedule, schedule))
+
+    const manifest = require(manifestPath)
+
+    manifest.functions.forEach((fn) => {
+      t.is(fn.schedule, schedule)
+    })
+  },
+)


### PR DESCRIPTION
**- Summary**

Currently, any schedule data is surfaced in the result of `zipFunction` and `zipFunctions` as `config.schedule`. This PR adds a new top-level `schedule` property, which contains the same value.

This property will be useful when we introduce the in-code config declarations, because we'll be able to merge schedule data coming from the two types of sources and decide which one takes priority.

**- Test plan**

New test added.