### PR TITLE
chore: use ES modules in benchmarks

### DIFF
--- a/benchmarks/esbuild.js
+++ b/benchmarks/esbuild.js
@@ -1,8 +1,8 @@
-const { join } = require('path')
+import { join } from 'path'
 
-const { zipFunctions } = require('..')
+import { zipFunctions } from '../dist/main.js'
 
-const { timeFunction, FIXTURES_DIR } = require('./helpers/main')
+import { timeFunction, FIXTURES_DIR } from './helpers/main.js'
 
 const BENCHMARK_OUTPUT = 'benchmarks/output'
 const RUNS = 3

--- a/benchmarks/helpers/main.js
+++ b/benchmarks/helpers/main.js
@@ -1,9 +1,9 @@
-// eslint-disable-next-line node/no-unsupported-features/node-builtins
-const { performance, PerformanceObserver } = require('perf_hooks')
+import { performance, PerformanceObserver } from 'perf_hooks'
+import { fileURLToPath } from 'url'
 
-const FIXTURES_DIR = `${__dirname}/../fixtures`
+export const FIXTURES_DIR = fileURLToPath(new URL('../fixtures', import.meta.url))
 
-const timeFunction = (func, runs = 1) =>
+export const timeFunction = (func, runs = 1) =>
   new Promise((resolve) => {
     const finishedRuns = new Map()
 
@@ -30,5 +30,8 @@ const timeFunction = (func, runs = 1) =>
       performance.measure(`run-${index}`, `run-${index}-start`)
     })
   })
+<<<<<<< HEAD
 
 module.exports = { timeFunction, FIXTURES_DIR }
+=======
+>>>>>>> 9afae99 (fix: use ES modules in benchmarks)

--- a/benchmarks/helpers/main.js
+++ b/benchmarks/helpers/main.js
@@ -30,8 +30,3 @@ export const timeFunction = (func, runs = 1) =>
       performance.measure(`run-${index}`, `run-${index}-start`)
     })
   })
-<<<<<<< HEAD
-
-module.exports = { timeFunction, FIXTURES_DIR }
-=======
->>>>>>> 9afae99 (fix: use ES modules in benchmarks)

--- a/benchmarks/nft.js
+++ b/benchmarks/nft.js
@@ -1,7 +1,6 @@
+import { zipFunctions } from '../dist/main.js'
 
-const { zipFunctions } = require('../dist/main')
-
-const { timeFunction, FIXTURES_DIR } = require('./helpers/main')
+import { timeFunction, FIXTURES_DIR } from './helpers/main.js'
 
 const BENCHMARK_OUTPUT = 'benchmarks/output'
 const RUNS = 3

--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/benchmarks/zisi.js
+++ b/benchmarks/zisi.js
@@ -1,7 +1,6 @@
+import { zipFunctions } from '../dist/main.js'
 
-const { zipFunctions } = require('..')
-
-const { timeFunction, FIXTURES_DIR } = require('./helpers/main')
+import { timeFunction, FIXTURES_DIR } from './helpers/main.js'
 
 const BENCHMARK_OUTPUT = 'benchmarks/output'
 const RUNS = 3


### PR DESCRIPTION
Part of https://github.com/netlify/zip-it-and-ship-it/issues/749

Depends on #975

This migrates the benchmarks to using pure ES modules.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/zip-it-and-ship-it/issues/new/choose) before writing your code
      🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re
      fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [x] Update or add tests (if any source code was changed or added) 🧪
- [x] Update or add documentation (if features were changed or added) 📝
- [x] Make sure the status checks below are successful ✅