### PR TITLE
fix: add more error info on missing functions folders

### DIFF
--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -48,11 +48,14 @@ export const listFunctionsDirectories = async function (srcFolders: string[]) {
   const validDirectories = filenamesByDirectory
     .map((result) => {
       if (result.status === 'rejected') {
-        if (result.reason instanceof Error && (result.reason as NodeJS.ErrnoException).code !== 'ENOENT') {
-          throw result.reason
+        // If the error is about `ENOENT` (FileNotFound) then we only throw later if this happens
+        // for all directories.
+        if (result.reason instanceof Error && (result.reason as NodeJS.ErrnoException).code === 'ENOENT') {
+          return null
         }
 
-        return null
+        // In any other error case besides `ENOENT` throw immediately
+        throw result.reason
       }
 
       return result.value

--- a/tests/main.js
+++ b/tests/main.js
@@ -823,7 +823,7 @@ testMany(
   ['bundler_default', 'bundler_esbuild', 'bundler_esbuild_zisi', 'bundler_default_nft', 'bundler_nft'],
   async (options, t) => {
     await t.throwsAsync(zipNode(t, 'does-not-exist', { opts: options }), {
-      message: /Functions folder does not exist/,
+      message: /Functions folders do not exist/,
     })
   },
 )
@@ -2698,6 +2698,22 @@ test('listFunction includes in-source config declarations', async (t) => {
     runtime: 'js',
     schedule: '@daily',
   })
+})
+
+test('listFunctionsFiles throws if all function directories do not exist', async (t) => {
+  const error = await t.throwsAsync(
+    async () =>
+      await listFunctionsFiles([
+        join(FIXTURES_DIR, 'missing-functions-folder', 'functions'),
+        join(FIXTURES_DIR, 'missing-functions-folder', 'functions2'),
+      ]),
+  )
+  t.regex(error.message, /Functions folders do not exist: /)
+})
+
+test('listFunctionsFiles does not hide errors that have nothing todo with folder existents', async (t) => {
+  const error = await t.throwsAsync(async () => await listFunctionsFiles([true]))
+  t.notRegex(error.message, /Functions folders do not exist: /)
 })
 
 test('listFunctionsFiles includes in-source config declarations', async (t) => {


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

For https://github.com/netlify/pod-compute/issues/108

Throws underlying errors if the error is not a FileNotFound Error.