### PR TITLE
chore: simplify `renovate.json5`

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -9,14 +9,6 @@
   dependencyDashboard: true,
   automerge: false,
   packageRules: [
-    {
-      matchPackageNames: ['p-map'],
-      allowedVersions: '<5',
-    },
-    {
-      matchPackageNames: ['yargs'],
-      allowedVersions: '<17',
-    },
     // Version 0.5.6 of adm-zip is breaking tests. See:
     // https://github.com/netlify/zip-it-and-ship-it/pull/651/checks?check_run_id=3587767454
     {
@@ -27,10 +19,6 @@
       // Fake dependencies used in tests
       packageNames: ['test'],
       enabled: false,
-    },
-    {
-      matchPackageNames: ['pkg-dir'],
-      allowedVersions: '<=5',
     },
   ],
 }


### PR DESCRIPTION
Part of https://github.com/netlify/zip-it-and-ship-it/issues/748

This simplifies `renovate.json5` since those rules are already part of our shared Renovate configuration.