### PR TITLE
feat: add `zipGo` config property

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -19,6 +19,7 @@ interface FunctionConfig {
   processDynamicNodeImports?: boolean
   rustTargetDirectory?: string
   schedule?: string
+  zipGo?: boolean
 }
 
 type GlobPattern = string

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -20,6 +20,7 @@ interface ZipFunctionOptions {
   config?: Config
   featureFlags?: FeatureFlags
   repositoryRoot?: string
+  zipGo?: boolean
 }
 
 type ZipFunctionsOptions = ZipFunctionOptions & {
@@ -49,6 +50,7 @@ const zipFunctions = async function (
     manifest,
     parallelLimit = DEFAULT_PARALLEL_LIMIT,
     repositoryRoot = basePath,
+    zipGo,
   }: ZipFunctionsOptions = {},
 ) {
   validateArchiveFormat(archiveFormat)
@@ -66,6 +68,7 @@ const zipFunctions = async function (
         config: func.config,
         destFolder,
         extension: func.extension,
+        featureFlags,
         filename: func.filename,
         mainFile: func.mainFile,
         name: func.name,
@@ -74,7 +77,6 @@ const zipFunctions = async function (
         srcDir: func.srcDir,
         srcPath: func.srcPath,
         stat: func.stat,
-        featureFlags,
       })
 
       return { ...zipResult, mainFile: func.mainFile, name: func.name, runtime: func.runtime }

--- a/tests/fixtures/go-simple/test.go
+++ b/tests/fixtures/go-simple/test.go
@@ -1,7 +1,0 @@
-package main
-
-import "fmt"
-
-func main() {
-	fmt.Println("test")
-}


### PR DESCRIPTION
#### Summary

Go functions must be zipped before we upload them to AWS. This PR adds a `zipGo` configuration option, which determines whether the output of a Go function is a binary or a ZIP containing it.

We used to have a similar configuration property, but it was removed in #372 because it wasn't being used anywhere. We shouldn't need to use it in buildbot because when it finds a Go binary, it [takes care of wrapping it in a ZIP archive](https://github.com/netlify/open-api/blob/master/go/porcelain/deploy.go#L741-L757). This is why this flow currently works in buildbot and fails in the CLI.

Once this config property is in place, we should conditionally set it based on whether we are bundling in buildbot or in the CLI.

Part of https://github.com/netlify/cli/issues/1147.

**A picture of a cute animal (not mandatory, but encouraged)**

![istockphoto-1172290687-612x612](https://user-images.githubusercontent.com/4162329/149986581-e804a6b8-d483-4735-9527-ee838792bf0d.jpg)

