### PR TITLE
fix: refactor error annotation, to not loose original error

### DIFF
--- a/src/runtimes/go/builder.ts
+++ b/src/runtimes/go/builder.ts
@@ -19,7 +19,7 @@ export const build = async ({ destPath, mainFile, srcDir }: { destPath: string; 
   } catch (error) {
     console.error(`Could not compile Go function ${functionName}:\n`)
 
-    throw new FunctionBundlingUserError(error, { functionName, runtime: 'go' })
+    throw FunctionBundlingUserError.addCustomErrorInfo(error, { functionName, runtime: 'go' })
   }
 
   const stat = await fs.lstat(destPath)

--- a/src/runtimes/node/bundlers/esbuild/bundler.ts
+++ b/src/runtimes/node/bundlers/esbuild/bundler.ts
@@ -133,7 +133,7 @@ export const bundleJsFile = async function ({
       warnings,
     }
   } catch (error) {
-    throw new FunctionBundlingUserError(error, { functionName: name, runtime: 'js', bundler: 'esbuild' })
+    throw FunctionBundlingUserError.addCustomErrorInfo(error, { functionName: name, runtime: 'js', bundler: 'esbuild' })
   }
 }
 

--- a/src/runtimes/node/bundlers/nft/transpile.ts
+++ b/src/runtimes/node/bundlers/nft/transpile.ts
@@ -23,6 +23,6 @@ export const transpile = async (path: string, config: FunctionConfig, functionNa
 
     return transpiled.outputFiles[0].text
   } catch (error) {
-    throw new FunctionBundlingUserError(error, { functionName, runtime: 'js', bundler: 'nft' })
+    throw FunctionBundlingUserError.addCustomErrorInfo(error, { functionName, runtime: 'js', bundler: 'nft' })
   }
 }

--- a/src/runtimes/node/bundlers/zisi/list_imports.ts
+++ b/src/runtimes/node/bundlers/zisi/list_imports.ts
@@ -57,7 +57,7 @@ export const listImports = async ({
       target: 'esnext',
     })
   } catch (error) {
-    throw new FunctionBundlingUserError(error, { functionName, runtime: 'js', bundler: 'zisi' })
+    throw FunctionBundlingUserError.addCustomErrorInfo(error, { functionName, runtime: 'js', bundler: 'zisi' })
   } finally {
     await safeUnlink(targetPath)
   }

--- a/src/runtimes/rust/builder.ts
+++ b/src/runtimes/rust/builder.ts
@@ -17,7 +17,7 @@ export const build = async ({ config, name, srcDir }: { config: FunctionConfig; 
   try {
     await installToolchainOnce()
   } catch (error) {
-    throw new FunctionBundlingUserError(error, { functionName, runtime: 'rs' })
+    throw FunctionBundlingUserError.addCustomErrorInfo(error, { functionName, runtime: 'rs' })
   }
 
   const targetDirectory = await getTargetDirectory({ config, name })
@@ -67,7 +67,7 @@ const cargoBuild = async ({
         'There is no Rust toolchain installed. Visit https://ntl.fyi/missing-rust-toolchain for more information.'
     }
 
-    throw new FunctionBundlingUserError(error, { functionName, runtime: 'rs' })
+    throw FunctionBundlingUserError.addCustomErrorInfo(error, { functionName, runtime: 'rs' })
   }
 }
 

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -12,22 +12,27 @@ interface CustomErrorInfo {
   location: CustomErrorLocation
 }
 
+type UserError = Error & { customErrorInfo: CustomErrorInfo }
+
 export class FunctionBundlingUserError extends Error {
-  customErrorInfo: CustomErrorInfo
-
-  constructor(messageOrError: string | Error, customErrorInfo: CustomErrorLocation) {
-    const isError = messageOrError instanceof Error
-
-    super(isError ? messageOrError.message : messageOrError)
+  constructor(message: string, customErrorInfo: CustomErrorLocation) {
+    super(message)
 
     Object.setPrototypeOf(this, new.target.prototype)
     this.name = 'FunctionBundlingUserError'
-    if (isError) {
-      this.stack = messageOrError.stack
-    } else {
-      Error.captureStackTrace(this, FunctionBundlingUserError)
+    Error.captureStackTrace(this, FunctionBundlingUserError)
+
+    FunctionBundlingUserError.addCustomErrorInfo(this, customErrorInfo)
+  }
+
+  static addCustomErrorInfo(error: Error, customErrorInfo: CustomErrorLocation): UserError {
+    const info: CustomErrorInfo = {
+      type: 'functionsBundling',
+      location: customErrorInfo,
     }
 
-    this.customErrorInfo = { type: 'functionsBundling', location: customErrorInfo }
+    ;(error as UserError).customErrorInfo = info
+
+    return error as UserError
   }
 }


### PR DESCRIPTION
With the previous approach for example `code` was lost
Instead of wrapping the error we now only annotate it.

The current version of zisi breaks @netlify/build because it makes some assumptions about errors (message, code, type) that were changed.