### PR TITLE
fix: use safe version of `getPackageJson` when transpiling ESM

### DIFF
--- a/src/runtimes/node/bundlers/esbuild/special_cases.ts
+++ b/src/runtimes/node/bundlers/esbuild/special_cases.ts
@@ -1,17 +1,7 @@
-import { getPackageJson, PackageJson } from '../../utils/package_json'
+import { getPackageJsonIfAvailable, PackageJson } from '../../utils/package_json'
 
 const EXTERNAL_MODULES = ['@prisma/client']
 const IGNORED_MODULES = ['aws-sdk']
-
-const getPackageJsonIfAvailable = async (srcDir: string): Promise<PackageJson> => {
-  try {
-    const packageJson = await getPackageJson(srcDir)
-
-    return packageJson
-  } catch {
-    return {}
-  }
-}
 
 const getModulesForNextJs = ({ dependencies, devDependencies }: PackageJson) => {
   const allDependencies = { ...dependencies, ...devDependencies }

--- a/src/runtimes/node/bundlers/nft/es_modules.ts
+++ b/src/runtimes/node/bundlers/nft/es_modules.ts
@@ -7,7 +7,7 @@ import { FeatureFlags } from '../../../../feature_flags'
 import { cachedReadFile, FsCache } from '../../../../utils/fs'
 import { ModuleFormat } from '../../utils/module_format'
 import { getNodeSupportMatrix } from '../../utils/node_version'
-import { getPackageJson, PackageJson } from '../../utils/package_json'
+import { getPackageJsonIfAvailable, PackageJson } from '../../utils/package_json'
 
 import { transpile } from './transpile'
 
@@ -73,7 +73,7 @@ const processESM = async ({
     }
   }
 
-  const packageJson = await getPackageJson(dirname(mainFile))
+  const packageJson = await getPackageJsonIfAvailable(dirname(mainFile))
   const nodeSupport = getNodeSupportMatrix(config.nodeVersion)
 
   if (featureFlags.zisi_pure_esm && packageJson.type === 'module' && nodeSupport.esm) {

--- a/src/runtimes/node/utils/package_json.ts
+++ b/src/runtimes/node/utils/package_json.ts
@@ -46,4 +46,14 @@ const getPackageJson = async function (srcDir: string): Promise<PackageJson> {
   }
 }
 
-export { getPackageJson, PackageJson, sanitisePackageJson }
+const getPackageJsonIfAvailable = async (srcDir: string): Promise<PackageJson> => {
+  try {
+    const packageJson = await getPackageJson(srcDir)
+
+    return packageJson
+  } catch {
+    return {}
+  }
+}
+
+export { getPackageJson, getPackageJsonIfAvailable, PackageJson, sanitisePackageJson }


### PR DESCRIPTION
#### Summary

Use `getPackageJsonIfAvailable` instead of `getPackageJson`, to avoid throwing an error when transpiling ESM in NFT.