### PR TITLE
feat: remove `nftTranspile` feature flag

### DIFF
--- a/src/feature_flags.ts
+++ b/src/feature_flags.ts
@@ -4,7 +4,6 @@ const FLAGS: Record<string, boolean> = {
   buildGoSource: Boolean(env.NETLIFY_EXPERIMENTAL_BUILD_GO_SOURCE),
   buildRustSource: Boolean(env.NETLIFY_EXPERIMENTAL_BUILD_RUST_SOURCE),
   defaultEsModulesToEsbuild: Boolean(env.NETLIFY_EXPERIMENTAL_DEFAULT_ES_MODULES_TO_ESBUILD),
-  nftTranspile: false,
   parseISC: false,
   parseWithEsbuild: false,
   traceWithNft: false,

--- a/src/runtimes/node/bundlers/nft/index.ts
+++ b/src/runtimes/node/bundlers/nft/index.ts
@@ -22,7 +22,6 @@ const appearsToBeModuleName = (name: string) => !name.startsWith('.')
 const bundle: BundleFunction = async ({
   basePath,
   config,
-  featureFlags,
   mainFile,
   pluginsModulesPath,
   repositoryRoot = basePath,
@@ -37,7 +36,6 @@ const bundle: BundleFunction = async ({
     config,
     mainFile,
     pluginsModulesPath,
-    transpile: featureFlags.nftTranspile,
   })
   const filteredIncludedPaths = filterExcludedPaths([...dependencyPaths, ...includedFilePaths], excludedPaths)
   const dirnames = filteredIncludedPaths.map((filePath) => normalize(dirname(filePath))).sort()
@@ -66,13 +64,11 @@ const traceFilesAndTranspile = async function ({
   config,
   mainFile,
   pluginsModulesPath,
-  transpile,
 }: {
   basePath?: string
   config: FunctionConfig
   mainFile: string
   pluginsModulesPath?: string
-  transpile: boolean
 }) {
   const fsCache: FsCache = {}
   const {
@@ -115,9 +111,7 @@ const traceFilesAndTranspile = async function ({
   const normalizedDependencyPaths = [...dependencyPaths].map((path) =>
     basePath ? resolve(basePath, path) : resolve(path),
   )
-  const rewrites = transpile
-    ? await transpileESM({ basePath, config, esmPaths: esmFileList, fsCache, reasons })
-    : undefined
+  const rewrites = await transpileESM({ basePath, config, esmPaths: esmFileList, fsCache, reasons })
 
   return {
     paths: normalizedDependencyPaths,

--- a/tests/main.js
+++ b/tests/main.js
@@ -88,10 +88,6 @@ const testMany = makeTestMany(test, {
   bundler_nft: {
     config: { '*': { nodeBundler: 'nft' } },
   },
-  bundler_nft_transpile: {
-    config: { '*': { nodeBundler: 'nft' } },
-    featureFlags: { nftTranspile: true },
-  },
 })
 
 const getNodeBundlerString = (variation) => {
@@ -434,8 +430,8 @@ testMany(
 
 testMany(
   'Can bundle functions with `.js` extension using ES Modules',
-  ['bundler_esbuild', 'bundler_nft', 'bundler_nft_transpile'],
-  async (options, t, variation) => {
+  ['bundler_esbuild', 'bundler_nft'],
+  async (options, t) => {
     const length = 4
     const fixtureName = 'local-require-esm'
     const opts = merge(options, {
@@ -459,14 +455,6 @@ testMany(
       t.is(await func2()(), 0)
     }
 
-    if (variation === 'bundler_nft') {
-      t.throws(func1)
-      t.throws(func3)
-      t.throws(func4)
-
-      return
-    }
-
     t.is(func1().ZERO, 0)
     t.is(typeof func3().howdy, 'string')
     t.deepEqual(func4(), {})
@@ -475,8 +463,8 @@ testMany(
 
 testMany(
   'Can bundle functions with `.js` extension using ES Modules when `archiveType` is `none`',
-  ['bundler_esbuild', 'bundler_nft', 'bundler_nft_transpile'],
-  async (options, t, variation) => {
+  ['bundler_esbuild', 'bundler_nft'],
+  async (options, t) => {
     const length = 4
     const fixtureName = 'local-require-esm'
     const opts = merge(options, {
@@ -499,14 +487,6 @@ testMany(
       t.is(await func2()(), 0)
     }
 
-    if (variation === 'bundler_nft') {
-      t.throws(func1)
-      t.throws(func3)
-      t.throws(func4)
-
-      return
-    }
-
     t.is(func1().ZERO, 0)
     t.is(typeof func3().howdy, 'string')
     t.deepEqual(func4(), {})
@@ -515,7 +495,7 @@ testMany(
 
 testMany(
   'Can bundle CJS functions that import ESM files with an `import()` expression',
-  ['bundler_esbuild', 'bundler_nft', 'bundler_nft_transpile'],
+  ['bundler_esbuild', 'bundler_nft'],
   async (options, t) => {
     const fixtureName = 'node-cjs-importing-mjs'
     const { files, tmpDir } = await zipFixture(t, fixtureName, {


### PR DESCRIPTION
**- Summary**

Removes the `nftTranspile` feature flag, which has now been rolled out to all accounts.

**- Test plan**

Adjusted existing tests.

**- A picture of a cute animal (not mandatory but encouraged)**

![5fc4f8557afa5b21e3bdc475-sloth-with-baby-sloth-hanging](https://user-images.githubusercontent.com/4162329/144047664-89732421-0b0e-4f55-af37-8f76885ff248.jpg)

