### PR TITLE
fix: add node 16 to valid types and be more strict about version in esbuild types

### DIFF
--- a/src/runtimes/node/bundlers/esbuild/bundler_target.ts
+++ b/src/runtimes/node/bundlers/esbuild/bundler_target.ts
@@ -1,6 +1,11 @@
 import { FeatureFlags } from '../../../../feature_flags'
 import { ModuleFormat } from '../../utils/module_format'
-import { DEFAULT_NODE_VERSION, getNodeSupportMatrix } from '../../utils/node_version'
+import {
+  DEFAULT_NODE_VERSION,
+  getNodeSupportMatrix,
+  NodeVersionString,
+  ShortNodeVersionString,
+} from '../../utils/node_version'
 import { getClosestPackageJson } from '../../utils/package_json'
 
 const versionMap = {
@@ -11,14 +16,13 @@ const versionMap = {
   '16.x': 'node16',
 } as const
 
-type VersionKeys = keyof typeof versionMap
-type VersionValues = typeof versionMap[VersionKeys]
+type VersionValues = typeof versionMap[keyof typeof versionMap]
 
-const getBundlerTarget = (suppliedVersion?: string): VersionValues => {
+const getBundlerTarget = (suppliedVersion?: NodeVersionString): VersionValues => {
   const version = normalizeVersion(suppliedVersion)
 
   if (version && version in versionMap) {
-    return versionMap[version as VersionKeys]
+    return versionMap[version]
   }
 
   return versionMap[`${DEFAULT_NODE_VERSION}.x`]
@@ -45,10 +49,10 @@ const getModuleFormat = async (
   }
 }
 
-const normalizeVersion = (version?: string) => {
-  const match = version && version.match(/^nodejs(.*)$/)
+const normalizeVersion = (version?: NodeVersionString): ShortNodeVersionString | undefined => {
+  const match = version && (version.match(/^nodejs(.*)$/) as [string, ShortNodeVersionString])
 
-  return match ? match[1] : version
+  return match ? match[1] : (version as ShortNodeVersionString)
 }
 
 export { getBundlerTarget, getModuleFormat }

--- a/src/runtimes/node/utils/node_version.ts
+++ b/src/runtimes/node/utils/node_version.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-magic-numbers */
-type SupportedVersionNumbers = 8 | 10 | 12 | 14
-export type NodeVersionString = `${SupportedVersionNumbers}.x` | `nodejs${SupportedVersionNumbers}.x`
+type SupportedVersionNumbers = 8 | 10 | 12 | 14 | 16
+export type ShortNodeVersionString = `${SupportedVersionNumbers}.x`
+export type NodeVersionString = ShortNodeVersionString | `nodejs${SupportedVersionNumbers}.x`
 
 export interface NodeVersionSupport {
   esm: boolean


### PR DESCRIPTION
#### Summary

I noticed this problem while working on another PR that we are missing node 16 in the types. 

I also added more strictness to the types in esbuild that handle the node version.
