### PR TITLE
fix: guard against self-referencing element in `shouldTranspile`

### DIFF
--- a/src/runtimes/node/bundlers/nft/es_modules.ts
+++ b/src/runtimes/node/bundlers/nft/es_modules.ts
@@ -127,7 +127,7 @@ const shouldTranspile = (
 
   // The path should be transpiled if every parent will also be transpiled, or
   // if there is no parent.
-  const shouldTranspilePath = [...parents].every((parentPath) => shouldTranspile(parentPath, cache, esmPaths, reasons))
+  const shouldTranspilePath = parentPaths.every((parentPath) => shouldTranspile(parentPath, cache, esmPaths, reasons))
 
   cache.set(path, shouldTranspilePath)
 

--- a/src/runtimes/node/bundlers/nft/es_modules.ts
+++ b/src/runtimes/node/bundlers/nft/es_modules.ts
@@ -114,9 +114,10 @@ const shouldTranspile = (
   }
 
   const { parents } = reason
+  const parentPaths = [...parents].filter((parentPath) => parentPath !== path)
 
   // If the path is an entrypoint, we transpile it only if it's an ESM file.
-  if (parents.size === 0) {
+  if (parentPaths.length === 0) {
     const isESM = esmPaths.has(path)
 
     cache.set(path, isESM)
@@ -126,9 +127,7 @@ const shouldTranspile = (
 
   // The path should be transpiled if every parent will also be transpiled, or
   // if there is no parent.
-  const shouldTranspilePath = [...parents]
-    .filter((parentPath) => parentPath !== path)
-    .every((parentPath) => shouldTranspile(parentPath, cache, esmPaths, reasons))
+  const shouldTranspilePath = [...parents].every((parentPath) => shouldTranspile(parentPath, cache, esmPaths, reasons))
 
   cache.set(path, shouldTranspilePath)
 

--- a/src/runtimes/node/bundlers/nft/es_modules.ts
+++ b/src/runtimes/node/bundlers/nft/es_modules.ts
@@ -126,7 +126,9 @@ const shouldTranspile = (
 
   // The path should be transpiled if every parent will also be transpiled, or
   // if there is no parent.
-  const shouldTranspilePath = [...parents].every((parentPath) => shouldTranspile(parentPath, cache, esmPaths, reasons))
+  const shouldTranspilePath = [...parents]
+    .filter((parentPath) => parentPath !== path)
+    .every((parentPath) => shouldTranspile(parentPath, cache, esmPaths, reasons))
 
   cache.set(path, shouldTranspilePath)
 


### PR DESCRIPTION
#### Summary

When using NFT, we determine whether an ESM file needs to be transpiled by checking whether all of its parents are also ESM files. We use the `reasons` object to figure out the parent/child relationships, but we need to account for the fact that the initial file is declared as a parent of itself.

This PR accounts for this case.