### PR TITLE
fix: always build for amd64 when building go functions

### DIFF
--- a/src/runtimes/go/builder.ts
+++ b/src/runtimes/go/builder.ts
@@ -13,6 +13,7 @@ export const build = async ({ destPath, mainFile, srcDir }: { destPath: string; 
       env: {
         CGO_ENABLED: '0',
         GOOS: 'linux',
+        GOARCH: 'amd64',
       },
     })
   } catch (error) {


### PR DESCRIPTION
I noticed that we build for whatever architecture the current host has. Which when for example building locally on M1 MacBook probably creates Linux/arm64 binary which would be wrong, but even if not I feel saver by defining it explicitly.

Ref: https://github.com/netlify/pillar-runtime/issues/231