### PR TITLE
chore: re-pin `@babel/parser` version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.5.2",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "7.17.0",
+        "@babel/parser": "7.16.8",
         "@netlify/esbuild": "^0.13.6",
         "@vercel/nft": "^0.17.0",
         "archiver": "^5.3.0",
@@ -46,7 +46,7 @@
         "zip-it-and-ship-it": "dist/bin.js"
       },
       "devDependencies": {
-        "@babel/types": "^7.17.0",
+        "@babel/types": "^7.15.6",
         "@netlify/eslint-config-node": "^5.1.2",
         "@types/archiver": "^5.1.1",
         "@types/end-of-stream": "^1.4.1",
@@ -62,7 +62,7 @@
         "husky": "^7.0.4",
         "npm-run-all": "^4.1.5",
         "p-every": "^2.0.0",
-        "sinon": "^13.0.0",
+        "sinon": "^13.0.1",
         "sort-on": "^4.1.1",
         "source-map-support": "^0.5.20",
         "throat": "^6.0.1"
@@ -351,9 +351,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.0.tgz",
-      "integrity": "sha512-VKXSCQx5D8S04ej+Dqsr1CzYvvWgf20jIw2D+YhQCrIlr2UZGaDds23Y0xg75/skOxpLCRpUZvk/1EAVkGoDOw==",
+      "version": "7.16.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.8.tgz",
+      "integrity": "sha512-i7jDUfrVBWc+7OKcBzEe5n7fbv3i2fWtxKzzCvOjnzSxMfWMigAhtfJ7qzZNGFNMsCCd67+uz553dYKWXPvCKw==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -397,9 +397,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
-      "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+      "version": "7.16.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.8.tgz",
+      "integrity": "sha512-smN2DQc5s4M7fntyjGtyIPbRJv6wW4rU/94fmYJ7PKQuZkC0qGMHXJbg6sNGt12JmVr4k5YaptI/XtiLJBnmIg==",
       "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.16.7",
@@ -12146,9 +12146,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.0.tgz",
-      "integrity": "sha512-VKXSCQx5D8S04ej+Dqsr1CzYvvWgf20jIw2D+YhQCrIlr2UZGaDds23Y0xg75/skOxpLCRpUZvk/1EAVkGoDOw=="
+      "version": "7.16.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.8.tgz",
+      "integrity": "sha512-i7jDUfrVBWc+7OKcBzEe5n7fbv3i2fWtxKzzCvOjnzSxMfWMigAhtfJ7qzZNGFNMsCCd67+uz553dYKWXPvCKw=="
     },
     "@babel/template": {
       "version": "7.16.7",
@@ -12180,9 +12180,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
-      "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+      "version": "7.16.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.8.tgz",
+      "integrity": "sha512-smN2DQc5s4M7fntyjGtyIPbRJv6wW4rU/94fmYJ7PKQuZkC0qGMHXJbg6sNGt12JmVr4k5YaptI/XtiLJBnmIg==",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.16.7",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "url": "https://github.com/netlify/zip-it-and-ship-it/issues"
   },
   "dependencies": {
-    "@babel/parser": "7.17.0",
+    "@babel/parser": "7.16.8",
     "@netlify/esbuild": "^0.13.6",
     "@vercel/nft": "^0.17.0",
     "archiver": "^5.3.0",

--- a/renovate.json5
+++ b/renovate.json5
@@ -17,5 +17,11 @@
       packageNames: ['test'],
       enabled: false,
     },
+
+    // https://github.com/netlify/zip-it-and-ship-it/pull/966
+    {
+      matchPackageNames: ['@babel/parser'],
+      allowedVersions: '<=7.16.8',
+    },
   ],
 }


### PR DESCRIPTION
Reinstates https://github.com/netlify/zip-it-and-ship-it/pull/966, which was reverted by Renovate.

Also adds a rule to the Renovate config to prevent this from happening again.