### PR TITLE
chore: add "cypress passed" comment to integration test

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -88,5 +88,7 @@ jobs:
           comment: |
             ## Integration Test: netlify/netlify-plugin-nextjs
 
+            ✅ Cypress tests passed
+
             - **Deploy URL**: ${{ env.deploy_url }}
             - **Deploy logs**: ${{ env.deploy_log_url }}


### PR DESCRIPTION
When looking at https://github.com/netlify/zip-it-and-ship-it/pull/1080#issuecomment-1120830764, I was wondering "hm, does this mean I should take a look at this? 🤔". To make it obvious that this includes some e2e tests, I added the "cypress tests passed" line to the comment.