### PR TITLE
feat: generate pure ESM functions for NFT

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,8 @@ import mergeOptions from 'merge-options'
 import minimatch from 'minimatch'
 
 import { FunctionSource } from './function'
-import type { NodeBundlerName, NodeVersion } from './runtimes/node'
+import type { NodeVersionString } from './runtimes/node'
+import type { NodeBundlerName } from './runtimes/node/bundlers'
 
 interface FunctionConfig {
   externalNodeModules?: string[]
@@ -11,7 +12,7 @@ interface FunctionConfig {
   ignoredNodeModules?: string[]
   nodeBundler?: NodeBundlerName
   nodeSourcemap?: boolean
-  nodeVersion?: NodeVersion
+  nodeVersion?: NodeVersionString
   processDynamicNodeImports?: boolean
   rustTargetDirectory?: string
   schedule?: string

--- a/src/feature_flags.ts
+++ b/src/feature_flags.ts
@@ -6,6 +6,7 @@ const FLAGS: Record<string, boolean> = {
   defaultEsModulesToEsbuild: Boolean(env.NETLIFY_EXPERIMENTAL_DEFAULT_ES_MODULES_TO_ESBUILD),
   parseWithEsbuild: false,
   traceWithNft: false,
+  zisi_pure_esm: false,
 }
 
 type FeatureFlag = keyof typeof FLAGS

--- a/src/runtimes/node/bundlers/esbuild/bundler.ts
+++ b/src/runtimes/node/bundlers/esbuild/bundler.ts
@@ -3,7 +3,7 @@ import { basename, dirname, extname, resolve, join } from 'path'
 import { build, Metafile } from '@netlify/esbuild'
 import { tmpName } from 'tmp-promise'
 
-import type { NodeBundlerName } from '../..'
+import type { NodeBundlerName } from '..'
 import type { FunctionConfig } from '../../../../config'
 import { getPathWithExtension, safeUnlink } from '../../../../utils/fs'
 import type { RuntimeName } from '../../../runtime'

--- a/src/runtimes/node/bundlers/esbuild/index.ts
+++ b/src/runtimes/node/bundlers/esbuild/index.ts
@@ -122,6 +122,7 @@ const bundle: BundleFunction = async ({
     bundlerWarnings,
     inputs,
     mainFile: normalizedMainFile,
+    moduleFormat: 'cjs',
     nativeNodeModules,
     nodeModulesWithDynamicImports,
     srcFiles: [...supportingSrcFiles, ...bundlePaths.keys()],

--- a/src/runtimes/node/bundlers/index.ts
+++ b/src/runtimes/node/bundlers/index.ts
@@ -1,13 +1,17 @@
 import type { Message } from '@netlify/esbuild'
 
-import type { NodeBundlerName } from '..'
 import { FunctionConfig } from '../../../config'
 import { FeatureFlag, FeatureFlags } from '../../../feature_flags'
 import { FunctionSource } from '../../../function'
+import { detectEsModule } from '../utils/detect_es_module'
+import { ModuleFormat } from '../utils/module_format'
+import { NodeVersionString } from '../utils/node_version'
 
 import esbuildBundler from './esbuild'
 import nftBundler from './nft'
 import zisiBundler from './zisi'
+
+export type NodeBundlerName = 'esbuild' | 'esbuild_zisi' | 'nft' | 'zisi'
 
 // TODO: Create a generic warning type
 type BundlerWarning = Message
@@ -49,6 +53,7 @@ type BundleFunction = (
   cleanupFunction?: CleanupFunction
   inputs: string[]
   mainFile: string
+  moduleFormat: ModuleFormat
   nativeNodeModules?: NativeNodeModules
   nodeModulesWithDynamicImports?: string[]
   srcFiles: string[]
@@ -86,5 +91,37 @@ const getBundler = (name: NodeBundlerName): NodeBundler => {
   }
 }
 
-export { getBundler }
+// We use ZISI as the default bundler, except for certain extensions, for which
+// esbuild is the only option.
+const getDefaultBundler = async ({
+  extension,
+  mainFile,
+  featureFlags,
+}: {
+  extension: string
+  mainFile: string
+  featureFlags: FeatureFlags
+}): Promise<NodeBundlerName> => {
+  const { defaultEsModulesToEsbuild, traceWithNft } = featureFlags
+
+  if (['.mjs', '.ts'].includes(extension)) {
+    return 'esbuild'
+  }
+
+  if (traceWithNft) {
+    return 'nft'
+  }
+
+  if (defaultEsModulesToEsbuild) {
+    const isEsModule = await detectEsModule({ mainFile })
+
+    if (isEsModule) {
+      return 'esbuild'
+    }
+  }
+
+  return 'zisi'
+}
+
+export { getBundler, getDefaultBundler }
 export type { BundleFunction, GetSrcFilesFunction, NativeNodeModules }

--- a/src/runtimes/node/bundlers/index.ts
+++ b/src/runtimes/node/bundlers/index.ts
@@ -5,7 +5,6 @@ import { FeatureFlag, FeatureFlags } from '../../../feature_flags'
 import { FunctionSource } from '../../../function'
 import { detectEsModule } from '../utils/detect_es_module'
 import { ModuleFormat } from '../utils/module_format'
-import { NodeVersionString } from '../utils/node_version'
 
 import esbuildBundler from './esbuild'
 import nftBundler from './nft'

--- a/src/runtimes/node/bundlers/nft/es_modules.ts
+++ b/src/runtimes/node/bundlers/nft/es_modules.ts
@@ -3,6 +3,7 @@ import { basename, dirname, resolve } from 'path'
 import { NodeFileTraceReasons } from '@vercel/nft'
 
 import type { FunctionConfig } from '../../../../config'
+import { FeatureFlags } from '../../../../feature_flags'
 import { cachedReadFile, FsCache } from '../../../../utils/fs'
 import { ModuleFormat } from '../../utils/module_format'
 import { getNodeSupportMatrix } from '../../utils/node_version'
@@ -51,6 +52,7 @@ const processESM = async ({
   basePath,
   config,
   esmPaths,
+  featureFlags,
   fsCache,
   mainFile,
   reasons,
@@ -58,6 +60,7 @@ const processESM = async ({
   basePath: string | undefined
   config: FunctionConfig
   esmPaths: Set<string>
+  featureFlags: FeatureFlags
   fsCache: FsCache
   mainFile: string
   reasons: NodeFileTraceReasons
@@ -73,7 +76,7 @@ const processESM = async ({
   const packageJson = await getPackageJson(dirname(mainFile))
   const nodeSupport = getNodeSupportMatrix(config.nodeVersion)
 
-  if (packageJson.type === 'module' && nodeSupport.esm) {
+  if (featureFlags.zisi_pure_esm && packageJson.type === 'module' && nodeSupport.esm) {
     return {
       moduleFormat: 'esm',
     }

--- a/src/runtimes/node/bundlers/nft/index.ts
+++ b/src/runtimes/node/bundlers/nft/index.ts
@@ -7,6 +7,7 @@ import unixify from 'unixify'
 
 import type { BundleFunction } from '..'
 import type { FunctionConfig } from '../../../../config'
+import { FeatureFlags } from '../../../../feature_flags'
 import { cachedReadFile, FsCache } from '../../../../utils/fs'
 import type { GetSrcFilesFunction } from '../../../runtime'
 import { getBasePath } from '../../utils/base_path'
@@ -22,6 +23,7 @@ const appearsToBeModuleName = (name: string) => !name.startsWith('.')
 const bundle: BundleFunction = async ({
   basePath,
   config,
+  featureFlags,
   mainFile,
   pluginsModulesPath,
   repositoryRoot = basePath,
@@ -38,6 +40,7 @@ const bundle: BundleFunction = async ({
   } = await traceFilesAndTranspile({
     basePath: repositoryRoot,
     config,
+    featureFlags,
     mainFile,
     pluginsModulesPath,
   })
@@ -67,11 +70,13 @@ const ignoreFunction = (path: string) => {
 const traceFilesAndTranspile = async function ({
   basePath,
   config,
+  featureFlags,
   mainFile,
   pluginsModulesPath,
 }: {
   basePath?: string
   config: FunctionConfig
+  featureFlags: FeatureFlags
   mainFile: string
   pluginsModulesPath?: string
 }) {
@@ -120,6 +125,7 @@ const traceFilesAndTranspile = async function ({
     basePath,
     config,
     esmPaths: esmFileList,
+    featureFlags,
     fsCache,
     mainFile,
     reasons,

--- a/src/runtimes/node/bundlers/zisi/index.ts
+++ b/src/runtimes/node/bundlers/zisi/index.ts
@@ -42,6 +42,7 @@ const bundle: BundleFunction = async ({
     basePath: getBasePath(dirnames),
     inputs: srcFiles,
     mainFile,
+    moduleFormat: 'cjs',
     srcFiles,
   }
 }

--- a/src/runtimes/node/bundlers/zisi/list_imports.ts
+++ b/src/runtimes/node/bundlers/zisi/list_imports.ts
@@ -2,7 +2,7 @@ import * as esbuild from '@netlify/esbuild'
 import isBuiltinModule from 'is-builtin-module'
 import { tmpName } from 'tmp-promise'
 
-import type { NodeBundlerName } from '../..'
+import type { NodeBundlerName } from '..'
 import { safeUnlink } from '../../../../utils/fs'
 import type { RuntimeName } from '../../../runtime'
 

--- a/src/runtimes/node/index.ts
+++ b/src/runtimes/node/index.ts
@@ -7,7 +7,6 @@ import { GetSrcFilesFunction, Runtime, ZipFunction } from '../runtime'
 import { getBundler, getDefaultBundler } from './bundlers'
 import { findFunctionsInPaths, findFunctionInPath } from './finder'
 import { findISCDeclarationsInPath } from './in_source_config'
-import { getNodeVersion } from './utils/node_version'
 import { createAliases as createPluginsModulesPathAliases, getPluginsModulesPath } from './utils/plugin_modules_path'
 import { zipNodeJs } from './utils/zip'
 

--- a/src/runtimes/node/index.ts
+++ b/src/runtimes/node/index.ts
@@ -2,50 +2,16 @@ import { join } from 'path'
 
 import cpFile from 'cp-file'
 
-import { FeatureFlags } from '../../feature_flags'
 import { GetSrcFilesFunction, Runtime, ZipFunction } from '../runtime'
 
-import { getBundler } from './bundlers'
+import { getBundler, getDefaultBundler } from './bundlers'
 import { findFunctionsInPaths, findFunctionInPath } from './finder'
 import { findISCDeclarationsInPath } from './in_source_config'
-import { detectEsModule } from './utils/detect_es_module'
+import { getNodeVersion } from './utils/node_version'
 import { createAliases as createPluginsModulesPathAliases, getPluginsModulesPath } from './utils/plugin_modules_path'
 import { zipNodeJs } from './utils/zip'
 
-export type NodeBundlerName = 'esbuild' | 'esbuild_zisi' | 'nft' | 'zisi'
-export { NodeVersion } from './utils/node_version'
-
-// We use ZISI as the default bundler, except for certain extensions, for which
-// esbuild is the only option.
-const getDefaultBundler = async ({
-  extension,
-  mainFile,
-  featureFlags,
-}: {
-  extension: string
-  mainFile: string
-  featureFlags: FeatureFlags
-}): Promise<NodeBundlerName> => {
-  const { defaultEsModulesToEsbuild, traceWithNft } = featureFlags
-
-  if (['.mjs', '.ts'].includes(extension)) {
-    return 'esbuild'
-  }
-
-  if (traceWithNft) {
-    return 'nft'
-  }
-
-  if (defaultEsModulesToEsbuild) {
-    const isEsModule = await detectEsModule({ mainFile })
-
-    if (isEsModule) {
-      return 'esbuild'
-    }
-  }
-
-  return 'zisi'
-}
+export { NodeVersionString } from './utils/node_version'
 
 // A proxy for the `getSrcFiles` function which adds a default `bundler` using
 // the `getDefaultBundler` function.
@@ -98,6 +64,7 @@ const zipFunction: ZipFunction = async function ({
     bundlerWarnings,
     inputs,
     mainFile: finalMainFile = mainFile,
+    moduleFormat,
     nativeNodeModules,
     nodeModulesWithDynamicImports,
     rewrites,
@@ -130,6 +97,7 @@ const zipFunction: ZipFunction = async function ({
     extension,
     filename,
     mainFile: finalMainFile,
+    moduleFormat,
     rewrites,
     srcFiles,
   })

--- a/src/runtimes/node/utils/entry_file.ts
+++ b/src/runtimes/node/utils/entry_file.ts
@@ -1,0 +1,45 @@
+import { basename, extname } from 'path'
+
+import type { ModuleFormat } from './module_format'
+import { normalizeFilePath } from './normalize_path'
+
+interface EntryFile {
+  contents: string
+  filename: string
+}
+
+const getEntryFileContents = (mainPath: string, moduleFormat: string) => {
+  const importPath = `.${mainPath.startsWith('/') ? mainPath : `/${mainPath}`}`
+
+  if (moduleFormat === 'cjs') {
+    return `module.exports = require('${importPath}')`
+  }
+
+  return `export { handler } from '${importPath}'`
+}
+
+const getEntryFile = ({
+  commonPrefix,
+  filename,
+  mainFile,
+  moduleFormat,
+  userNamespace,
+}: {
+  commonPrefix: string
+  filename: string
+  mainFile: string
+  moduleFormat: ModuleFormat
+  userNamespace: string
+}): EntryFile => {
+  const mainPath = normalizeFilePath({ commonPrefix, path: mainFile, userNamespace })
+  const extension = extname(filename)
+  const entryFilename = `${basename(filename, extension)}.js`
+  const contents = getEntryFileContents(mainPath, moduleFormat)
+
+  return {
+    contents,
+    filename: entryFilename,
+  }
+}
+
+export { EntryFile, getEntryFile }

--- a/src/runtimes/node/utils/module_format.ts
+++ b/src/runtimes/node/utils/module_format.ts
@@ -1,0 +1,1 @@
+export type ModuleFormat = 'cjs' | 'esm'

--- a/src/runtimes/node/utils/node_version.ts
+++ b/src/runtimes/node/utils/node_version.ts
@@ -42,5 +42,12 @@ const parseVersion = (input: string | undefined) => {
   return version
 }
 
-export { getNodeSupportMatrix, getNodeVersion, NodeVersionString, NodeVersionSupport }
+export {
+  DEFAULT_NODE_VERSION,
+  getNodeSupportMatrix,
+  getNodeVersion,
+  NodeVersionString,
+  NodeVersionSupport,
+  parseVersion,
+}
 /* eslint-enable no-magic-numbers */

--- a/src/runtimes/node/utils/node_version.ts
+++ b/src/runtimes/node/utils/node_version.ts
@@ -1,12 +1,24 @@
-// eslint-disable-next-line no-magic-numbers
+/* eslint-disable no-magic-numbers */
 type SupportedVersionNumbers = 8 | 10 | 12 | 14
-type NodeVersion = `${SupportedVersionNumbers}.x` | `nodejs${SupportedVersionNumbers}.x`
+type NodeVersionString = `${SupportedVersionNumbers}.x` | `nodejs${SupportedVersionNumbers}.x`
+
+interface NodeVersionSupport {
+  esm: boolean
+}
 
 // Must match the default version used in Bitballoon.
 const DEFAULT_NODE_VERSION = 14
 const VERSION_REGEX = /(nodejs)?(\d+)\.x/
 
 const getNodeVersion = (configVersion?: string) => parseVersion(configVersion) ?? DEFAULT_NODE_VERSION
+
+const getNodeSupportMatrix = (configVersion?: string): NodeVersionSupport => {
+  const versionNumber = getNodeVersion(configVersion)
+
+  return {
+    esm: versionNumber >= 14,
+  }
+}
 
 // Takes a string in the format defined by the `NodeVersion` type and returns
 // the numeric major version (e.g. "nodejs14.x" => 14).
@@ -30,4 +42,5 @@ const parseVersion = (input: string | undefined) => {
   return version
 }
 
-export { DEFAULT_NODE_VERSION, getNodeVersion, parseVersion, NodeVersion }
+export { getNodeSupportMatrix, getNodeVersion, NodeVersionString, NodeVersionSupport }
+/* eslint-enable no-magic-numbers */

--- a/src/runtimes/node/utils/normalize_path.ts
+++ b/src/runtimes/node/utils/normalize_path.ts
@@ -1,0 +1,24 @@
+import { normalize, sep } from 'path'
+
+import unixify from 'unixify'
+
+// `adm-zip` and `require()` expect Unix paths.
+// We remove the common path prefix.
+// With files on different Windows drives, we remove the drive letter.
+const normalizeFilePath = function ({
+  commonPrefix,
+  path,
+  userNamespace,
+}: {
+  commonPrefix: string
+  path: string
+  userNamespace: string
+}) {
+  const userNamespacePathSegment = userNamespace ? `${userNamespace}${sep}` : ''
+  const pathA = normalize(path)
+  const pathB = pathA.replace(commonPrefix, userNamespacePathSegment)
+  const pathC = unixify(pathB)
+  return pathC
+}
+
+export { normalizeFilePath }

--- a/src/runtimes/runtime.ts
+++ b/src/runtimes/runtime.ts
@@ -4,7 +4,7 @@ import { FeatureFlags } from '../feature_flags'
 import { FunctionSource, SourceFile } from '../function'
 import { FsCache } from '../utils/fs'
 
-import type { NodeBundlerName } from './node'
+import type { NodeBundlerName } from './node/bundlers'
 import type { ISCValues } from './node/in_source_config'
 
 type RuntimeName = 'go' | 'js' | 'rs'

--- a/tests/fixtures/node-esm/func1.js
+++ b/tests/fixtures/node-esm/func1.js
@@ -1,0 +1,1 @@
+export const handler = () => true

--- a/tests/fixtures/node-esm/func2/func2.js
+++ b/tests/fixtures/node-esm/func2/func2.js
@@ -1,0 +1,1 @@
+export const handler = () => true

--- a/tests/fixtures/node-esm/package.json
+++ b/tests/fixtures/node-esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/tests/main.js
+++ b/tests/main.js
@@ -543,32 +543,69 @@ testMany(
   },
 )
 
-testMany('Can bundle native ESM functions when the Node version is >=14', ['bundler_nft'], async (options, t) => {
-  const length = 2
-  const fixtureName = 'node-esm'
-  const opts = merge(options, {
-    basePath: `${FIXTURES_DIR}/${fixtureName}`,
-  })
-  const { files, tmpDir } = await zipFixture(t, fixtureName, {
-    length,
-    opts,
-  })
+testMany(
+  'Can bundle native ESM functions when the Node version is >=14 and the `zisi_pure_esm` flag is on',
+  ['bundler_nft'],
+  async (options, t) => {
+    const length = 2
+    const fixtureName = 'node-esm'
+    const opts = merge(options, {
+      basePath: `${FIXTURES_DIR}/${fixtureName}`,
+      featureFlags: { zisi_pure_esm: true },
+    })
+    const { files, tmpDir } = await zipFixture(t, fixtureName, {
+      length,
+      opts,
+    })
 
-  await unzipFiles(files, (path) => `${path}/../${basename(path)}_out`)
+    await unzipFiles(files, (path) => `${path}/../${basename(path)}_out`)
 
-  const functionPaths = [join(tmpDir, 'func1.zip_out', 'func1.js'), join(tmpDir, 'func2.zip_out', 'func2.js')]
-  const func1 = await import(functionPaths[0])
-  const func2 = await import(functionPaths[1])
+    const functionPaths = [join(tmpDir, 'func1.zip_out', 'func1.js'), join(tmpDir, 'func2.zip_out', 'func2.js')]
+    const func1 = await import(functionPaths[0])
+    const func2 = await import(functionPaths[1])
 
-  t.true(func1.handler())
-  t.true(func2.handler())
+    t.true(func1.handler())
+    t.true(func2.handler())
 
-  const functionsAreESM = await Promise.all(
-    functionPaths.map((functionPath) => detectEsModule({ mainFile: functionPath })),
-  )
+    const functionsAreESM = await Promise.all(
+      functionPaths.map((functionPath) => detectEsModule({ mainFile: functionPath })),
+    )
 
-  t.true(functionsAreESM.every(Boolean))
-})
+    t.true(functionsAreESM.every(Boolean))
+  },
+)
+
+testMany(
+  'Can bundle ESM functions and transpile them to CJS when the Node version is >=14 and the `zisi_pure_esm` flag is on',
+  ['bundler_nft'],
+  async (options, t) => {
+    const length = 2
+    const fixtureName = 'node-esm'
+    const opts = merge(options, {
+      basePath: `${FIXTURES_DIR}/${fixtureName}`,
+      featureFlags: { zisi_pure_esm: true },
+    })
+    const { files, tmpDir } = await zipFixture(t, fixtureName, {
+      length,
+      opts,
+    })
+
+    await unzipFiles(files, (path) => `${path}/../${basename(path)}_out`)
+
+    const functionPaths = [join(tmpDir, 'func1.zip_out', 'func1.js'), join(tmpDir, 'func2.zip_out', 'func2.js')]
+    const func1 = await import(functionPaths[0])
+    const func2 = await import(functionPaths[1])
+
+    t.true(func1.handler())
+    t.true(func2.handler())
+
+    const functionsAreESM = await Promise.all(
+      functionPaths.map((functionPath) => detectEsModule({ mainFile: functionPath })),
+    )
+
+    t.true(functionsAreESM.every(Boolean))
+  },
+)
 
 testMany(
   'Can require local files deeply',

--- a/tests/main.js
+++ b/tests/main.js
@@ -29,6 +29,7 @@ const shellUtilsStub = sinon.stub(shellUtils, 'runCommand')
 const { zipFunction, listFunctions, listFunctionsFiles, listFunction } = require('..')
 
 const { ESBUILD_LOG_LIMIT } = require('../dist/runtimes/node/bundlers/esbuild/bundler')
+const { detectEsModule } = require('../dist/runtimes/node/utils/detect_es_module')
 
 const { getRequires, zipNode, zipFixture, unzipFiles, zipCheckFunctions, FIXTURES_DIR } = require('./helpers/main')
 const { computeSha1 } = require('./helpers/sha')
@@ -419,26 +420,44 @@ testMany(
 )
 
 testMany(
-  'Can bundle functions with `.js` extension using ES Modules',
-  ['bundler_esbuild', 'bundler_nft'],
+  'Can bundle ESM functions and transpile them to CJS when the Node version is <14',
+  ['bundler_nft'],
   async (options, t) => {
     const length = 4
     const fixtureName = 'local-require-esm'
     const opts = merge(options, {
       basePath: `${FIXTURES_DIR}/${fixtureName}`,
+      config: {
+        '*': {
+          nodeVersion: 'nodejs12.x',
+        },
+      },
       featureFlags: { defaultEsModulesToEsbuild: false },
     })
-    const { files, tmpDir } = await zipFixture(t, 'local-require-esm', {
+    const { files, tmpDir } = await zipFixture(t, fixtureName, {
       length,
       opts,
     })
 
     await unzipFiles(files, (path) => `${path}/../${basename(path)}_out`)
 
-    const func1 = () => require(join(tmpDir, 'function.zip_out', 'function.js'))
-    const func2 = () => require(join(tmpDir, 'function_cjs.zip_out', 'function_cjs.js'))
-    const func3 = () => require(join(tmpDir, 'function_export_only.zip_out', 'function_export_only.js'))
-    const func4 = () => require(join(tmpDir, 'function_import_only.zip_out', 'function_import_only.js'))
+    const functionPaths = [
+      join(tmpDir, 'function.zip_out', 'function.js'),
+      join(tmpDir, 'function_cjs.zip_out', 'function_cjs.js'),
+      join(tmpDir, 'function_export_only.zip_out', 'function_export_only.js'),
+      join(tmpDir, 'function_import_only.zip_out', 'function_import_only.js'),
+    ]
+    const func1 = () => require(functionPaths[0])
+    const func2 = () => require(functionPaths[1])
+    const func3 = () => require(functionPaths[2])
+    const func4 = () => require(functionPaths[3])
+
+    const functionsAreESM = await Promise.all(
+      functionPaths.map((functionPath) => detectEsModule({ mainFile: functionPath })),
+    )
+
+    // None of the functions should be ESM since we're transpiling them to CJS.
+    t.false(functionsAreESM.some(Boolean))
 
     // Dynamic imports are not supported in Node <13.2.0.
     if (semver.gte(nodeVersion, '13.2.0')) {
@@ -452,7 +471,7 @@ testMany(
 )
 
 testMany(
-  'Can bundle functions with `.js` extension using ES Modules when `archiveType` is `none`',
+  'Can bundle ESM functions and transpile them to CJS when the Node version is <14 and `archiveType` is `none`',
   ['bundler_esbuild', 'bundler_nft'],
   async (options, t) => {
     const length = 4
@@ -460,17 +479,35 @@ testMany(
     const opts = merge(options, {
       archiveFormat: 'none',
       basePath: `${FIXTURES_DIR}/${fixtureName}`,
+      config: {
+        '*': {
+          nodeVersion: 'nodejs12.x',
+        },
+      },
       featureFlags: { defaultEsModulesToEsbuild: false },
     })
-    const { tmpDir } = await zipFixture(t, 'local-require-esm', {
+    const { tmpDir } = await zipFixture(t, fixtureName, {
       length,
       opts,
     })
 
-    const func1 = () => require(join(tmpDir, 'function', 'function.js'))
-    const func2 = () => require(join(tmpDir, 'function_cjs', 'function_cjs.js'))
-    const func3 = () => require(join(tmpDir, 'function_export_only', 'function_export_only.js'))
-    const func4 = () => require(join(tmpDir, 'function_import_only', 'function_import_only.js'))
+    const functionPaths = [
+      join(tmpDir, 'function', 'function.js'),
+      join(tmpDir, 'function_cjs', 'function_cjs.js'),
+      join(tmpDir, 'function_export_only', 'function_export_only.js'),
+      join(tmpDir, 'function_import_only', 'function_import_only.js'),
+    ]
+    const func1 = () => require(functionPaths[0])
+    const func2 = () => require(functionPaths[1])
+    const func3 = () => require(functionPaths[2])
+    const func4 = () => require(functionPaths[3])
+
+    const functionsAreESM = await Promise.all(
+      functionPaths.map((functionPath) => detectEsModule({ mainFile: functionPath })),
+    )
+
+    // None of the functions should be ESM since we're transpiling them to CJS.
+    t.false(functionsAreESM.some(Boolean))
 
     // Dynamic imports are not supported in Node <13.2.0.
     if (semver.gte(nodeVersion, '13.2.0')) {
@@ -505,6 +542,33 @@ testMany(
     }
   },
 )
+
+testMany('Can bundle native ESM functions when the Node version is >=14', ['bundler_nft'], async (options, t) => {
+  const length = 2
+  const fixtureName = 'node-esm'
+  const opts = merge(options, {
+    basePath: `${FIXTURES_DIR}/${fixtureName}`,
+  })
+  const { files, tmpDir } = await zipFixture(t, fixtureName, {
+    length,
+    opts,
+  })
+
+  await unzipFiles(files, (path) => `${path}/../${basename(path)}_out`)
+
+  const functionPaths = [join(tmpDir, 'func1.zip_out', 'func1.js'), join(tmpDir, 'func2.zip_out', 'func2.js')]
+  const func1 = await import(functionPaths[0])
+  const func2 = await import(functionPaths[1])
+
+  t.true(func1.handler())
+  t.true(func2.handler())
+
+  const functionsAreESM = await Promise.all(
+    functionPaths.map((functionPath) => detectEsModule({ mainFile: functionPath })),
+  )
+
+  t.true(functionsAreESM.every(Boolean))
+})
 
 testMany(
   'Can require local files deeply',

--- a/tests/main.js
+++ b/tests/main.js
@@ -2,6 +2,7 @@ const { mkdir, readFile, chmod, symlink, unlink, rename, stat, writeFile } = req
 const { tmpdir } = require('os')
 const { basename, dirname, isAbsolute, join, normalize, resolve, sep } = require('path')
 const { arch, env, platform, version: nodeVersion } = require('process')
+const { pathToFileURL } = require('url')
 
 const test = require('ava')
 const cpy = require('cpy')
@@ -561,8 +562,8 @@ testMany(
     await unzipFiles(files, (path) => `${path}/../${basename(path)}_out`)
 
     const functionPaths = [join(tmpDir, 'func1.zip_out', 'func1.js'), join(tmpDir, 'func2.zip_out', 'func2.js')]
-    const func1 = await import(functionPaths[0])
-    const func2 = await import(functionPaths[1])
+    const func1 = await import(pathToFileURL(functionPaths[0]))
+    const func2 = await import(pathToFileURL(functionPaths[1]))
 
     t.true(func1.handler())
     t.true(func2.handler())
@@ -576,14 +577,13 @@ testMany(
 )
 
 testMany(
-  'Can bundle ESM functions and transpile them to CJS when the Node version is >=14 and the `zisi_pure_esm` flag is on',
+  'Can bundle ESM functions and transpile them to CJS when the Node version is >=14 and the `zisi_pure_esm` flag is off',
   ['bundler_nft'],
   async (options, t) => {
     const length = 2
     const fixtureName = 'node-esm'
     const opts = merge(options, {
       basePath: `${FIXTURES_DIR}/${fixtureName}`,
-      featureFlags: { zisi_pure_esm: true },
     })
     const { files, tmpDir } = await zipFixture(t, fixtureName, {
       length,
@@ -593,8 +593,8 @@ testMany(
     await unzipFiles(files, (path) => `${path}/../${basename(path)}_out`)
 
     const functionPaths = [join(tmpDir, 'func1.zip_out', 'func1.js'), join(tmpDir, 'func2.zip_out', 'func2.js')]
-    const func1 = await import(functionPaths[0])
-    const func2 = await import(functionPaths[1])
+    const func1 = await import(pathToFileURL(functionPaths[0]))
+    const func2 = await import(pathToFileURL(functionPaths[1]))
 
     t.true(func1.handler())
     t.true(func2.handler())
@@ -603,7 +603,7 @@ testMany(
       functionPaths.map((functionPath) => detectEsModule({ mainFile: functionPath })),
     )
 
-    t.true(functionsAreESM.every(Boolean))
+    t.false(functionsAreESM.some(Boolean))
   },
 )
 


### PR DESCRIPTION
#### Summary

As of last month, AWS Lambda [supports native ESM functions](https://aws.amazon.com/blogs/compute/using-node-js-es-modules-and-top-level-await-in-aws-lambda/). Currently, we're unable to take advantage of this functionality since zip-it-and-ship-it always generates CJS functions.

This PR starts changing that by generating pure ESM functions when all of the following conditions are met:

- The bundler is NFT
- The Node.js version (supplied via the `nodeVersion` configuration property) is greater than or equal to Node 14
- The `zisi_pure_esm` feature flag is enabled

In any other scenario, zip-it-and-ship-it continues to transpile ESM and generate CJS functions.