### PR TITLE
fix(nft): correctly annotate transpilation errors in nft bundler

### DIFF
--- a/src/runtimes/node/bundlers/nft/es_modules.ts
+++ b/src/runtimes/node/bundlers/nft/es_modules.ts
@@ -56,6 +56,7 @@ export const processESM = async ({
   fsCache,
   mainFile,
   reasons,
+  name,
 }: {
   basePath: string | undefined
   config: FunctionConfig
@@ -64,6 +65,7 @@ export const processESM = async ({
   fsCache: FsCache
   mainFile: string
   reasons: NodeFileTraceReasons
+  name: string
 }): Promise<{ rewrites?: Map<string, string>; moduleFormat: ModuleFormat }> => {
   const entrypointIsESM = isEntrypointESM({ basePath, esmPaths, mainFile })
 
@@ -82,7 +84,7 @@ export const processESM = async ({
     }
   }
 
-  const rewrites = await transpileESM({ basePath, config, esmPaths, fsCache, reasons })
+  const rewrites = await transpileESM({ basePath, config, esmPaths, fsCache, reasons, name })
 
   return {
     moduleFormat: 'cjs',
@@ -140,12 +142,14 @@ const transpileESM = async ({
   esmPaths,
   fsCache,
   reasons,
+  name,
 }: {
   basePath: string | undefined
   config: FunctionConfig
   esmPaths: Set<string>
   fsCache: FsCache
   reasons: NodeFileTraceReasons
+  name: string
 }) => {
   const cache: Map<string, boolean> = new Map()
   const pathsToTranspile = [...esmPaths].filter((path) => shouldTranspile(path, cache, esmPaths, reasons))
@@ -166,7 +170,7 @@ const transpileESM = async ({
   await Promise.all(
     pathsToTranspile.map(async (path) => {
       const absolutePath = resolvePath(path, basePath)
-      const transpiled = await transpile(absolutePath, config)
+      const transpiled = await transpile(absolutePath, config, name)
 
       rewrites.set(absolutePath, transpiled)
     }),

--- a/src/runtimes/node/bundlers/nft/index.ts
+++ b/src/runtimes/node/bundlers/nft/index.ts
@@ -25,6 +25,7 @@ const bundle: BundleFunction = async ({
   config,
   featureFlags,
   mainFile,
+  name,
   pluginsModulesPath,
   repositoryRoot = basePath,
 }) => {
@@ -43,6 +44,7 @@ const bundle: BundleFunction = async ({
     featureFlags,
     mainFile,
     pluginsModulesPath,
+    name,
   })
   const filteredIncludedPaths = filterExcludedPaths([...dependencyPaths, ...includedFilePaths], excludedPaths)
   const dirnames = filteredIncludedPaths.map((filePath) => normalize(dirname(filePath))).sort()
@@ -73,12 +75,14 @@ const traceFilesAndTranspile = async function ({
   featureFlags,
   mainFile,
   pluginsModulesPath,
+  name,
 }: {
   basePath?: string
   config: FunctionConfig
   featureFlags: FeatureFlags
   mainFile: string
   pluginsModulesPath?: string
+  name: string
 }) {
   const fsCache: FsCache = {}
   const {
@@ -129,6 +133,7 @@ const traceFilesAndTranspile = async function ({
     fsCache,
     mainFile,
     reasons,
+    name,
   })
 
   return {

--- a/src/runtimes/node/bundlers/nft/transpile.ts
+++ b/src/runtimes/node/bundlers/nft/transpile.ts
@@ -1,22 +1,36 @@
 import { build } from '@netlify/esbuild'
 
 import type { FunctionConfig } from '../../../../config.js'
+import type { RuntimeName } from '../../../runtime.js'
 import { getBundlerTarget } from '../esbuild/bundler_target.js'
+import type { NodeBundlerName } from '../index.js'
 
-export const transpile = async (path: string, config: FunctionConfig) => {
+export const transpile = async (path: string, config: FunctionConfig, functionName: string) => {
   // The version of ECMAScript to use as the build target. This will determine
   // whether certain features are transpiled down or left untransformed.
   const nodeTarget = getBundlerTarget(config.nodeVersion)
-  const transpiled = await build({
-    bundle: false,
-    entryPoints: [path],
-    format: 'cjs',
-    logLevel: 'error',
-    platform: 'node',
-    sourcemap: Boolean(config.nodeSourcemap),
-    target: [nodeTarget],
-    write: false,
-  })
 
-  return transpiled.outputFiles[0].text
+  try {
+    const transpiled = await build({
+      bundle: false,
+      entryPoints: [path],
+      format: 'cjs',
+      logLevel: 'error',
+      platform: 'node',
+      sourcemap: Boolean(config.nodeSourcemap),
+      target: [nodeTarget],
+      write: false,
+    })
+
+    return transpiled.outputFiles[0].text
+  } catch (error) {
+    const bundler: NodeBundlerName = 'nft'
+    const runtime: RuntimeName = 'js'
+    error.customErrorInfo = {
+      type: 'functionsBundling',
+      location: { bundler, functionName, runtime },
+    }
+
+    throw error
+  }
 }

--- a/src/runtimes/node/bundlers/nft/transpile.ts
+++ b/src/runtimes/node/bundlers/nft/transpile.ts
@@ -26,6 +26,7 @@ export const transpile = async (path: string, config: FunctionConfig, functionNa
   } catch (error) {
     const bundler: NodeBundlerName = 'nft'
     const runtime: RuntimeName = 'js'
+
     error.customErrorInfo = {
       type: 'functionsBundling',
       location: { bundler, functionName, runtime },

--- a/tests/fixtures/node-esm-top-level-await-error/function.js
+++ b/tests/fixtures/node-esm-top-level-await-error/function.js
@@ -1,0 +1,5 @@
+const func = async () => {}
+
+await func()
+
+export { func } //makes nft detect this file as esm

--- a/tests/main.js
+++ b/tests/main.js
@@ -1897,6 +1897,23 @@ testMany(
   },
 )
 
+test('Adds `type: "functionsBundling"` to user errors when transpiling esm in nft bundler', async (t) => {
+  try {
+    await zipNode(t, 'node-esm-top-level-await-error', {
+      opts: { config: { '*': { nodeBundler: 'nft' } } },
+    })
+
+    t.fail('Bundling should have thrown')
+  } catch (error) {
+    const { customErrorInfo } = error
+
+    t.is(customErrorInfo.type, 'functionsBundling')
+    t.is(customErrorInfo.location.bundler, 'nft')
+    t.is(customErrorInfo.location.functionName, 'function')
+    t.is(customErrorInfo.location.runtime, 'js')
+  }
+})
+
 test('Returns a list of all modules with dynamic imports in a `nodeModulesWithDynamicImports` property', async (t) => {
   const fixtureName = 'node-module-dynamic-import'
   const { files } = await zipNode(t, fixtureName, {


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Add customErrorInfo to errors happening during transpilation of esm with esbuild in the nft bundler.
I had to loop the function name through to the actual `esbuild` call, to generate the error location properly.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/zip-it-and-ship-it/issues/new/choose) before writing your code 🧑‍💻.
      This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing
      a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [x] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [x] Make sure the status checks below are successful ✅


