### PR TITLE
chore!: drop support for Node 10

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -13,12 +13,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        node-version: [10.18.0, '*']
+        node-version: [12.20.0, '*']
         exclude:
           - os: macOS-latest
-            node-version: 10.18.0
+            node-version: 12.20.0
           - os: windows-latest
-            node-version: 10.18.0
+            node-version: 12.20.0
       fail-fast: false
     steps:
       # Increasing the maximum number of open files. See:

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@netlify/esbuild": "^0.13.6",
         "@vercel/nft": "^0.17.0",
         "archiver": "^5.3.0",
-        "array-flat-polyfill": "^1.0.1",
         "common-path-prefix": "^3.0.0",
         "cp-file": "^9.0.0",
         "del": "^6.0.0",
@@ -72,7 +71,7 @@
         "typescript": "^4.4.3"
       },
       "engines": {
-        "node": ">=10.18.0"
+        "node": "^12.20.0 || ^14.14.0 || >=16.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1828,14 +1827,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/array-flat-polyfill": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/array-flat-polyfill/-/array-flat-polyfill-1.0.1.tgz",
-      "integrity": "sha512-hfJmKupmQN0lwi0xG6FQ5U8Rd97RnIERplymOv/qpq8AoNKPPAnxJadjFA23FNWm88wykh9HmpLJUUwUtNU/iw==",
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/array-ify": {
@@ -13940,11 +13931,6 @@
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
       "dev": true
-    },
-    "array-flat-polyfill": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/array-flat-polyfill/-/array-flat-polyfill-1.0.1.tgz",
-      "integrity": "sha512-hfJmKupmQN0lwi0xG6FQ5U8Rd97RnIERplymOv/qpq8AoNKPPAnxJadjFA23FNWm88wykh9HmpLJUUwUtNU/iw=="
     },
     "array-ify": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "@netlify/esbuild": "^0.13.6",
     "@vercel/nft": "^0.17.0",
     "archiver": "^5.3.0",
-    "array-flat-polyfill": "^1.0.1",
     "common-path-prefix": "^3.0.0",
     "cp-file": "^9.0.0",
     "del": "^6.0.0",
@@ -117,7 +116,7 @@
     "typescript": "^4.4.3"
   },
   "engines": {
-    "node": ">=10.18.0"
+    "node": "^12.20.0 || ^14.14.0 || >=16.0.0"
   },
   "ava": {
     "files": [

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,5 @@
 import { extname } from 'path'
 
-import './utils/polyfills'
 import { Config } from './config'
 import { FeatureFlags, getFlags } from './feature_flags'
 import { FunctionSource } from './function'

--- a/src/runtimes/node/bundlers/zisi/traverse.ts
+++ b/src/runtimes/node/bundlers/zisi/traverse.ts
@@ -107,9 +107,7 @@ const getNestedModules = async function ({
       getDependencyPathsForDependency({ dependency, basedir: modulePath, state, packageJson, pluginsModulesPath }),
     ),
   )
-  // TODO: switch to Array.flat() once we drop support for Node.js < 11.0.0
-  // eslint-disable-next-line unicorn/prefer-spread
-  return ([] as string[]).concat(...depsPaths)
+  return depsPaths.flat()
 }
 
 export { getDependencyPathsForDependency }

--- a/src/utils/polyfills.ts
+++ b/src/utils/polyfills.ts
@@ -1,3 +1,0 @@
-// Patches `Array.flat()` and `Array.flatMap()`
-// TODO: remove after dropping Node <12 support
-import 'array-flat-polyfill'


### PR DESCRIPTION
Fixes https://github.com/netlify/zip-it-and-ship-it/issues/748

This drops Node 10 support.

This does not drop Node 8/10 support as a compilation target (`nodeVersion` option) since I believe this is separate from the Node.js version supported for consumers installing this module through npm, but please let me know if this is incorrect.

This can be reviewed, but can only be released once https://github.com/netlify/build/pull/3873 is released.

I will also fix the branch protection rule right before merging this.