### PR TITLE
fix: pin down esbuild version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "7.16.8",
-        "@netlify/esbuild": "^0.13.6",
+        "@netlify/esbuild": "0.13.6",
         "@vercel/nft": "^0.17.0",
         "archiver": "^5.3.0",
         "common-path-prefix": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@babel/parser": "7.16.8",
-    "@netlify/esbuild": "^0.13.6",
+    "@netlify/esbuild": "0.13.6",
     "@vercel/nft": "^0.17.0",
     "archiver": "^5.3.0",
     "common-path-prefix": "^3.0.0",


### PR DESCRIPTION
At the moment, some users of `netlify-cli` will install an updated version of `@netlify/esbuild` that [fails some test](https://github.com/netlify/zip-it-and-ship-it/pull/1035). Let's pin down the version so people stay on the current one!
