### PR TITLE
chore: move `typescript` to `devDependencies` in lock file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
         "semver": "^7.0.0",
         "tmp-promise": "^3.0.2",
         "toml": "^3.0.0",
-        "typescript": "^4.6.0-beta",
         "unixify": "^1.0.0",
         "yargs": "^16.0.0"
       },
@@ -65,7 +64,8 @@
         "sinon": "^13.0.0",
         "sort-on": "^4.1.1",
         "source-map-support": "^0.5.20",
-        "throat": "^6.0.1"
+        "throat": "^6.0.1",
+        "typescript": "^4.6.0-beta"
       },
       "engines": {
         "node": "^12.20.0 || ^14.14.0 || >=16.0.0"
@@ -11710,6 +11710,7 @@
       "version": "4.6.0-dev.20220128",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.0-dev.20220128.tgz",
       "integrity": "sha512-bTe3MO3eY4Pt0PFhnuXtj9GxYRvwYDdx+r/+mpK2Xzfz4SLwCydTVdrNs5tqfMuqoPn7piOLeBfzkoheQUDeXw==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -20964,7 +20965,8 @@
     "typescript": {
       "version": "4.6.0-dev.20220128",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.0-dev.20220128.tgz",
-      "integrity": "sha512-bTe3MO3eY4Pt0PFhnuXtj9GxYRvwYDdx+r/+mpK2Xzfz4SLwCydTVdrNs5tqfMuqoPn7piOLeBfzkoheQUDeXw=="
+      "integrity": "sha512-bTe3MO3eY4Pt0PFhnuXtj9GxYRvwYDdx+r/+mpK2Xzfz4SLwCydTVdrNs5tqfMuqoPn7piOLeBfzkoheQUDeXw==",
+      "dev": true
     },
     "unbox-primitive": {
       "version": "1.0.1",


### PR DESCRIPTION
#### Summary

Completes #1019.