### PR TITLE
fix: handle cyclic dependencies in NFT bundler [WIP]

### DIFF
--- a/src/runtimes/node/bundlers/nft/es_modules.ts
+++ b/src/runtimes/node/bundlers/nft/es_modules.ts
@@ -95,6 +95,7 @@ export const processESM = async ({
 const resolvePath = (relativePath: string, basePath?: string) =>
   basePath ? resolve(basePath, relativePath) : resolve(relativePath)
 
+// eslint-disable-next-line max-statements
 const shouldTranspile = (
   path: string,
   cache: Map<string, boolean>,
@@ -126,6 +127,11 @@ const shouldTranspile = (
 
     return isESM
   }
+
+  // Because this method is recursive we have to assume here that we probably want to transpile this file
+  // This is done so that endless recursion can never happen in the case that a parent has this file again as parent
+  // We will override this later anyway.
+  cache.set(path, true)
 
   // The path should be transpiled if every parent will also be transpiled, or
   // if there is no parent.

--- a/tests/fixtures/node-esm-import-loop/functions/func1.js
+++ b/tests/fixtures/node-esm-import-loop/functions/func1.js
@@ -1,0 +1,3 @@
+import { handler } from '../import1.js'
+
+export { handler }

--- a/tests/fixtures/node-esm-import-loop/import1.js
+++ b/tests/fixtures/node-esm-import-loop/import1.js
@@ -1,0 +1,5 @@
+import { handler } from './import2.js'
+
+const realHandler = () => true
+
+export { realHandler, handler }

--- a/tests/fixtures/node-esm-import-loop/import2.js
+++ b/tests/fixtures/node-esm-import-loop/import2.js
@@ -1,0 +1,3 @@
+import { realHandler } from './import1.js'
+
+export { realHandler as handler }

--- a/tests/main.js
+++ b/tests/main.js
@@ -2815,3 +2815,25 @@ testMany('None bundler emits esm with default nodeVersion', ['bundler_none'], as
 
   t.is(originalFile, bundledFile)
 })
+
+testMany('All ESM bundlers can handle import loops', ['bundler_esbuild', 'bundler_nft'], async (options, t) => {
+  const fixtureName = 'node-esm-import-loop'
+  const opts = merge(options, {
+    basePath: join(FIXTURES_DIR, fixtureName),
+    config: {
+      '*': {
+        nodeVersion: 'nodejs16.x',
+      },
+    },
+  })
+  const { files, tmpDir } = await zipFixture(t, `${fixtureName}/functions`, {
+    length: 1,
+    opts,
+  })
+
+  await unzipFiles(files)
+
+  const func = await importFunctionFile(join(tmpDir, 'func1.js'))
+
+  t.is(func.handler(), true)
+})


### PR DESCRIPTION
#### Summary

This adds support for cyclic dependencies in the NFT bundler and adds a test for it (also for esbuild).

This DOES NOT work though yet, because esbuild, which is used in NFT to transpile (but not bundle) generates invalid code:
https://github.com/evanw/esbuild/issues/1856

We need to look into esbuild, maybe we can fix this.