### PR TITLE
fix: handle invalid `files` entry in package.json

### DIFF
--- a/src/runtimes/node/utils/detect_native_module.ts
+++ b/src/runtimes/node/utils/detect_native_module.ts
@@ -21,7 +21,10 @@ export const isNativeModule = ({
     return true
   }
 
-  const hasBinaryFile = files.some((path) => !path.startsWith('!') && extname(path) === '.node')
+  // Check if files is an array, as we never know (see https://github.com/math-utils/hamming-distance/pull/4)
+  const hasBinaryFile = Array.isArray(files)
+    ? files.some((path) => !path.startsWith('!') && extname(path) === '.node')
+    : false
 
   return hasBinaryFile
 }


### PR DESCRIPTION
#### Summary

Fixes netlify/cli#4612

Add more defensive code so that invalid `files` properties don't make everything explode. See https://github.com/math-utils/hamming-distance/pull/4