### PR TITLE
feat: adds `getNodeVersion` util

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,13 +11,14 @@ module.exports = {
       },
     },
     {
-      files: 'tests/*.js',
+      files: 'tests/**/*.js',
       rules: {
         'import/max-dependencies': 'off',
         'import/no-dynamic-require': 'off',
         'max-lines-per-function': 'off',
         'max-statements': 'off',
         'node/global-require': 'off',
+        'no-magic-numbers': 'off',
       },
     },
   ],

--- a/package.json
+++ b/package.json
@@ -112,7 +112,8 @@
   },
   "ava": {
     "files": [
-      "tests/*"
+      "tests/*",
+      "tests/unit/**/*.js"
     ],
     "verbose": true,
     "timeout": "2m"

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,11 +2,7 @@ import mergeOptions from 'merge-options'
 import minimatch from 'minimatch'
 
 import { FunctionSource } from './function'
-import type { NodeBundlerName } from './runtimes/node'
-
-// eslint-disable-next-line no-magic-numbers
-type SupportedVersionNumbers = 8 | 10 | 12 | 14
-type NodeVersion = `${SupportedVersionNumbers}.x` | `nodejs${SupportedVersionNumbers}.x`
+import type { NodeBundlerName, NodeVersion } from './runtimes/node'
 
 interface FunctionConfig {
   externalNodeModules?: string[]

--- a/src/runtimes/node/index.ts
+++ b/src/runtimes/node/index.ts
@@ -13,6 +13,7 @@ import { createAliases as createPluginsModulesPathAliases, getPluginsModulesPath
 import { zipNodeJs } from './utils/zip'
 
 export type NodeBundlerName = 'esbuild' | 'esbuild_zisi' | 'nft' | 'zisi'
+export { NodeVersion } from './utils/node_version'
 
 // We use ZISI as the default bundler, except for certain extensions, for which
 // esbuild is the only option.

--- a/src/runtimes/node/utils/node_version.ts
+++ b/src/runtimes/node/utils/node_version.ts
@@ -1,0 +1,33 @@
+// eslint-disable-next-line no-magic-numbers
+type SupportedVersionNumbers = 8 | 10 | 12 | 14
+type NodeVersion = `${SupportedVersionNumbers}.x` | `nodejs${SupportedVersionNumbers}.x`
+
+// Must match the default version used in Bitballoon.
+const DEFAULT_NODE_VERSION = 14
+const VERSION_REGEX = /(nodejs)?(\d+)\.x/
+
+const getNodeVersion = (configVersion?: string) => parseVersion(configVersion) ?? DEFAULT_NODE_VERSION
+
+// Takes a string in the format defined by the `NodeVersion` type and returns
+// the numeric major version (e.g. "nodejs14.x" => 14).
+const parseVersion = (input: string | undefined) => {
+  if (input === undefined) {
+    return
+  }
+
+  const match = input.match(VERSION_REGEX)
+
+  if (match === null) {
+    return
+  }
+
+  const version = Number.parseInt(match[2])
+
+  if (Number.isNaN(version)) {
+    return
+  }
+
+  return version
+}
+
+export { DEFAULT_NODE_VERSION, getNodeVersion, parseVersion, NodeVersion }

--- a/tests/main.js
+++ b/tests/main.js
@@ -2200,7 +2200,6 @@ test.serial('Builds Rust functions from source if the `buildRustSource` feature 
   })
 
   t.is(files.length, 2)
-  // eslint-disable-next-line no-magic-numbers
   t.is(shellUtilsStub.callCount, 4)
 
   const { args: call1 } = shellUtilsStub.getCall(0)

--- a/tests/unit/runtimes/node/utils/node_version.js
+++ b/tests/unit/runtimes/node/utils/node_version.js
@@ -1,0 +1,12 @@
+const test = require('ava')
+
+const { getNodeVersion, DEFAULT_NODE_VERSION } = require('../../../../../dist/runtimes/node/utils/node_version')
+
+test('getNodeVersion', (t) => {
+  t.is(getNodeVersion('nodejs12.x'), 12)
+  t.is(getNodeVersion('nodejs8.x'), 8)
+  t.is(getNodeVersion('12.x'), 12)
+  t.is(getNodeVersion('8.x'), 8)
+  t.is(getNodeVersion('node14'), DEFAULT_NODE_VERSION)
+  t.is(getNodeVersion(':shrug'), DEFAULT_NODE_VERSION)
+})

--- a/tests/unit/runtimes/node/utils/node_version.js
+++ b/tests/unit/runtimes/node/utils/node_version.js
@@ -1,6 +1,10 @@
 const test = require('ava')
 
-const { getNodeVersion, DEFAULT_NODE_VERSION } = require('../../../../../dist/runtimes/node/utils/node_version')
+const {
+  DEFAULT_NODE_VERSION,
+  getNodeVersion,
+  parseVersion,
+} = require('../../../../../dist/runtimes/node/utils/node_version')
 
 test('getNodeVersion', (t) => {
   t.is(getNodeVersion('nodejs12.x'), 12)
@@ -8,5 +12,14 @@ test('getNodeVersion', (t) => {
   t.is(getNodeVersion('12.x'), 12)
   t.is(getNodeVersion('8.x'), 8)
   t.is(getNodeVersion('node14'), DEFAULT_NODE_VERSION)
-  t.is(getNodeVersion(':shrug'), DEFAULT_NODE_VERSION)
+  t.is(getNodeVersion(':shrug:'), DEFAULT_NODE_VERSION)
+})
+
+test('parseVersion', (t) => {
+  t.is(parseVersion('nodejs12.x'), 12)
+  t.is(parseVersion('nodejs8.x'), 8)
+  t.is(parseVersion('12.x'), 12)
+  t.is(parseVersion('8.x'), 8)
+  t.is(parseVersion('node14'), undefined)
+  t.is(parseVersion(':shrug:'), undefined)
 })

--- a/tests/unit/runtimes/node/utils/package_json.js
+++ b/tests/unit/runtimes/node/utils/package_json.js
@@ -1,6 +1,6 @@
 const test = require('ava')
 
-const { sanitisePackageJson } = require('../dist/runtimes/node/utils/package_json')
+const { sanitisePackageJson } = require('../../../../../dist/runtimes/node/utils/package_json')
 
 test('sanitisePackageJson', (t) => {
   t.deepEqual(


### PR DESCRIPTION
Also moves unit tests into separate files under a `test/unit` directory, matching the file structure of the files being unit-tested.