### PR TITLE
feat!: output pure ESM for `.mjs` files

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -31,6 +31,7 @@ module.exports = {
         'import/extensions': 'off',
         'import/no-namespace': 'off',
         // https://github.com/typescript-eslint/typescript-eslint/issues/2483
+        'max-lines': 'off',
         'no-shadow': 'off',
         '@typescript-eslint/no-shadow': 'error',
       },

--- a/src/feature_flags.ts
+++ b/src/feature_flags.ts
@@ -1,10 +1,24 @@
 import { env } from 'process'
 
 export const defaultFlags: Record<string, boolean> = {
+  // Build Rust functions from source.
   buildRustSource: Boolean(env.NETLIFY_EXPERIMENTAL_BUILD_RUST_SOURCE),
+
+  // Use esbuild to trace dependencies in the legacy bundler.
   parseWithEsbuild: false,
+
+  // Use NFT as the default bundler.
   traceWithNft: false,
+
+  // Output pure (i.e. untranspiled) ESM files when the function file has ESM
+  // syntax and the parent `package.json` file has `{"type": "module"}`.
   zisi_pure_esm: false,
+
+  // Output pure (i.e. untranspiled) ESM files when the function file has a
+  // `.mjs` extension.
+  zisi_pure_esm_mjs: false,
+
+  // Load configuration from per-function JSON files.
   project_deploy_configuration_api_use_per_function_configuration_files: false,
 }
 

--- a/src/runtimes/node/bundlers/esbuild/bundler.ts
+++ b/src/runtimes/node/bundlers/esbuild/bundler.ts
@@ -1,6 +1,6 @@
 import { basename, dirname, extname, resolve, join } from 'path'
 
-import { build, Metafile } from '@netlify/esbuild'
+import { build, BuildOptions, Metafile } from '@netlify/esbuild'
 import { tmpName } from 'tmp-promise'
 
 import type { FunctionConfig } from '../../../../config.js'
@@ -8,6 +8,7 @@ import { FeatureFlags } from '../../../../feature_flags.js'
 import { FunctionBundlingUserError } from '../../../../utils/error.js'
 import { getPathWithExtension, safeUnlink } from '../../../../utils/fs.js'
 import { RuntimeType } from '../../../runtime.js'
+import { getFileExtensionForFormat, ModuleFileExtension, ModuleFormat } from '../../utils/module_format.js'
 import { NodeBundlerType } from '../types.js'
 
 import { getBundlerTarget, getModuleFormat } from './bundler_target.js'
@@ -32,6 +33,7 @@ export const bundleJsFile = async function ({
   externalModules = [],
   featureFlags,
   ignoredModules = [],
+  mainFile,
   name,
   srcDir,
   srcFile,
@@ -42,6 +44,7 @@ export const bundleJsFile = async function ({
   externalModules: string[]
   featureFlags: FeatureFlags
   ignoredModules: string[]
+  mainFile: string
   name: string
   srcDir: string
   srcFile: string
@@ -94,8 +97,19 @@ export const bundleJsFile = async function ({
   const { includedFiles: includedFilesFromModuleDetection, moduleFormat } = await getModuleFormat(
     srcDir,
     featureFlags,
+    extname(mainFile),
     config.nodeVersion,
   )
+
+  // The extension of the output file.
+  const extension = getFileExtensionForFormat(moduleFormat, featureFlags)
+
+  const outExtension: BuildOptions['outExtension'] = {}
+
+  // When outputting an ESM file, configure esbuild to produce a `.mjs` file.
+  if (moduleFormat === ModuleFormat.ESM) {
+    outExtension[ModuleFileExtension.JS] = ModuleFileExtension.MJS
+  }
 
   try {
     const { metafile = { inputs: {}, outputs: {} }, warnings } = await build({
@@ -107,6 +121,7 @@ export const bundleJsFile = async function ({
       logLimit: ESBUILD_LOG_LIMIT,
       metafile: true,
       nodePaths: additionalModulePaths,
+      outExtension,
       outdir: targetDirectory,
       platform: 'node',
       plugins,
@@ -117,6 +132,7 @@ export const bundleJsFile = async function ({
     })
     const bundlePaths = getBundlePaths({
       destFolder: targetDirectory,
+      extension,
       outputs: metafile.outputs,
       srcFile,
     })
@@ -128,6 +144,7 @@ export const bundleJsFile = async function ({
       additionalPaths,
       bundlePaths,
       cleanTempFiles,
+      extension,
       inputs,
       moduleFormat,
       nativeNodeModules,
@@ -149,14 +166,16 @@ export const bundleJsFile = async function ({
 // with the `aliases` format used upstream.
 const getBundlePaths = ({
   destFolder,
+  extension: outputExtension,
   outputs,
   srcFile,
 }: {
   destFolder: string
+  extension: string
   outputs: Metafile['outputs']
   srcFile: string
 }) => {
-  const bundleFilename = `${basename(srcFile, extname(srcFile))}.js`
+  const bundleFilename = basename(srcFile, extname(srcFile)) + outputExtension
   const mainFileDirectory = dirname(srcFile)
   const bundlePaths: Map<string, string> = new Map()
 
@@ -171,11 +190,11 @@ const getBundlePaths = ({
     const absolutePath = join(destFolder, filename)
 
     if (output.entryPoint && basename(output.entryPoint) === basename(srcFile)) {
-      // Ensuring the main file has a `.js` extension.
-      const normalizedSrcFile = getPathWithExtension(srcFile, '.js')
+      // Ensuring the main file has the right extension.
+      const normalizedSrcFile = getPathWithExtension(srcFile, outputExtension)
 
       bundlePaths.set(absolutePath, normalizedSrcFile)
-    } else if (extension === '.js' || filename === `${bundleFilename}.map`) {
+    } else if (extension === outputExtension || filename === `${bundleFilename}.map`) {
       bundlePaths.set(absolutePath, join(mainFileDirectory, filename))
     }
   })

--- a/src/runtimes/node/bundlers/esbuild/bundler.ts
+++ b/src/runtimes/node/bundlers/esbuild/bundler.ts
@@ -104,12 +104,9 @@ export const bundleJsFile = async function ({
   // The extension of the output file.
   const extension = getFileExtensionForFormat(moduleFormat, featureFlags)
 
-  const outExtension: BuildOptions['outExtension'] = {}
-
   // When outputting an ESM file, configure esbuild to produce a `.mjs` file.
-  if (moduleFormat === ModuleFormat.ESM) {
-    outExtension[ModuleFileExtension.JS] = ModuleFileExtension.MJS
-  }
+  const outExtension =
+    moduleFormat === ModuleFormat.ESM ? { [ModuleFileExtension.JS]: ModuleFileExtension.MJS } : undefined
 
   try {
     const { metafile = { inputs: {}, outputs: {} }, warnings } = await build({

--- a/src/runtimes/node/bundlers/esbuild/bundler.ts
+++ b/src/runtimes/node/bundlers/esbuild/bundler.ts
@@ -1,6 +1,6 @@
 import { basename, dirname, extname, resolve, join } from 'path'
 
-import { build, BuildOptions, Metafile } from '@netlify/esbuild'
+import { build, Metafile } from '@netlify/esbuild'
 import { tmpName } from 'tmp-promise'
 
 import type { FunctionConfig } from '../../../../config.js'

--- a/src/runtimes/node/bundlers/esbuild/bundler_target.ts
+++ b/src/runtimes/node/bundlers/esbuild/bundler_target.ts
@@ -1,5 +1,5 @@
 import { FeatureFlags } from '../../../../feature_flags'
-import { ModuleFormat } from '../../utils/module_format'
+import { ModuleFileExtension, ModuleFormat } from '../../utils/module_format'
 import {
   DEFAULT_NODE_VERSION,
   getNodeSupportMatrix,
@@ -31,8 +31,16 @@ const getBundlerTarget = (suppliedVersion?: NodeVersionString): VersionValues =>
 const getModuleFormat = async (
   srcDir: string,
   featureFlags: FeatureFlags,
+  extension: string,
   configVersion?: string,
 ): Promise<{ includedFiles: string[]; moduleFormat: ModuleFormat }> => {
+  if (extension === ModuleFileExtension.MJS && featureFlags.zisi_pure_esm_mjs) {
+    return {
+      includedFiles: [],
+      moduleFormat: ModuleFormat.ESM,
+    }
+  }
+
   const packageJsonFile = await getClosestPackageJson(srcDir)
   const nodeSupport = getNodeSupportMatrix(configVersion)
 

--- a/src/runtimes/node/bundlers/esbuild/index.ts
+++ b/src/runtimes/node/bundlers/esbuild/index.ts
@@ -68,6 +68,7 @@ const bundle: BundleFunction = async ({
     additionalPaths,
     bundlePaths,
     cleanTempFiles,
+    extension: outputExtension,
     inputs,
     moduleFormat,
     nativeNodeModules = {},
@@ -80,6 +81,7 @@ const bundle: BundleFunction = async ({
     externalModules,
     featureFlags,
     ignoredModules,
+    mainFile,
     name,
     srcDir,
     srcFile: mainFile,
@@ -109,7 +111,7 @@ const bundle: BundleFunction = async ({
   // path of the original, pre-bundling function file. We'll add the actual
   // bundled file further below.
   const supportingSrcFiles = srcFiles.filter((path) => path !== mainFile)
-  const normalizedMainFile = getPathWithExtension(mainFile, '.js')
+  const normalizedMainFile = getPathWithExtension(mainFile, outputExtension)
   const functionBasePath = getFunctionBasePath({
     basePathFromConfig: basePath,
     mainFile,

--- a/src/runtimes/node/bundlers/index.ts
+++ b/src/runtimes/node/bundlers/index.ts
@@ -3,6 +3,7 @@ import { extname } from 'path'
 import { FunctionConfig } from '../../../config.js'
 import { FeatureFlags } from '../../../feature_flags.js'
 import { detectEsModule } from '../utils/detect_es_module.js'
+import { ModuleFileExtension } from '../utils/module_format.js'
 
 import esbuildBundler from './esbuild/index.js'
 import nftBundler from './nft/index.js'
@@ -61,6 +62,10 @@ const getDefaultBundler = async ({
   mainFile: string
   featureFlags: FeatureFlags
 }): Promise<NodeBundlerType> => {
+  if (extension === ModuleFileExtension.MJS && featureFlags.zisi_pure_esm_mjs) {
+    return NodeBundlerType.NFT
+  }
+
   if (ESBUILD_EXTENSIONS.has(extension)) {
     return NodeBundlerType.ESBUILD
   }
@@ -69,7 +74,7 @@ const getDefaultBundler = async ({
     return NodeBundlerType.NFT
   }
 
-  const functionIsESM = extname(mainFile) !== '.cjs' && (await detectEsModule({ mainFile }))
+  const functionIsESM = extname(mainFile) !== ModuleFileExtension.CJS && (await detectEsModule({ mainFile }))
 
   return functionIsESM ? NodeBundlerType.NFT : NodeBundlerType.ZISI
 }

--- a/src/runtimes/node/bundlers/zisi/src_files.ts
+++ b/src/runtimes/node/bundlers/zisi/src_files.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines */
 import { dirname, basename, normalize } from 'path'
 
 import { not as notJunk } from 'junk'
@@ -208,4 +207,3 @@ const getTreeShakedDependencies = async function ({
 
   return [path, ...depsPath]
 }
-/* eslint-enable max-lines */

--- a/src/runtimes/node/index.ts
+++ b/src/runtimes/node/index.ts
@@ -103,6 +103,7 @@ const zipFunction: ZipFunction = async function ({
     basePath: finalBasePath,
     destFolder,
     extension,
+    featureFlags,
     filename,
     mainFile: finalMainFile,
     moduleFormat,

--- a/src/runtimes/node/parser/index.ts
+++ b/src/runtimes/node/parser/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines */
 import { promises as fs } from 'fs'
 import { join, relative, resolve } from 'path'
 
@@ -225,4 +224,3 @@ const validateGlobNodes = (globNodes: string[]) => {
 
   return hasStrings && hasStaticHead
 }
-/* eslint-enable max-lines */

--- a/src/runtimes/node/utils/entry_file.ts
+++ b/src/runtimes/node/utils/entry_file.ts
@@ -1,14 +1,18 @@
-import { basename, extname } from 'path'
-
 import { ModuleFormat } from './module_format.js'
 import { normalizeFilePath } from './normalize_path.js'
 
-export interface EntryFile {
-  contents: string
-  filename: string
-}
-
-const getEntryFileContents = (mainPath: string, moduleFormat: string) => {
+export const getEntryFile = ({
+  commonPrefix,
+  mainFile,
+  moduleFormat,
+  userNamespace,
+}: {
+  commonPrefix: string
+  mainFile: string
+  moduleFormat: ModuleFormat
+  userNamespace: string
+}) => {
+  const mainPath = normalizeFilePath({ commonPrefix, path: mainFile, userNamespace })
   const importPath = `.${mainPath.startsWith('/') ? mainPath : `/${mainPath}`}`
 
   if (moduleFormat === ModuleFormat.COMMONJS) {
@@ -16,28 +20,4 @@ const getEntryFileContents = (mainPath: string, moduleFormat: string) => {
   }
 
   return `export { handler } from '${importPath}'`
-}
-
-export const getEntryFile = ({
-  commonPrefix,
-  filename,
-  mainFile,
-  moduleFormat,
-  userNamespace,
-}: {
-  commonPrefix: string
-  filename: string
-  mainFile: string
-  moduleFormat: ModuleFormat
-  userNamespace: string
-}): EntryFile => {
-  const mainPath = normalizeFilePath({ commonPrefix, path: mainFile, userNamespace })
-  const extension = extname(filename)
-  const entryFilename = `${basename(filename, extension)}.js`
-  const contents = getEntryFileContents(mainPath, moduleFormat)
-
-  return {
-    contents,
-    filename: entryFilename,
-  }
 }

--- a/src/runtimes/node/utils/module_format.ts
+++ b/src/runtimes/node/utils/module_format.ts
@@ -1,4 +1,23 @@
+import type { FeatureFlags } from '../../../feature_flags.js'
+
 export const enum ModuleFormat {
   COMMONJS = 'cjs',
   ESM = 'esm',
+}
+
+export const enum ModuleFileExtension {
+  CJS = '.cjs',
+  JS = '.js',
+  MJS = '.mjs',
+}
+
+export const getFileExtensionForFormat = (
+  moduleFormat: ModuleFormat,
+  featureFlags: FeatureFlags,
+): ModuleFileExtension => {
+  if (moduleFormat === ModuleFormat.ESM && featureFlags.zisi_pure_esm_mjs) {
+    return ModuleFileExtension.MJS
+  }
+
+  return ModuleFileExtension.JS
 }

--- a/tests/fixtures/node-mjs-extension/func1.mjs
+++ b/tests/fixtures/node-mjs-extension/func1.mjs
@@ -1,1 +1,3 @@
-export const handler = () => true
+import { format } from 'some-module'
+
+export const handler = () => format === 'esm'

--- a/tests/fixtures/node-mjs-extension/func2/func2.mjs
+++ b/tests/fixtures/node-mjs-extension/func2/func2.mjs
@@ -1,1 +1,3 @@
-export const handler = () => true
+import { format } from 'some-module'
+
+export const handler = () => format === 'esm'

--- a/tests/fixtures/node-mjs-extension/func3/index.mjs
+++ b/tests/fixtures/node-mjs-extension/func3/index.mjs
@@ -1,1 +1,3 @@
-export const handler = () => true
+import { format } from 'some-module'
+
+export const handler = () => format === 'esm'

--- a/tests/fixtures/node-mjs-extension/node_modules/some-module/index.js
+++ b/tests/fixtures/node-mjs-extension/node_modules/some-module/index.js
@@ -1,0 +1,1 @@
+export const format = 'esm'

--- a/tests/fixtures/node-mjs-extension/node_modules/some-module/package.json
+++ b/tests/fixtures/node-mjs-extension/node_modules/some-module/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "index.js",
+  "type": "module"
+}

--- a/tests/main.js
+++ b/tests/main.js
@@ -2890,3 +2890,34 @@ testMany('None bundler emits esm with default nodeVersion', ['bundler_none'], as
 
   t.is(originalFile, bundledFile)
 })
+
+testMany(
+  'Can bundle native ESM functions when the extension is `.mjs` and the `zisi_pure_esm_mjs` feature flag is on',
+  allBundleConfigs,
+  async (options, t) => {
+    const length = 3
+    const fixtureName = 'node-mjs-extension'
+    const opts = merge(options, {
+      basePath: join(FIXTURES_DIR, fixtureName),
+      featureFlags: { zisi_pure_esm_mjs: true },
+    })
+    const { files, tmpDir } = await zipFixture(t, fixtureName, {
+      length,
+      opts,
+    })
+
+    await unzipFiles(files, (path) => `${path}/../${basename(path)}_out`)
+
+    for (let index = 1; index <= length; index++) {
+      const funcDir = join(tmpDir, `func${index}.zip_out`)
+
+      await writeFile(join(funcDir, 'package.json'), JSON.stringify({ type: 'module' }))
+
+      const funcFile = join(funcDir, `func${index}.mjs`)
+      const func = await importFunctionFile(funcFile)
+
+      t.true(func.handler())
+      t.true(await detectEsModule({ mainFile: funcFile }))
+    }
+  },
+)

--- a/tests/main.js
+++ b/tests/main.js
@@ -2911,6 +2911,8 @@ testMany(
     for (let index = 1; index <= length; index++) {
       const funcDir = join(tmpDir, `func${index}.zip_out`)
 
+      // Writing a basic package.json with `type: "module"` just so that we can
+      // import the functions from the test.
       await writeFile(join(funcDir, 'package.json'), JSON.stringify({ type: 'module' }))
 
       const funcFile = join(funcDir, `func${index}.mjs`)


### PR DESCRIPTION
#### Summary

Currently, ESM functions are transpiled down to CommonJS. With this PR, we'll output pure ESM functions when:

- The input function file has the `.mjs` extension, and
- The `zisi_pure_esm_mjs` feature flag is on

Part of https://github.com/netlify/zip-it-and-ship-it/issues/750.