### PR TITLE
feat: add `nodeModuleFormat` configuration property

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,7 @@ import type { FeatureFlags } from './feature_flags.js'
 import { FunctionSource } from './function.js'
 import type { NodeBundlerType } from './runtimes/node/bundlers/types.js'
 import type { NodeVersionString } from './runtimes/node/index.js'
+import type { ModuleFormat } from './runtimes/node/utils/module_format.js'
 import { minimatch } from './utils/matching.js'
 
 interface FunctionConfig {
@@ -22,6 +23,11 @@ interface FunctionConfig {
   rustTargetDirectory?: string
   schedule?: string
   zipGo?: boolean
+
+  // Temporary configuration property, only meant to be used by the deploy
+  // configuration API. Once we start emitting ESM files for all ESM functions,
+  // we can remove this.
+  nodeModuleFormat?: ModuleFormat
 }
 
 interface FunctionConfigFile {

--- a/src/feature_flags.ts
+++ b/src/feature_flags.ts
@@ -27,7 +27,7 @@ export type FeatureFlags = Record<FeatureFlag, boolean>
 
 // List of supported flags and their default value.
 
-export const getFlags = (input: Record<string, boolean> = {}, flags = defaultFlags) =>
+export const getFlags = (input: Record<string, boolean> = {}, flags = defaultFlags): FeatureFlags =>
   Object.entries(flags).reduce(
     (result, [key, defaultValue]) => ({
       ...result,


### PR DESCRIPTION
#### Summary

Adds a `nodeModuleFormat` configuration property. When set to `esm`, it produces the same effect as enabling the `zisi_pure_esm_mjs` feature flag enabled in https://github.com/netlify/zip-it-and-ship-it/pull/1198.