### PR TITLE
fix: detect a wider range of scheduled functions

### DIFF
--- a/src/runtimes/node/in_source_config/index.ts
+++ b/src/runtimes/node/in_source_config/index.ts
@@ -1,6 +1,7 @@
 import { ArgumentPlaceholder, Expression, SpreadElement, JSXNamespacedName } from '@babel/types'
 
 import { nonNullable } from '../../../utils/non_nullable.js'
+import { createBindingsMethod } from '../parser/bindings.js'
 import { getMainExport } from '../parser/exports.js'
 import { getImports } from '../parser/imports.js'
 import { safelyParseFile } from '../parser/index.js'
@@ -22,7 +23,8 @@ export const findISCDeclarationsInPath = async (sourcePath: string): Promise<ISC
   }
 
   const imports = ast.body.flatMap((node) => getImports(node, IN_SOURCE_CONFIG_MODULE))
-  const mainExports = getMainExport(ast.body)
+  const getAllBindings = createBindingsMethod(ast.body)
+  const mainExports = getMainExport(ast.body, getAllBindings)
   const iscExports = mainExports
     .map(({ args, local: exportName }) => {
       const matchingImport = imports.find(({ local: importName }) => importName === exportName)
@@ -33,7 +35,7 @@ export const findISCDeclarationsInPath = async (sourcePath: string): Promise<ISC
 
       switch (matchingImport.imported) {
         case 'schedule':
-          return parseSchedule({ args })
+          return parseSchedule({ args }, getAllBindings)
 
         default:
         // no-op

--- a/src/runtimes/node/in_source_config/properties/schedule.ts
+++ b/src/runtimes/node/in_source_config/properties/schedule.ts
@@ -1,7 +1,16 @@
+import type { BindingMethod } from '../../parser/bindings.js'
 import type { ISCHandlerArg } from '../index.js'
 
-export const parse = ({ args }: { args: ISCHandlerArg[] }) => {
-  const [expression] = args
+export const parse = ({ args }: { args: ISCHandlerArg[] }, getAllBindings: BindingMethod) => {
+  let [expression] = args
+
+  if (expression.type === 'Identifier') {
+    const binding = getAllBindings().get(expression.name)
+    if (binding) {
+      expression = binding
+    }
+  }
+
   const schedule = expression.type === 'StringLiteral' ? expression.value : undefined
 
   return {

--- a/src/runtimes/node/parser/bindings.ts
+++ b/src/runtimes/node/parser/bindings.ts
@@ -20,7 +20,7 @@ const getBindingsFromNode = function (node: Statement, bindings: Bindings): void
     node.expression.type === 'AssignmentExpression' &&
     node.expression.left.type === 'Identifier'
   ) {
-    // The variable was reassigned, so lets store the new value
+    // The variable was reassigned, so let's store the new value
     bindings.set(node.expression.left.name, node.expression.right)
   } else if (node.type === 'ExportNamedDeclaration' && node.declaration?.type === 'VariableDeclaration') {
     // A `export const|let ...` creates a binding that can later be referenced again

--- a/src/runtimes/node/parser/bindings.ts
+++ b/src/runtimes/node/parser/bindings.ts
@@ -1,0 +1,55 @@
+import type { Expression, Statement, VariableDeclaration } from '@babel/types'
+
+type Bindings = Map<string, Expression>
+
+const getBindingFromVariableDeclaration = function (node: VariableDeclaration, bindings: Bindings): void {
+  node.declarations.forEach((declaration) => {
+    if (declaration.id.type === 'Identifier' && declaration.init) {
+      bindings.set(declaration.id.name, declaration.init)
+    }
+  })
+}
+
+// eslint-disable-next-line complexity
+const getBindingsFromNode = function (node: Statement, bindings: Bindings): void {
+  if (node.type === 'VariableDeclaration') {
+    // A variable was created, so create it and store the potential value
+    getBindingFromVariableDeclaration(node, bindings)
+  } else if (
+    node.type === 'ExpressionStatement' &&
+    node.expression.type === 'AssignmentExpression' &&
+    node.expression.left.type === 'Identifier'
+  ) {
+    // The variable was reassigned, so lets store the new value
+    bindings.set(node.expression.left.name, node.expression.right)
+  } else if (node.type === 'ExportNamedDeclaration' && node.declaration?.type === 'VariableDeclaration') {
+    // A `export const|let ...` creates a binding that can later be referenced again
+    getBindingFromVariableDeclaration(node.declaration, bindings)
+  }
+}
+
+/**
+ * Goes through all relevant nodes and creates a map from binding name to assigned value/expression
+ */
+const getAllBindings = function (nodes: Statement[]): Bindings {
+  const bindings: Bindings = new Map()
+
+  nodes.forEach((node) => {
+    getBindingsFromNode(node, bindings)
+  })
+
+  return bindings
+}
+
+export type BindingMethod = () => Bindings
+
+export const createBindingsMethod = function (nodes: Statement[]): BindingMethod {
+  // memoize the result for these nodes
+  let result: Bindings | null = null
+  return () => {
+    if (!result) {
+      result = getAllBindings(nodes)
+    }
+    return result
+  }
+}

--- a/src/runtimes/node/parser/bindings.ts
+++ b/src/runtimes/node/parser/bindings.ts
@@ -45,11 +45,12 @@ export type BindingMethod = () => Bindings
 
 export const createBindingsMethod = function (nodes: Statement[]): BindingMethod {
   // memoize the result for these nodes
-  let result: Bindings | null = null
+  let result: Bindings
   return () => {
     if (!result) {
       result = getAllBindings(nodes)
     }
+
     return result
   }
 }

--- a/src/runtimes/node/parser/exports.ts
+++ b/src/runtimes/node/parser/exports.ts
@@ -106,6 +106,7 @@ const getExportsFromExpression = (node: Expression | undefined | null) => {
   if (node?.type !== 'CallExpression') {
     return []
   }
+
   const { arguments: args, callee } = node
 
   if (callee.type !== 'Identifier') {

--- a/src/runtimes/node/parser/exports.ts
+++ b/src/runtimes/node/parser/exports.ts
@@ -103,6 +103,8 @@ const getExportsFromBindings = (
 }
 
 const getExportsFromExpression = (node: Expression | undefined | null) => {
+  // We're only interested in expressions representing function calls, because
+  // the ISC patterns we implement at the moment are all helper functions.
   if (node?.type !== 'CallExpression') {
     return []
   }

--- a/tests/fixtures/in-source-config/functions/cron_esm_no_direct_export.js
+++ b/tests/fixtures/in-source-config/functions/cron_esm_no_direct_export.js
@@ -1,0 +1,7 @@
+import { schedule } from '@netlify/functions'
+
+const handler = schedule('@daily', async () => {
+  // function handler
+})
+
+export { handler }

--- a/tests/fixtures/in-source-config/functions/cron_esm_no_direct_export_renamed.js
+++ b/tests/fixtures/in-source-config/functions/cron_esm_no_direct_export_renamed.js
@@ -1,0 +1,6 @@
+import { schedule } from '@netlify/functions'
+
+const _handler = schedule('@daily', async () => {
+  // function handler
+})
+export { _handler as handler }

--- a/tests/fixtures/in-source-config/functions/cron_esm_no_direct_export_renamed_reassigned.js
+++ b/tests/fixtures/in-source-config/functions/cron_esm_no_direct_export_renamed_reassigned.js
@@ -1,0 +1,8 @@
+import { schedule } from '@netlify/functions'
+
+const handler = async () => {
+  // function handler
+}
+
+const _handler = schedule('@daily', handler)
+export { _handler as handler }

--- a/tests/fixtures/in-source-config/functions/cron_esm_schedule_reassigned.js
+++ b/tests/fixtures/in-source-config/functions/cron_esm_schedule_reassigned.js
@@ -1,0 +1,7 @@
+import { schedule } from '@netlify/functions'
+
+const SCHEDULE = '@daily'
+
+export const handler = schedule(SCHEDULE, async () => {
+  // function handler
+})

--- a/tests/main.js
+++ b/tests/main.js
@@ -2662,7 +2662,7 @@ testMany(
   'Finds in-source config declarations using the `schedule` helper',
   ['bundler_default', 'bundler_esbuild', 'bundler_nft'],
   async (options, t) => {
-    const FUNCTIONS_COUNT = 7
+    const FUNCTIONS_COUNT = 11
     const { files } = await zipFixture(t, join('in-source-config', 'functions'), {
       opts: options,
       length: FUNCTIONS_COUNT,
@@ -2692,7 +2692,7 @@ test('listFunctions includes in-source config declarations', async (t) => {
   const functions = await listFunctions(join(FIXTURES_DIR, 'in-source-config', 'functions'), {
     parseISC: true,
   })
-  const FUNCTIONS_COUNT = 7
+  const FUNCTIONS_COUNT = 11
   t.is(functions.length, FUNCTIONS_COUNT)
   functions.forEach((func) => {
     t.is(func.schedule, '@daily')


### PR DESCRIPTION
scheduled functions which are reassigned or not directly exported are now detected

This PR extends the functionality of the detection for the in-source-config of scheduled functions.

2 cases were not supported previously:

1. The schedule is not directly supplied as string to the `schedule()` helper but assigned to a variable `schedule(SCHEDULE, ...)`
2. The schedule helper is not directly exported (`export const handler = schedule()`) but instead assigned to a variable which is exported `export { handler }`

To solve both of these cases I opted to collect all variable bindings and their current value (only in the root scope). This is done by iterating through all nodes and collecting all declarations of variables and all reassigns. This method is memoized so that multiple calls (at the moment maximum 2) won't result in duplicated work.

Now, when the cron pattern in the schedule helper (1) or the export (2) is encountered as an identifier instead of the expected value, the code now can resolve the identifier to its value using the binding-map.
