### PR TITLE
fix: use dynamic `import()` in tests

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -14,10 +14,8 @@ module.exports = {
       files: 'tests/**/*.js',
       rules: {
         'import/max-dependencies': 'off',
-        'import/no-dynamic-require': 'off',
         'max-lines-per-function': 'off',
         'max-statements': 'off',
-        'node/global-require': 'off',
         'no-magic-numbers': 'off',
       },
     },


### PR DESCRIPTION
Part of https://github.com/netlify/zip-it-and-ship-it/issues/749

This replaces `require()` to dynamic `import()` in tests, as part of the migration to ES modules.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/zip-it-and-ship-it/issues/new/choose) before writing your code
      🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re
      fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [x] Update or add tests (if any source code was changed or added) 🧪
- [x] Update or add documentation (if features were changed or added) 📝
- [x] Make sure the status checks below are successful ✅