### PR TITLE
feat: remove `parseISC` feature flag

### DIFF
--- a/src/feature_flags.ts
+++ b/src/feature_flags.ts
@@ -4,7 +4,6 @@ const FLAGS: Record<string, boolean> = {
   buildGoSource: Boolean(env.NETLIFY_EXPERIMENTAL_BUILD_GO_SOURCE),
   buildRustSource: Boolean(env.NETLIFY_EXPERIMENTAL_BUILD_RUST_SOURCE),
   defaultEsModulesToEsbuild: Boolean(env.NETLIFY_EXPERIMENTAL_DEFAULT_ES_MODULES_TO_ESBUILD),
-  parseISC: false,
   parseWithEsbuild: false,
   traceWithNft: false,
 }

--- a/src/runtimes/node/index.ts
+++ b/src/runtimes/node/index.ts
@@ -117,11 +117,7 @@ const zipFunction: ZipFunction = async function ({
     stat,
   })
 
-  let inSourceConfig = {}
-
-  if (featureFlags.parseISC) {
-    inSourceConfig = await findISCDeclarationsInPath(mainFile)
-  }
+  const inSourceConfig = await findISCDeclarationsInPath(mainFile)
 
   createPluginsModulesPathAliases(srcFiles, pluginsModulesPath, aliases, finalBasePath)
 

--- a/tests/main.js
+++ b/tests/main.js
@@ -2390,14 +2390,9 @@ testMany(
   'Finds in-source config declarations using the `schedule` helper',
   ['bundler_default', 'bundler_esbuild', 'bundler_nft'],
   async (options, t) => {
-    const opts = merge(options, {
-      featureFlags: {
-        parseISC: true,
-      },
-    })
     const FUNCTIONS_COUNT = 6
     const { files } = await zipFixture(t, join('in-source-config', 'functions'), {
-      opts,
+      opts: options,
       length: FUNCTIONS_COUNT,
     })
 


### PR DESCRIPTION
**- Summary**

Removes the `parseISC` feature flag, which has now been fully rolled out.

**- Test plan**

Existing test amended.