### PR TITLE
fix: pin `@babel/parser` to `7.16.8`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.5.1",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.15.7",
+        "@babel/parser": "7.16.8",
         "@netlify/esbuild": "^0.13.6",
         "@vercel/nft": "^0.17.0",
         "archiver": "^5.3.0",
@@ -351,9 +351,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.16.12",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.12.tgz",
-      "integrity": "sha512-VfaV15po8RiZssrkPweyvbGVSe4x2y+aciFCgn0n0/SJMR22cwofRV1mtnJQYcSB1wUTaA/X1LnA3es66MCO5A==",
+      "version": "7.16.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.8.tgz",
+      "integrity": "sha512-i7jDUfrVBWc+7OKcBzEe5n7fbv3i2fWtxKzzCvOjnzSxMfWMigAhtfJ7qzZNGFNMsCCd67+uz553dYKWXPvCKw==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -12147,9 +12147,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.16.12",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.12.tgz",
-      "integrity": "sha512-VfaV15po8RiZssrkPweyvbGVSe4x2y+aciFCgn0n0/SJMR22cwofRV1mtnJQYcSB1wUTaA/X1LnA3es66MCO5A=="
+      "version": "7.16.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.8.tgz",
+      "integrity": "sha512-i7jDUfrVBWc+7OKcBzEe5n7fbv3i2fWtxKzzCvOjnzSxMfWMigAhtfJ7qzZNGFNMsCCd67+uz553dYKWXPvCKw=="
     },
     "@babel/template": {
       "version": "7.16.7",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "url": "https://github.com/netlify/zip-it-and-ship-it/issues"
   },
   "dependencies": {
-    "@babel/parser": "^7.15.7",
+    "@babel/parser": "7.16.8",
     "@netlify/esbuild": "^0.13.6",
     "@vercel/nft": "^0.17.0",
     "archiver": "^5.3.0",


### PR DESCRIPTION
Some builds are experiencing a big slowdown when we upgrade `@babel/parser` from `7.16.8` to `7.16.10` (note: there is no `7.16.9` release).

The only PR introduced by that release is https://github.com/babel/babel/pull/14130, so it appears to have some issues. It could be one of the following bugs, but we are not sure yet: https://github.com/babel/babel/issues/14182, https://github.com/babel/babel/issues/14175

We are certain that the problem comes from this specific package and this specific version. We also know the problem comes from `@babel/parser` as a direct dependency of `@netlify/zip-it-and-ship-it`, as opposed to as an indirect dependency through `precinct` and `node-source-walker`.

This PR pins the version of `@babel/parser` until we figure out why this version is creating a problem on our side.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/zip-it-and-ship-it/issues/new/choose) before writing your code
      🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re
      fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [x] Update or add tests (if any source code was changed or added) 🧪
- [x] Update or add documentation (if features were changed or added) 📝
- [x] Make sure the status checks below are successful ✅