### PR TITLE
fix: emit declaration for ListedFunction for upstream usage in @netlify/build

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,7 @@ export { NodeBundlerType } from './runtimes/node/bundlers/types.js'
 export { RuntimeType } from './runtimes/runtime.js'
 export { ModuleFormat } from './runtimes/node/utils/module_format.js'
 
-interface ListedFunction {
+export interface ListedFunction {
   name: string
   mainFile: string
   runtime: RuntimeType


### PR DESCRIPTION
#### Summary

To migrate @netlify/build to typescript (part of https://github.com/netlify/build/issues/4472) and make it transpile we need this interface to be exported as it is the return type of a used function

```typescript
const getListedFunction = function ({
  runtime,
  name,
  mainFile,
  extension,
  config,
  inSourceConfig,
}: AugmentedFunctionSource): ListedFunction {
  return { name, mainFile, runtime: runtime.name, extension, schedule: inSourceConfig?.schedule ?? config.schedule }
}
```

This changes fixes following error in netlify build:

![CleanShot 2022-09-08 at 11 32 36](https://user-images.githubusercontent.com/11156362/189088195-b5d807d2-accf-45d7-98d7-f82c243ce1f9.png)



---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/zip-it-and-ship-it/issues/new/choose) before writing your code 🧑‍💻.
      This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing
      a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
