### PR TITLE
chore: move typescript to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "semver": "^7.0.0",
     "tmp-promise": "^3.0.2",
     "toml": "^3.0.0",
-    "typescript": "^4.6.0-beta",
     "unixify": "^1.0.0",
     "yargs": "^16.0.0"
   },
@@ -105,7 +104,8 @@
     "sinon": "^13.0.0",
     "sort-on": "^4.1.1",
     "source-map-support": "^0.5.20",
-    "throat": "^6.0.1"
+    "throat": "^6.0.1",
+    "typescript": "^4.6.0-beta"
   },
   "engines": {
     "node": "^12.20.0 || ^14.14.0 || >=16.0.0"


### PR DESCRIPTION
As discussed in https://github.com/netlify/zip-it-and-ship-it/pull/678#issuecomment-931400198, TypeScript is no longer needed as a prod dependency. This PR moves it to dev dependencies.