### PR TITLE
chore: make Renovate ignore modules in fixtures

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,10 +1,7 @@
 {
   extends: ['github>netlify/renovate-config:default'],
   ignorePresets: [':prHourlyLimit2'],
-  ignorePaths: [
-    "benchmarks/fixtures/",
-    "tests/fixtures/node_modules" // hand-built node_modules folder, used for testing. shouldn't be updated.
-  ],
+  ignorePaths: ['benchmarks/fixtures/', 'tests/fixtures'],
   semanticCommits: true,
   dependencyDashboard: true,
   automerge: false,


### PR DESCRIPTION
**- Summary**

Avoids things like https://github.com/netlify/zip-it-and-ship-it/pull/839.