### PR TITLE
feat: output cjs extension for bundles and entry-files

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -7,6 +7,7 @@ module.exports = {
   },
   rules: {
     'import/extensions': ['error', 'ignorePackages'],
+    'max-lines': 'off',
     'n/no-missing-import': 'off',
     'no-magic-numbers': 'off',
     'max-lines-per-function': 'off',

--- a/src/feature_flags.ts
+++ b/src/feature_flags.ts
@@ -20,6 +20,9 @@ export const defaultFlags: Record<string, boolean> = {
 
   // Load configuration from per-function JSON files.
   project_deploy_configuration_api_use_per_function_configuration_files: false,
+
+  // Output CJS file extension
+  zisi_output_cjs_extension: false,
 }
 
 export type FeatureFlag = keyof typeof defaultFlags

--- a/src/runtimes/node/bundlers/esbuild/index.ts
+++ b/src/runtimes/node/bundlers/esbuild/index.ts
@@ -68,11 +68,11 @@ const bundle: BundleFunction = async ({
     additionalPaths,
     bundlePaths,
     cleanTempFiles,
-    extension: outputExtension,
     inputs,
     moduleFormat,
     nativeNodeModules = {},
     nodeModulesWithDynamicImports,
+    outputExtension,
     warnings,
   } = await bundleJsFile({
     additionalModulePaths: pluginsModulesPath ? [pluginsModulesPath] : [],

--- a/src/runtimes/node/utils/entry_file.ts
+++ b/src/runtimes/node/utils/entry_file.ts
@@ -20,7 +20,7 @@ const getEntryFileContents = (mainPath: string, moduleFormat: string) => {
   return `export { handler } from '${importPath}'`
 }
 
-// They are also in the order that lambda will try to find the entry point
+// They are also in the order that AWS Lambda will try to find the entry point
 const POSSIBLE_LAMBDA_ENTRY_EXTENSIONS = ['.js', '.mjs', '.cjs']
 
 export const isEntryFile = (

--- a/src/runtimes/node/utils/entry_file.ts
+++ b/src/runtimes/node/utils/entry_file.ts
@@ -1,18 +1,16 @@
-import { ModuleFormat } from './module_format.js'
+import { basename, extname, resolve } from 'path'
+
+import type { FeatureFlags } from '../../../feature_flags.js'
+
+import { getFileExtensionForFormat, ModuleFormat } from './module_format.js'
 import { normalizeFilePath } from './normalize_path.js'
 
-export const getEntryFile = ({
-  commonPrefix,
-  mainFile,
-  moduleFormat,
-  userNamespace,
-}: {
-  commonPrefix: string
-  mainFile: string
-  moduleFormat: ModuleFormat
-  userNamespace: string
-}) => {
-  const mainPath = normalizeFilePath({ commonPrefix, path: mainFile, userNamespace })
+export interface EntryFile {
+  contents: string
+  filename: string
+}
+
+const getEntryFileContents = (mainPath: string, moduleFormat: string) => {
   const importPath = `.${mainPath.startsWith('/') ? mainPath : `/${mainPath}`}`
 
   if (moduleFormat === ModuleFormat.COMMONJS) {
@@ -20,4 +18,72 @@ export const getEntryFile = ({
   }
 
   return `export { handler } from '${importPath}'`
+}
+
+// They are also in the order that lambda will try to find the entry point
+const POSSIBLE_LAMBDA_ENTRY_EXTENSIONS = ['.js', '.mjs', '.cjs']
+
+export const isEntryFile = (
+  mainFile: string,
+  {
+    basePath,
+    filename,
+  }: {
+    basePath: string
+    filename: string
+  },
+) =>
+  POSSIBLE_LAMBDA_ENTRY_EXTENSIONS.some((extension) => {
+    const entryFilename = getEntryFileName({ extension, filename })
+    const entryFilePath = resolve(basePath, entryFilename)
+
+    return entryFilePath === mainFile
+  })
+
+export const conflictsWithEntryFile = (
+  srcFiles: string[],
+  {
+    basePath,
+    mainFile,
+    filename,
+  }: {
+    basePath: string
+    filename: string
+    mainFile: string
+  },
+) =>
+  POSSIBLE_LAMBDA_ENTRY_EXTENSIONS.some((extension) => {
+    const entryFilename = getEntryFileName({ extension, filename })
+    const entryFilePath = resolve(basePath, entryFilename)
+
+    return srcFiles.some((srcFile) => srcFile === entryFilePath && srcFile !== mainFile)
+  })
+
+const getEntryFileName = ({ extension, filename }: { extension: string; filename: string }) =>
+  `${basename(filename, extname(filename))}${extension}`
+
+export const getEntryFile = ({
+  commonPrefix,
+  featureFlags,
+  filename,
+  mainFile,
+  moduleFormat,
+  userNamespace,
+}: {
+  commonPrefix: string
+  featureFlags: FeatureFlags
+  filename: string
+  mainFile: string
+  moduleFormat: ModuleFormat
+  userNamespace: string
+}): EntryFile => {
+  const mainPath = normalizeFilePath({ commonPrefix, path: mainFile, userNamespace })
+  const extension = getFileExtensionForFormat(moduleFormat, featureFlags)
+  const entryFilename = getEntryFileName({ extension, filename })
+  const contents = getEntryFileContents(mainPath, moduleFormat)
+
+  return {
+    contents,
+    filename: entryFilename,
+  }
 }

--- a/src/runtimes/node/utils/entry_file.ts
+++ b/src/runtimes/node/utils/entry_file.ts
@@ -24,7 +24,7 @@ const getEntryFileContents = (mainPath: string, moduleFormat: string) => {
 const POSSIBLE_LAMBDA_ENTRY_EXTENSIONS = [ModuleFileExtension.JS, ModuleFileExtension.MJS, ModuleFileExtension.CJS]
 
 // checks if the file is considered a entry-file in AWS Lambda
-export const isEntryFile = (
+export const isNamedLikeEntryFile = (
   file: string,
   {
     basePath,
@@ -53,7 +53,7 @@ export const conflictsWithEntryFile = (
     filename: string
     mainFile: string
   },
-) => srcFiles.some((srcFile) => isEntryFile(srcFile, { basePath, filename }) && srcFile !== mainFile)
+) => srcFiles.some((srcFile) => isNamedLikeEntryFile(srcFile, { basePath, filename }) && srcFile !== mainFile)
 
 // Returns the name for the AWS Lambda entry file
 // We do set the handler in AWS Lambda to `<func-name>.handler` and because of

--- a/src/runtimes/node/utils/module_format.ts
+++ b/src/runtimes/node/utils/module_format.ts
@@ -19,5 +19,9 @@ export const getFileExtensionForFormat = (
     return ModuleFileExtension.MJS
   }
 
+  if (featureFlags.zisi_output_cjs_extension && moduleFormat === ModuleFormat.COMMONJS) {
+    return ModuleFileExtension.CJS
+  }
+
   return ModuleFileExtension.JS
 }

--- a/src/runtimes/node/utils/zip.ts
+++ b/src/runtimes/node/utils/zip.ts
@@ -12,7 +12,7 @@ import type { FeatureFlags } from '../../../feature_flags.js'
 import type { RuntimeCache } from '../../../utils/cache.js'
 import { cachedLstat, mkdirAndWriteFile } from '../../../utils/fs.js'
 
-import { conflictsWithEntryFile, EntryFile, getEntryFile, isEntryFile } from './entry_file.js'
+import { conflictsWithEntryFile, EntryFile, getEntryFile, isNamedLikeEntryFile } from './entry_file.js'
 import { ModuleFormat } from './module_format.js'
 import { normalizeFilePath } from './normalize_path.js'
 
@@ -110,7 +110,7 @@ const createZipArchive = async function ({
 
   // We don't need an entry file if it would end up with the same path as the
   // function's main file.
-  const needsEntryFile = !isEntryFile(mainFile, { basePath, filename })
+  const needsEntryFile = !isNamedLikeEntryFile(mainFile, { basePath, filename })
 
   // There is a naming conflict with the entry file if one of the supporting
   // files (i.e. not the main file) has the path that the entry file needs to

--- a/src/runtimes/node/utils/zip.ts
+++ b/src/runtimes/node/utils/zip.ts
@@ -1,7 +1,7 @@
 import { Buffer } from 'buffer'
 import { Stats, promises as fs } from 'fs'
 import os from 'os'
-import { basename, join, resolve } from 'path'
+import { basename, join } from 'path'
 
 import { copyFile } from 'cp-file'
 import { deleteAsync as deleteFiles } from 'del'
@@ -12,8 +12,8 @@ import type { FeatureFlags } from '../../../feature_flags.js'
 import type { RuntimeCache } from '../../../utils/cache.js'
 import { cachedLstat, mkdirAndWriteFile } from '../../../utils/fs.js'
 
-import { getEntryFile } from './entry_file.js'
-import { getFileExtensionForFormat, ModuleFormat } from './module_format.js'
+import { conflictsWithEntryFile, EntryFile, getEntryFile, isEntryFile } from './entry_file.js'
+import { ModuleFormat } from './module_format.js'
 import { normalizeFilePath } from './normalize_path.js'
 
 // Taken from https://www.npmjs.com/package/cpy.
@@ -51,23 +51,22 @@ const createDirectory = async function ({
   rewrites = new Map(),
   srcFiles,
 }: ZipNodeParameters) {
-  const entryFile = getEntryFile({
+  const { contents: entryContents, filename: entryFilename } = getEntryFile({
     commonPrefix: basePath,
+    featureFlags,
+    filename,
     mainFile,
     moduleFormat,
     userNamespace: DEFAULT_USER_SUBDIRECTORY,
   })
-  const entryFileExtension = getFileExtensionForFormat(moduleFormat, featureFlags)
-  const entryFilename = basename(filename, extension) + entryFileExtension
   const functionFolder = join(destFolder, basename(filename, extension))
-  const entryFilePath = resolve(functionFolder, entryFilename)
 
   // Deleting the functions directory in case it exists before creating it.
   await deleteFiles(functionFolder, { force: true })
   await fs.mkdir(functionFolder, { recursive: true })
 
   // Writing entry file.
-  await fs.writeFile(entryFilePath, entryFile)
+  await fs.writeFile(join(functionFolder, entryFilename), entryContents)
 
   // Copying source files.
   await pMap(
@@ -108,27 +107,35 @@ const createZipArchive = async function ({
 }: ZipNodeParameters) {
   const destPath = join(destFolder, `${basename(filename, extension)}.zip`)
   const { archive, output } = startZip(destPath)
-  const entryFileExtension = getFileExtensionForFormat(moduleFormat, featureFlags)
-  const entryFilename = basename(filename, extension) + entryFileExtension
-  const entryFilePath = resolve(basePath, entryFilename)
 
   // We don't need an entry file if it would end up with the same path as the
   // function's main file.
-  const needsEntryFile = entryFilePath !== mainFile
+  const needsEntryFile = !isEntryFile(mainFile, { basePath, filename })
 
   // There is a naming conflict with the entry file if one of the supporting
   // files (i.e. not the main file) has the path that the entry file needs to
   // take.
-  const hasEntryFileConflict = srcFiles.some((srcFile) => srcFile === entryFilePath && srcFile !== mainFile)
+  const hasEntryFileConflict = conflictsWithEntryFile(srcFiles, {
+    basePath,
+    filename,
+    mainFile,
+  })
 
   // If there is a naming conflict, we move all user files (everything other
   // than the entry file) to its own sub-directory.
   const userNamespace = hasEntryFileConflict ? DEFAULT_USER_SUBDIRECTORY : ''
 
   if (needsEntryFile) {
-    const entryFile = getEntryFile({ commonPrefix: basePath, mainFile, moduleFormat, userNamespace })
+    const entryFile = getEntryFile({
+      commonPrefix: basePath,
+      filename,
+      mainFile,
+      moduleFormat,
+      userNamespace,
+      featureFlags,
+    })
 
-    addEntryFileToZip(archive, entryFile, basename(entryFilePath))
+    addEntryFileToZip(archive, entryFile)
   }
 
   const srcFilesInfos = await Promise.all(srcFiles.map((file) => addStat(cache, file)))
@@ -163,10 +170,10 @@ export const zipNodeJs = function ({
   return createDirectory(options)
 }
 
-const addEntryFileToZip = function (archive: ZipArchive, contents: string, filename: string) {
-  const contentBuffer = Buffer.from(contents)
+const addEntryFileToZip = function (archive: ZipArchive, entryFile: EntryFile) {
+  const contentBuffer = Buffer.from(entryFile.contents)
 
-  addZipContent(archive, contentBuffer, filename)
+  addZipContent(archive, contentBuffer, entryFile.filename)
 }
 
 const addStat = async function (cache: RuntimeCache, srcFile: string) {

--- a/src/runtimes/node/utils/zip.ts
+++ b/src/runtimes/node/utils/zip.ts
@@ -170,10 +170,10 @@ export const zipNodeJs = function ({
   return createDirectory(options)
 }
 
-const addEntryFileToZip = function (archive: ZipArchive, entryFile: EntryFile) {
-  const contentBuffer = Buffer.from(entryFile.contents)
+const addEntryFileToZip = function (archive: ZipArchive, { contents, filename }: EntryFile) {
+  const contentBuffer = Buffer.from(contents)
 
-  addZipContent(archive, contentBuffer, entryFile.filename)
+  addZipContent(archive, contentBuffer, filename)
 }
 
 const addStat = async function (cache: RuntimeCache, srcFile: string) {

--- a/tests/fixtures/node-js-extension/func1.js
+++ b/tests/fixtures/node-js-extension/func1.js
@@ -1,0 +1,1 @@
+module.exports.handler = () => true

--- a/tests/fixtures/node-js-extension/func2/func2.js
+++ b/tests/fixtures/node-js-extension/func2/func2.js
@@ -1,0 +1,1 @@
+module.exports.handler = () => true

--- a/tests/fixtures/node-js-extension/func3/index.js
+++ b/tests/fixtures/node-js-extension/func3/index.js
@@ -1,0 +1,1 @@
+module.exports.handler = () => true

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -2473,7 +2473,7 @@ describe('zip-it-and-ship-it', () => {
   })
 
   testMany(
-    'bundlers emit entry file with cjs extension when FF on',
+    'Emits entry file with .cjs extension when `zisi_output_cjs_extension` flag is on',
     ['bundler_default', 'bundler_esbuild', 'bundler_nft'],
     async (options) => {
       const fixtureName = 'node-esm'
@@ -2499,7 +2499,7 @@ describe('zip-it-and-ship-it', () => {
     },
   )
 
-  testMany('bundlers keep cjs file extension', ['bundler_default', 'bundler_nft'], async (options) => {
+  testMany('Keeps .cjs extension', ['bundler_default', 'bundler_nft'], async (options) => {
     const fixtureName = 'node-cjs-extension'
     const opts = merge(options, {
       basePath: join(FIXTURES_DIR, fixtureName),
@@ -2521,7 +2521,7 @@ describe('zip-it-and-ship-it', () => {
   })
 
   testMany(
-    'bundlers do not create cjs entry file if entry with js extension is already present',
+    'Does not create .cjs entry file if entry with .js extension is already present',
     ['bundler_default', 'bundler_nft'],
     async (options) => {
       const fixtureName = 'node-js-extension'

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -1000,7 +1000,7 @@ describe('zip-it-and-ship-it', () => {
 
   testMany(
     'Handles a JavaScript function ({name}.cjs, {name}/{name}.cjs, {name}/index.cjs)',
-    ['bundler_esbuild', 'bundler_default'],
+    ['bundler_esbuild'],
     async (options) => {
       const { files, tmpDir } = await zipFixture('node-cjs-extension', {
         length: 3,
@@ -1017,6 +1017,32 @@ describe('zip-it-and-ship-it', () => {
       const { handler: handler1 } = await importFunctionFile(`${tmpDir}/func1.js`)
       expect(handler1()).toBe(true)
       const { handler: handler2 } = await importFunctionFile(`${tmpDir}/func2.js`)
+      expect(handler2()).toBe(true)
+      const { handler: handler3 } = await importFunctionFile(`${tmpDir}/func3.js`)
+      expect(handler3()).toBe(true)
+    },
+  )
+
+  // TODO can be merged with the above once the FF is on `zisi_output_cjs_extension`
+  testMany(
+    'Handles a JavaScript function ({name}.cjs, {name}/{name}.cjs, {name}/index.cjs)',
+    ['bundler_default'],
+    async (options) => {
+      const { files, tmpDir } = await zipFixture('node-cjs-extension', {
+        length: 3,
+        opts: options,
+      })
+
+      await unzipFiles(files)
+
+      expect(files).toHaveLength(3)
+      files.forEach((file) => {
+        expect(file.bundler).toBe(options.getCurrentBundlerName() ?? 'zisi')
+      })
+
+      const { handler: handler1 } = await importFunctionFile(`${tmpDir}/func1.cjs`)
+      expect(handler1()).toBe(true)
+      const { handler: handler2 } = await importFunctionFile(`${tmpDir}/func2.cjs`)
       expect(handler2()).toBe(true)
       const { handler: handler3 } = await importFunctionFile(`${tmpDir}/func3.js`)
       expect(handler3()).toBe(true)
@@ -2445,4 +2471,81 @@ describe('zip-it-and-ship-it', () => {
     expect(result.stderr).not.toContain('Dynamic require of "path" is not supported')
     expect(result).not.toBeInstanceOf(Error)
   })
+
+  testMany(
+    'bundlers emit entry file with cjs extension when FF on',
+    ['bundler_default', 'bundler_esbuild', 'bundler_nft'],
+    async (options) => {
+      const fixtureName = 'node-esm'
+      const opts = merge(options, {
+        basePath: join(FIXTURES_DIR, fixtureName),
+        featureFlags: { zisi_output_cjs_extension: true },
+      })
+      const { files, tmpDir } = await zipFixture(fixtureName, {
+        length: 2,
+        opts,
+      })
+
+      await unzipFiles(files)
+
+      const bundledFile2 = await importFunctionFile(join(tmpDir, 'func2.cjs'))
+      expect(bundledFile2.handler()).toBe(true)
+
+      if (options.getCurrentBundlerName() === 'esbuild') {
+        // nft does not create an entry here because the main file is already an entrypoint
+        const bundledFile1 = await importFunctionFile(join(tmpDir, 'func1.cjs'))
+        expect(bundledFile1.handler()).toBe(true)
+      }
+    },
+  )
+
+  testMany('bundlers keep cjs file extension', ['bundler_default', 'bundler_nft'], async (options) => {
+    const fixtureName = 'node-cjs-extension'
+    const opts = merge(options, {
+      basePath: join(FIXTURES_DIR, fixtureName),
+    })
+    const { files, tmpDir } = await zipFixture(fixtureName, {
+      length: 3,
+      opts,
+    })
+
+    await unzipFiles(files)
+
+    const bundledFile1 = await importFunctionFile(join(tmpDir, 'func1.cjs'))
+    const bundledFile2 = await importFunctionFile(join(tmpDir, 'func2.cjs'))
+    const bundledFile3 = await importFunctionFile(join(tmpDir, 'index.cjs'))
+
+    expect(bundledFile1.handler()).toBe(true)
+    expect(bundledFile2.handler()).toBe(true)
+    expect(bundledFile3.handler()).toBe(true)
+  })
+
+  testMany(
+    'bundlers do not create cjs entry file if entry with js extension is already present',
+    ['bundler_default', 'bundler_nft'],
+    async (options) => {
+      const fixtureName = 'node-js-extension'
+      const opts = merge(options, {
+        basePath: join(FIXTURES_DIR, fixtureName),
+        featureFlags: { zisi_output_cjs_extension: true },
+      })
+      const { files, tmpDir } = await zipFixture(fixtureName, {
+        length: 3,
+        opts,
+      })
+
+      await unzipFiles(files)
+
+      const bundledFile1 = await importFunctionFile(join(tmpDir, 'func1.js'))
+      const bundledFile2 = await importFunctionFile(join(tmpDir, 'func2.js'))
+
+      expect(bundledFile1.handler()).toBe(true)
+      expect(bundledFile2.handler()).toBe(true)
+
+      expect(`${tmpDir}/func1.cjs`).not.toPathExist()
+      expect(`${tmpDir}/func1.mjs`).not.toPathExist()
+      expect(`${tmpDir}/func2.cjs`).not.toPathExist()
+      expect(`${tmpDir}/func2.mjs`).not.toPathExist()
+    },
+  )
 })


### PR DESCRIPTION
### Summary

Fixes https://github.com/netlify/pod-compute/issues/149

This is behind a FF.

With FF enabled:
* esbuild outputs the bundle with cjs extension
* entry-file will be generated with `cjs` extension

Independent of FF we now check for file collisions with all possible entry-files `js, cjs, mjs` and not only with `js`. This is right now not as important as `js` takes precedence over `mjs and cjs` in AWS lambda, but once the FF is on this is critical as we generate the entry file with `cjs` extension but a user-non-main-file could be `func-name.js` and AWS would actually pick this one up instead of our entry-file.

Once we move to having a unique entry file like `__netlifyHandler.(c|m)js` we can clean this all up a lot.

For which functions will there be a hash change (with ff on):

- All functions that use the `*.cjs` file extension for the source function file
