### PR TITLE
chore: Enable lockfile maintenance

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -2,6 +2,7 @@
   extends: ['github>netlify/renovate-config:default'],
   ignorePresets: [':prHourlyLimit2'],
   ignorePaths: ['benchmarks/fixtures/', 'tests/fixtures'],
+  lockFileMaintenance: { enabled: true },
   semanticCommits: true,
   dependencyDashboard: true,
   automerge: false,


### PR DESCRIPTION
#### Summary

As discussed on slack we should enable lockfile maintenance to catch errors with the latest versions of transitive dependencies.