### PR TITLE
feat: improve performance by reworking caching and supply cache to NFT

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,6 @@
         "p-map": "^4.0.0",
         "path-exists": "^5.0.0",
         "precinct": "^9.0.1",
-        "read-package-json-fast": "^2.0.2",
         "require-package-name": "^2.0.1",
         "resolve": "^2.0.0-next.1",
         "semver": "^7.0.0",
@@ -6984,7 +6983,8 @@
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -7670,11 +7670,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/npm-normalize-package-bin": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
-      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA=="
     },
     "node_modules/npm-run-all": {
       "version": "4.1.5",
@@ -8543,18 +8538,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
-    },
-    "node_modules/read-package-json-fast": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/read-package-json-fast/-/read-package-json-fast-2.0.3.tgz",
-      "integrity": "sha512-W/BKtbL+dUjTuRL2vziuYhp76s5HZ9qQhd/dKfWIZveD0O40453QNyZhC0e63lqZrAQ4jiOapVoeJ7JrszenQQ==",
-      "dependencies": {
-        "json-parse-even-better-errors": "^2.3.0",
-        "npm-normalize-package-bin": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/read-pkg": {
       "version": "3.0.0",
@@ -15061,7 +15044,8 @@
     "json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
     },
     "json-schema-traverse": {
       "version": "1.0.0",
@@ -15572,11 +15556,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
-    },
-    "npm-normalize-package-bin": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
-      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA=="
     },
     "npm-run-all": {
       "version": "4.1.5",
@@ -16158,15 +16137,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
-    },
-    "read-package-json-fast": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/read-package-json-fast/-/read-package-json-fast-2.0.3.tgz",
-      "integrity": "sha512-W/BKtbL+dUjTuRL2vziuYhp76s5HZ9qQhd/dKfWIZveD0O40453QNyZhC0e63lqZrAQ4jiOapVoeJ7JrszenQQ==",
-      "requires": {
-        "json-parse-even-better-errors": "^2.3.0",
-        "npm-normalize-package-bin": "^1.0.1"
-      }
     },
     "read-pkg": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "p-map": "^4.0.0",
     "path-exists": "^5.0.0",
     "precinct": "^9.0.1",
-    "read-package-json-fast": "^2.0.2",
     "require-package-name": "^2.0.1",
     "resolve": "^2.0.0-next.1",
     "semver": "^7.0.0",

--- a/src/feature_flags.ts
+++ b/src/feature_flags.ts
@@ -20,6 +20,12 @@ export const defaultFlags: Record<string, boolean> = {
 
   // Load configuration from per-function JSON files.
   project_deploy_configuration_api_use_per_function_configuration_files: false,
+
+  // Enable runtime cache for NFT
+  zisi_nft_use_cache: false,
+
+  // Raise file IO limit for NFT
+  zisi_nft_higher_fileio_limit: false,
 }
 
 export type FeatureFlag = keyof typeof defaultFlags

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import { FunctionSource } from './function.js'
 import { getFunctionFromPath, getFunctionsFromPaths } from './runtimes/index.js'
 import { findISCDeclarationsInPath, ISCValues } from './runtimes/node/in_source_config/index.js'
 import { GetSrcFilesFunction, RuntimeType } from './runtimes/runtime.js'
+import { createNewCache } from './utils/cache.js'
 import { listFunctionsDirectories, resolveFunctionsDirectories } from './utils/fs.js'
 
 export { zipFunction, zipFunctions } from './zip.js'
@@ -60,7 +61,8 @@ export const listFunctions = async function (
   const featureFlags = getFlags(inputFeatureFlags)
   const srcFolders = resolveFunctionsDirectories(relativeSrcFolders)
   const paths = await listFunctionsDirectories(srcFolders)
-  const functionsMap = await getFunctionsFromPaths(paths, { featureFlags, config })
+  const cache = createNewCache()
+  const functionsMap = await getFunctionsFromPaths(paths, { cache, config, featureFlags })
   const functions = [...functionsMap.values()]
   const augmentedFunctions = parseISC ? await Promise.all(functions.map(augmentWithISC)) : functions
 
@@ -77,7 +79,8 @@ export const listFunction = async function (
   }: { featureFlags?: FeatureFlags; config?: Config; parseISC?: boolean } = {},
 ) {
   const featureFlags = getFlags(inputFeatureFlags)
-  const func = await getFunctionFromPath(path, { featureFlags, config })
+  const cache = createNewCache()
+  const func = await getFunctionFromPath(path, { cache, config, featureFlags })
 
   if (!func) {
     return
@@ -96,7 +99,8 @@ export const listFunctionsFiles = async function (
   const featureFlags = getFlags(inputFeatureFlags)
   const srcFolders = resolveFunctionsDirectories(relativeSrcFolders)
   const paths = await listFunctionsDirectories(srcFolders)
-  const functionsMap = await getFunctionsFromPaths(paths, { config, featureFlags })
+  const cache = createNewCache()
+  const functionsMap = await getFunctionsFromPaths(paths, { cache, config, featureFlags })
   const functions = [...functionsMap.values()]
   const augmentedFunctions = parseISC ? await Promise.all(functions.map(augmentWithISC)) : functions
   const listedFunctionsFiles = await Promise.all(

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,7 @@ import { FunctionSource } from './function.js'
 import { getFunctionFromPath, getFunctionsFromPaths } from './runtimes/index.js'
 import { findISCDeclarationsInPath, ISCValues } from './runtimes/node/in_source_config/index.js'
 import { GetSrcFilesFunction, RuntimeType } from './runtimes/runtime.js'
-import { createNewCache } from './utils/cache.js'
+import { RuntimeCache } from './utils/cache.js'
 import { listFunctionsDirectories, resolveFunctionsDirectories } from './utils/fs.js'
 
 export { zipFunction, zipFunctions } from './zip.js'
@@ -61,7 +61,7 @@ export const listFunctions = async function (
   const featureFlags = getFlags(inputFeatureFlags)
   const srcFolders = resolveFunctionsDirectories(relativeSrcFolders)
   const paths = await listFunctionsDirectories(srcFolders)
-  const cache = createNewCache()
+  const cache = new RuntimeCache()
   const functionsMap = await getFunctionsFromPaths(paths, { cache, config, featureFlags })
   const functions = [...functionsMap.values()]
   const augmentedFunctions = parseISC ? await Promise.all(functions.map(augmentWithISC)) : functions
@@ -79,7 +79,7 @@ export const listFunction = async function (
   }: { featureFlags?: FeatureFlags; config?: Config; parseISC?: boolean } = {},
 ) {
   const featureFlags = getFlags(inputFeatureFlags)
-  const cache = createNewCache()
+  const cache = new RuntimeCache()
   const func = await getFunctionFromPath(path, { cache, config, featureFlags })
 
   if (!func) {
@@ -99,7 +99,7 @@ export const listFunctionsFiles = async function (
   const featureFlags = getFlags(inputFeatureFlags)
   const srcFolders = resolveFunctionsDirectories(relativeSrcFolders)
   const paths = await listFunctionsDirectories(srcFolders)
-  const cache = createNewCache()
+  const cache = new RuntimeCache()
   const functionsMap = await getFunctionsFromPaths(paths, { cache, config, featureFlags })
   const functions = [...functionsMap.values()]
   const augmentedFunctions = parseISC ? await Promise.all(functions.map(augmentWithISC)) : functions

--- a/src/runtimes/detect_runtime.ts
+++ b/src/runtimes/detect_runtime.ts
@@ -1,8 +1,6 @@
-import type { Buffer } from 'buffer'
+import { readFile } from 'fs/promises'
 
 import { detect, Runtime as BinaryRuntime, Arch, Platform, BinaryInfo } from '@netlify/binary-info'
-
-import { cachedReadFile, FsCache } from '../utils/fs.js'
 
 import { RuntimeType } from './runtime.js'
 
@@ -21,20 +19,10 @@ The binary needs to be built for Linux/Amd64, but it was built for ${Platform[bi
 }
 
 // Try to guess the runtime by inspecting the binary file.
-export const detectBinaryRuntime = async function ({
-  fsCache,
-  path,
-}: {
-  fsCache: FsCache
-  path: string
-}): Promise<RuntimeType | undefined> {
+export const detectBinaryRuntime = async function ({ path }: { path: string }): Promise<RuntimeType | undefined> {
   try {
-    const buffer = await cachedReadFile(fsCache, path)
-
-    // We're using the Type Assertion because the `cachedReadFile` abstraction
-    // loses part of the return type information. We can safely say it's a
-    // Buffer in this case because we're not specifying an encoding.
-    const binaryInfo = detect(buffer as Buffer)
+    const fileContents = await readFile(path)
+    const binaryInfo = detect(fileContents)
 
     if (!isValidFunctionBinary(binaryInfo)) {
       return warnIncompatibleBinary(path, binaryInfo)

--- a/src/runtimes/go/index.ts
+++ b/src/runtimes/go/index.ts
@@ -33,7 +33,7 @@ const detectGoFunction = async ({ cache, path }: { cache: RuntimeCache; path: st
 
   const directoryName = basename(path)
 
-  const files = await cachedReaddir(cache.readDirCache, path)
+  const files = await cachedReaddir(cache.readdirCache, path)
   const mainFileName = [`${directoryName}.go`, 'main.go'].find((name) => files.includes(name))
 
   if (mainFileName === undefined) {

--- a/src/runtimes/go/index.ts
+++ b/src/runtimes/go/index.ts
@@ -4,7 +4,8 @@ import { basename, dirname, extname, join } from 'path'
 import { copyFile } from 'cp-file'
 
 import { SourceFile } from '../../function.js'
-import { cachedLstat, cachedReaddir, FsCache } from '../../utils/fs.js'
+import type { RuntimeCache } from '../../utils/cache.js'
+import { cachedLstat, cachedReaddir } from '../../utils/fs.js'
 import { nonNullable } from '../../utils/non_nullable.js'
 import { zipBinary } from '../../zip_binary.js'
 import { detectBinaryRuntime } from '../detect_runtime.js'
@@ -23,8 +24,8 @@ interface GoBinary {
   stat: Stats
 }
 
-const detectGoFunction = async ({ fsCache, path }: { fsCache: FsCache; path: string }) => {
-  const stat = await cachedLstat(fsCache, path)
+const detectGoFunction = async ({ cache, path }: { cache: RuntimeCache; path: string }) => {
+  const stat = await cachedLstat(cache.lstatCache, path)
 
   if (!stat.isDirectory()) {
     return
@@ -32,9 +33,7 @@ const detectGoFunction = async ({ fsCache, path }: { fsCache: FsCache; path: str
 
   const directoryName = basename(path)
 
-  // @ts-expect-error TODO: The `makeCachedFunction` abstraction is causing the
-  // return value of `readdir` to be incorrectly typed.
-  const files = (await cachedReaddir(fsCache, path)) as string[]
+  const files = await cachedReaddir(cache.readDirCache, path)
   const mainFileName = [`${directoryName}.go`, 'main.go'].find((name) => files.includes(name))
 
   if (mainFileName === undefined) {
@@ -44,28 +43,28 @@ const detectGoFunction = async ({ fsCache, path }: { fsCache: FsCache; path: str
   return mainFileName
 }
 
-const findFunctionsInPaths: FindFunctionsInPathsFunction = async function ({ featureFlags, fsCache, paths }) {
-  const functions = await Promise.all(paths.map((path) => findFunctionInPath({ featureFlags, fsCache, path })))
+const findFunctionsInPaths: FindFunctionsInPathsFunction = async function ({ cache, featureFlags, paths }) {
+  const functions = await Promise.all(paths.map((path) => findFunctionInPath({ cache, featureFlags, path })))
 
   return functions.filter(nonNullable)
 }
 
-const findFunctionInPath: FindFunctionInPathFunction = async function ({ fsCache, path }) {
-  const runtime = await detectBinaryRuntime({ fsCache, path })
+const findFunctionInPath: FindFunctionInPathFunction = async function ({ cache, path }) {
+  const runtime = await detectBinaryRuntime({ path })
 
   if (runtime === RuntimeType.GO) {
-    return processBinary({ fsCache, path })
+    return processBinary({ cache, path })
   }
 
-  const goSourceFile = await detectGoFunction({ fsCache, path })
+  const goSourceFile = await detectGoFunction({ cache, path })
 
   if (goSourceFile) {
-    return processSource({ fsCache, mainFile: goSourceFile, path })
+    return processSource({ cache, mainFile: goSourceFile, path })
   }
 }
 
-const processBinary = async ({ fsCache, path }: { fsCache: FsCache; path: string }): Promise<SourceFile> => {
-  const stat = (await cachedLstat(fsCache, path)) as Stats
+const processBinary = async ({ cache, path }: { cache: RuntimeCache; path: string }): Promise<SourceFile> => {
+  const stat = await cachedLstat(cache.lstatCache, path)
   const extension = extname(path)
   const filename = basename(path)
   const name = basename(path, extname(path))
@@ -82,11 +81,11 @@ const processBinary = async ({ fsCache, path }: { fsCache: FsCache; path: string
 }
 
 const processSource = async ({
-  fsCache,
+  cache,
   mainFile,
   path,
 }: {
-  fsCache: FsCache
+  cache: RuntimeCache
   mainFile: string
   path: string
 }): Promise<SourceFile> => {
@@ -94,7 +93,7 @@ const processSource = async ({
   // the `FunctionSource` interface. We should revisit whether `stat` should be
   // part of that interface in the first place, or whether we could compute it
   // downstream when needed (maybe using the FS cache as an optimisation).
-  const stat = (await cachedLstat(fsCache, path)) as Stats
+  const stat = (await cachedLstat(cache.lstatCache, path)) as Stats
   const filename = basename(path)
   const extension = extname(mainFile)
   const name = basename(path, extname(path))

--- a/src/runtimes/node/bundlers/esbuild/plugin_dynamic_imports.ts
+++ b/src/runtimes/node/bundlers/esbuild/plugin_dynamic_imports.ts
@@ -3,9 +3,9 @@ import { basename, join, relative } from 'path'
 import type { Plugin } from '@netlify/esbuild'
 import { findUp, findUpStop, pathExists } from 'find-up'
 import normalizePath from 'normalize-path'
-import readPackageJson from 'read-package-json-fast'
 
 import { parseExpression } from '../../parser/index.js'
+import { readPackageJson } from '../../utils/package_json.js'
 
 type PackageCache = Map<string, Promise<string | undefined>>
 
@@ -102,11 +102,14 @@ const getPackageNameCached = ({
   resolveDir: string
   srcDir: string
 }) => {
-  if (!cache.has(resolveDir)) {
-    cache.set(resolveDir, getPackageName({ resolveDir, srcDir }))
+  let result = cache.get(resolveDir)
+
+  if (result === undefined) {
+    result = getPackageName({ resolveDir, srcDir })
+    cache.set(resolveDir, result)
   }
 
-  return cache.get(resolveDir)
+  return result
 }
 
 const getShimContents = ({

--- a/src/runtimes/node/bundlers/esbuild/plugin_native_modules.ts
+++ b/src/runtimes/node/bundlers/esbuild/plugin_native_modules.ts
@@ -1,10 +1,9 @@
 import path from 'path'
 
 import type { Plugin } from '@netlify/esbuild'
-import readPackageJson from 'read-package-json-fast'
 
 import { isNativeModule } from '../../utils/detect_native_module.js'
-import { PackageJson } from '../../utils/package_json.js'
+import { PackageJson, readPackageJson } from '../../utils/package_json.js'
 import type { NativeNodeModules } from '../types.js'
 
 type NativeModuleCacheEntry = [boolean | undefined, PackageJson]

--- a/src/runtimes/node/bundlers/esbuild/src_files.ts
+++ b/src/runtimes/node/bundlers/esbuild/src_files.ts
@@ -11,8 +11,8 @@ export const getSrcFiles: GetSrcFilesFunction = async ({ config, mainFile, plugi
     includedFilesBasePath,
   )
   const dependencyPaths = await getSrcFilesForDependencies({
-    dependencies: externalNodeModules,
     basedir: srcDir,
+    dependencies: externalNodeModules,
     pluginsModulesPath,
   })
   const srcFiles = filterExcludedPaths(dependencyPaths, excludePatterns)
@@ -25,13 +25,13 @@ export const getSrcFiles: GetSrcFilesFunction = async ({ config, mainFile, plugi
 }
 
 const getSrcFilesForDependencies = async function ({
-  dependencies: dependencyNames,
   basedir,
+  dependencies: dependencyNames,
   state = getNewCache(),
   pluginsModulesPath,
 }: {
-  dependencies: string[]
   basedir: string
+  dependencies: string[]
   state?: TraversalCache
   pluginsModulesPath?: string
 }) {

--- a/src/runtimes/node/bundlers/nft/es_modules.ts
+++ b/src/runtimes/node/bundlers/nft/es_modules.ts
@@ -4,15 +4,16 @@ import { NodeFileTraceReasons } from '@vercel/nft'
 
 import type { FunctionConfig } from '../../../../config.js'
 import { FeatureFlags } from '../../../../feature_flags.js'
-import { cachedReadFile, FsCache } from '../../../../utils/fs.js'
+import type { RuntimeCache } from '../../../../utils/cache.js'
+import { cachedReadFile } from '../../../../utils/fs.js'
 import { ModuleFileExtension, ModuleFormat } from '../../utils/module_format.js'
 import { getNodeSupportMatrix } from '../../utils/node_version.js'
 import { getPackageJsonIfAvailable, PackageJson } from '../../utils/package_json.js'
 
 import { transpile } from './transpile.js'
 
-const getPatchedESMPackages = async (packages: string[], fsCache: FsCache) => {
-  const patchedPackages = await Promise.all(packages.map((path) => patchESMPackage(path, fsCache)))
+const getPatchedESMPackages = async (packages: string[], cache: RuntimeCache) => {
+  const patchedPackages = await Promise.all(packages.map((path) => patchESMPackage(path, cache)))
   const patchedPackagesMap = new Map<string, string>()
 
   packages.forEach((packagePath, index) => {
@@ -37,8 +38,8 @@ const isEntrypointESM = ({
   return entrypointIsESM
 }
 
-const patchESMPackage = async (path: string, fsCache: FsCache) => {
-  const file = (await cachedReadFile(fsCache, path, 'utf8')) as string
+const patchESMPackage = async (path: string, cache: RuntimeCache) => {
+  const file = await cachedReadFile(cache.fileCache, path)
   const packageJson: PackageJson = JSON.parse(file)
   const patchedPackageJson = {
     ...packageJson,
@@ -50,19 +51,19 @@ const patchESMPackage = async (path: string, fsCache: FsCache) => {
 
 export const processESM = async ({
   basePath,
+  cache,
   config,
   esmPaths,
   featureFlags,
-  fsCache,
   mainFile,
   reasons,
   name,
 }: {
   basePath: string | undefined
+  cache: RuntimeCache
   config: FunctionConfig
   esmPaths: Set<string>
   featureFlags: FeatureFlags
-  fsCache: FsCache
   mainFile: string
   reasons: NodeFileTraceReasons
   name: string
@@ -94,7 +95,7 @@ export const processESM = async ({
     }
   }
 
-  const rewrites = await transpileESM({ basePath, config, esmPaths, fsCache, reasons, name })
+  const rewrites = await transpileESM({ basePath, cache, config, esmPaths, reasons, name })
 
   return {
     moduleFormat: ModuleFormat.COMMONJS,
@@ -148,21 +149,21 @@ const shouldTranspile = (
 
 const transpileESM = async ({
   basePath,
+  cache,
   config,
   esmPaths,
-  fsCache,
   reasons,
   name,
 }: {
   basePath: string | undefined
+  cache: RuntimeCache
   config: FunctionConfig
   esmPaths: Set<string>
-  fsCache: FsCache
   reasons: NodeFileTraceReasons
   name: string
 }) => {
-  const cache: Map<string, boolean> = new Map()
-  const pathsToTranspile = [...esmPaths].filter((path) => shouldTranspile(path, cache, esmPaths, reasons))
+  const shouldCompileCache: Map<string, boolean> = new Map()
+  const pathsToTranspile = [...esmPaths].filter((path) => shouldTranspile(path, shouldCompileCache, esmPaths, reasons))
   const pathsToTranspileSet = new Set(pathsToTranspile)
   const packageJsonPaths: string[] = [...reasons.entries()]
     .filter(([path, reason]) => {
@@ -175,7 +176,7 @@ const transpileESM = async ({
       return needsPatch
     })
     .map(([path]) => (basePath ? resolve(basePath, path) : resolve(path)))
-  const rewrites = await getPatchedESMPackages(packageJsonPaths, fsCache)
+  const rewrites = await getPatchedESMPackages(packageJsonPaths, cache)
 
   await Promise.all(
     pathsToTranspile.map(async (path) => {

--- a/src/runtimes/node/bundlers/nft/es_modules.ts
+++ b/src/runtimes/node/bundlers/nft/es_modules.ts
@@ -162,6 +162,7 @@ const transpileESM = async ({
   reasons: NodeFileTraceReasons
   name: string
 }) => {
+  // Used for memoizing the check for whether a path should be transpiled.
   const shouldCompileCache: Map<string, boolean> = new Map()
   const pathsToTranspile = [...esmPaths].filter((path) => shouldTranspile(path, shouldCompileCache, esmPaths, reasons))
   const pathsToTranspileSet = new Set(pathsToTranspile)

--- a/src/runtimes/node/bundlers/nft/index.ts
+++ b/src/runtimes/node/bundlers/nft/index.ts
@@ -5,7 +5,8 @@ import nftResolveDependency from '@vercel/nft/out/resolve-dependency.js'
 
 import type { FunctionConfig } from '../../../../config.js'
 import { FeatureFlags } from '../../../../feature_flags.js'
-import { cachedReadFile, FsCache } from '../../../../utils/fs.js'
+import type { RuntimeCache } from '../../../../utils/cache.js'
+import { cachedReadFile } from '../../../../utils/fs.js'
 import { minimatch } from '../../../../utils/matching.js'
 import { getBasePath } from '../../utils/base_path.js'
 import { filterExcludedPaths, getPathsOfIncludedFiles } from '../../utils/included_files.js'
@@ -25,6 +26,7 @@ const appearsToBeModuleName = (name: string) => !name.startsWith('.')
 
 const bundle: BundleFunction = async ({
   basePath,
+  cache,
   config,
   featureFlags,
   mainFile,
@@ -43,6 +45,7 @@ const bundle: BundleFunction = async ({
     rewrites,
   } = await traceFilesAndTranspile({
     basePath: repositoryRoot,
+    cache,
     config,
     featureFlags,
     mainFile,
@@ -75,6 +78,7 @@ const ignoreFunction = (path: string) => {
 
 const traceFilesAndTranspile = async function ({
   basePath,
+  cache,
   config,
   featureFlags,
   mainFile,
@@ -82,23 +86,25 @@ const traceFilesAndTranspile = async function ({
   name,
 }: {
   basePath?: string
+  cache: RuntimeCache
   config: FunctionConfig
   featureFlags: FeatureFlags
   mainFile: string
   pluginsModulesPath?: string
   name: string
 }) {
-  const fsCache: FsCache = {}
   const {
     fileList: dependencyPaths,
     esmFileList,
     reasons,
   } = await nodeFileTrace([mainFile], {
+    fileIOConcurrency: 2048,
     base: basePath,
+    cache: cache.nftCache,
     ignore: ignoreFunction,
     readFile: async (path: string) => {
       try {
-        const source = (await cachedReadFile(fsCache, path, 'utf8')) as string
+        const source = await cachedReadFile(cache.fileCache, path)
 
         return source
       } catch (error) {
@@ -131,10 +137,10 @@ const traceFilesAndTranspile = async function ({
   )
   const { moduleFormat, rewrites } = await processESM({
     basePath,
+    cache,
     config,
     esmPaths: esmFileList,
     featureFlags,
-    fsCache,
     mainFile,
     reasons,
     name,

--- a/src/runtimes/node/bundlers/nft/index.ts
+++ b/src/runtimes/node/bundlers/nft/index.ts
@@ -98,6 +98,7 @@ const traceFilesAndTranspile = async function ({
     esmFileList,
     reasons,
   } = await nodeFileTrace([mainFile], {
+    // Default is 1024. Allowing double the fileIO in parallel makes nft faster, but uses a little more memory.
     fileIOConcurrency: 2048,
     base: basePath,
     cache: cache.nftCache,

--- a/src/runtimes/node/bundlers/nft/index.ts
+++ b/src/runtimes/node/bundlers/nft/index.ts
@@ -99,9 +99,9 @@ const traceFilesAndTranspile = async function ({
     reasons,
   } = await nodeFileTrace([mainFile], {
     // Default is 1024. Allowing double the fileIO in parallel makes nft faster, but uses a little more memory.
-    fileIOConcurrency: 2048,
+    fileIOConcurrency: featureFlags.zisi_nft_higher_fileio_limit ? 2048 : 1024,
     base: basePath,
-    cache: cache.nftCache,
+    cache: featureFlags.zisi_nft_use_cache ? cache.nftCache : undefined,
     ignore: ignoreFunction,
     readFile: async (path: string) => {
       try {

--- a/src/runtimes/node/bundlers/types.ts
+++ b/src/runtimes/node/bundlers/types.ts
@@ -3,6 +3,7 @@ import type { Message } from '@netlify/esbuild'
 import type { FunctionConfig } from '../../../config.js'
 import type { FeatureFlag, FeatureFlags } from '../../../feature_flags.js'
 import type { FunctionSource } from '../../../function.js'
+import type { RuntimeCache } from '../../../utils/cache.js'
 import type { ModuleFormat } from '../utils/module_format.js'
 
 export const enum NodeBundlerType {
@@ -23,6 +24,7 @@ export type NativeNodeModules = Record<string, Record<string, string | undefined
 export type BundleFunction = (
   args: {
     basePath?: string
+    cache: RuntimeCache
     config: FunctionConfig
     featureFlags: Record<FeatureFlag, boolean>
     pluginsModulesPath?: string

--- a/src/runtimes/node/index.ts
+++ b/src/runtimes/node/index.ts
@@ -32,6 +32,7 @@ const getSrcFilesWithBundler: GetSrcFilesFunction = async (parameters) => {
 const zipFunction: ZipFunction = async function ({
   archiveFormat,
   basePath,
+  cache,
   config = {},
   destFolder,
   extension,
@@ -79,6 +80,7 @@ const zipFunction: ZipFunction = async function ({
     srcFiles,
   } = await bundler.bundle({
     basePath,
+    cache,
     config,
     extension,
     featureFlags,
@@ -101,6 +103,7 @@ const zipFunction: ZipFunction = async function ({
     aliases,
     archiveFormat,
     basePath: finalBasePath,
+    cache,
     destFolder,
     extension,
     featureFlags,

--- a/src/runtimes/node/parser/index.ts
+++ b/src/runtimes/node/parser/index.ts
@@ -110,6 +110,10 @@ const parseFile = async (path: string) => {
   const ast = parse(code, {
     plugins: ['typescript'],
     sourceType: 'module',
+    // disable tokens, ranges and comments for performance and we do not use them
+    tokens: false,
+    ranges: false,
+    attachComment: false,
   })
 
   return ast.program

--- a/src/runtimes/node/utils/package_json.ts
+++ b/src/runtimes/node/utils/package_json.ts
@@ -68,18 +68,18 @@ export const getPackageJsonIfAvailable = async (srcDir: string): Promise<Package
   }
 }
 
-const readPackageJson = async (path: string) => {
+export const readPackageJson = async (path: string) => {
   try {
     // The path depends on the user's build, i.e. must be dynamic
     const packageJson = JSON.parse(await fs.readFile(path, 'utf8'))
 
-    return sanitisePackageJson(packageJson)
+    return sanitizePackageJson(packageJson)
   } catch (error) {
     throw new Error(`${path} is invalid JSON: ${error.message}`)
   }
 }
 
-const sanitiseFiles = (files: unknown): string[] | undefined => {
+const sanitizeFiles = (files: unknown): string[] | undefined => {
   if (!Array.isArray(files)) {
     return undefined
   }
@@ -87,7 +87,7 @@ const sanitiseFiles = (files: unknown): string[] | undefined => {
   return files.filter((file) => typeof file === 'string')
 }
 
-export const sanitisePackageJson = (packageJson: Record<string, unknown>): PackageJson => ({
+export const sanitizePackageJson = (packageJson: Record<string, unknown>): PackageJson => ({
   ...packageJson,
-  files: sanitiseFiles(packageJson.files),
+  files: sanitizeFiles(packageJson.files),
 })

--- a/src/runtimes/runtime.ts
+++ b/src/runtimes/runtime.ts
@@ -1,8 +1,8 @@
-import { ArchiveFormat } from '../archive.js'
-import { FunctionConfig } from '../config.js'
-import { FeatureFlags } from '../feature_flags.js'
-import { FunctionSource, SourceFile } from '../function.js'
-import { FsCache } from '../utils/fs.js'
+import type { ArchiveFormat } from '../archive.js'
+import type { FunctionConfig } from '../config.js'
+import type { FeatureFlags } from '../feature_flags.js'
+import type { FunctionSource, SourceFile } from '../function.js'
+import type { RuntimeCache } from '../utils/cache.js'
 
 import type { NodeBundlerType } from './node/bundlers/types.js'
 import type { ISCValues } from './node/in_source_config/index.js'
@@ -14,14 +14,14 @@ export const enum RuntimeType {
 }
 
 export type FindFunctionsInPathsFunction = (args: {
+  cache: RuntimeCache
   featureFlags: FeatureFlags
-  fsCache: FsCache
   paths: string[]
 }) => Promise<SourceFile[]>
 
 export type FindFunctionInPathFunction = (args: {
+  cache: RuntimeCache
   featureFlags: FeatureFlags
-  fsCache: FsCache
   path: string
 }) => Promise<SourceFile | undefined>
 
@@ -51,6 +51,7 @@ export type ZipFunction = (
   args: {
     archiveFormat: ArchiveFormat
     basePath?: string
+    cache: RuntimeCache
     config: FunctionConfig
     destFolder: string
     featureFlags: FeatureFlags

--- a/src/runtimes/rust/index.ts
+++ b/src/runtimes/rust/index.ts
@@ -26,7 +26,7 @@ const detectRustFunction = async ({ cache, path }: { cache: RuntimeCache; path: 
     return
   }
 
-  const files = await cachedReaddir(cache.readDirCache, path)
+  const files = await cachedReaddir(cache.readdirCache, path)
   const hasCargoManifest = files.includes(MANIFEST_NAME)
 
   if (!hasCargoManifest) {

--- a/src/runtimes/rust/index.ts
+++ b/src/runtimes/rust/index.ts
@@ -3,7 +3,8 @@ import { join, extname, dirname, basename } from 'path'
 
 import { FeatureFlags } from '../../feature_flags.js'
 import { SourceFile } from '../../function.js'
-import { cachedLstat, cachedReaddir, FsCache } from '../../utils/fs.js'
+import type { RuntimeCache } from '../../utils/cache.js'
+import { cachedLstat, cachedReaddir } from '../../utils/fs.js'
 import { nonNullable } from '../../utils/non_nullable.js'
 import { zipBinary } from '../../zip_binary.js'
 import { detectBinaryRuntime } from '../detect_runtime.js'
@@ -18,16 +19,14 @@ import {
 import { build } from './builder.js'
 import { MANIFEST_NAME } from './constants.js'
 
-const detectRustFunction = async ({ fsCache, path }: { fsCache: FsCache; path: string }) => {
-  const stat = await cachedLstat(fsCache, path)
+const detectRustFunction = async ({ cache, path }: { cache: RuntimeCache; path: string }) => {
+  const stat = await cachedLstat(cache.lstatCache, path)
 
   if (!stat.isDirectory()) {
     return
   }
 
-  // @ts-expect-error TODO: The `makeCachedFunction` abstraction is causing the
-  // return value of `readdir` to be incorrectly typed.
-  const files = (await cachedReaddir(fsCache, path)) as string[]
+  const files = await cachedReaddir(cache.readDirCache, path)
   const hasCargoManifest = files.includes(MANIFEST_NAME)
 
   if (!hasCargoManifest) {
@@ -37,7 +36,7 @@ const detectRustFunction = async ({ fsCache, path }: { fsCache: FsCache; path: s
   const mainFilePath = join(path, 'src', 'main.rs')
 
   try {
-    const mainFile = await cachedLstat(fsCache, mainFilePath)
+    const mainFile = await cachedLstat(cache.lstatCache, mainFilePath)
 
     if (mainFile.isFile()) {
       return mainFilePath
@@ -48,39 +47,39 @@ const detectRustFunction = async ({ fsCache, path }: { fsCache: FsCache; path: s
 }
 
 const findFunctionsInPaths: FindFunctionsInPathsFunction = async function ({
+  cache,
   featureFlags,
-  fsCache,
   paths,
 }: {
+  cache: RuntimeCache
   featureFlags: FeatureFlags
-  fsCache: FsCache
   paths: string[]
 }) {
-  const functions = await Promise.all(paths.map((path) => findFunctionInPath({ path, featureFlags, fsCache })))
+  const functions = await Promise.all(paths.map((path) => findFunctionInPath({ cache, featureFlags, path })))
 
   return functions.filter(nonNullable)
 }
 
-const findFunctionInPath: FindFunctionInPathFunction = async function ({ path, featureFlags, fsCache }) {
-  const runtime = await detectBinaryRuntime({ fsCache, path })
+const findFunctionInPath: FindFunctionInPathFunction = async function ({ cache, featureFlags, path }) {
+  const runtime = await detectBinaryRuntime({ path })
 
   if (runtime === RuntimeType.RUST) {
-    return processBinary({ fsCache, path })
+    return processBinary({ cache, path })
   }
 
   if (featureFlags.buildRustSource !== true) {
     return
   }
 
-  const rustSourceFile = await detectRustFunction({ fsCache, path })
+  const rustSourceFile = await detectRustFunction({ cache, path })
 
   if (rustSourceFile) {
-    return processSource({ fsCache, mainFile: rustSourceFile, path })
+    return processSource({ cache, mainFile: rustSourceFile, path })
   }
 }
 
-const processBinary = async ({ fsCache, path }: { fsCache: FsCache; path: string }): Promise<SourceFile> => {
-  const stat = (await cachedLstat(fsCache, path)) as Stats
+const processBinary = async ({ cache, path }: { cache: RuntimeCache; path: string }): Promise<SourceFile> => {
+  const stat = (await cachedLstat(cache.lstatCache, path)) as Stats
   const filename = basename(path)
   const extension = extname(path)
   const name = basename(path, extension)
@@ -97,11 +96,11 @@ const processBinary = async ({ fsCache, path }: { fsCache: FsCache; path: string
 }
 
 const processSource = async ({
-  fsCache,
+  cache,
   mainFile,
   path,
 }: {
-  fsCache: FsCache
+  cache: RuntimeCache
   mainFile: string
   path: string
 }): Promise<SourceFile> => {
@@ -109,7 +108,7 @@ const processSource = async ({
   // the `FunctionSource` interface. We should revisit whether `stat` should be
   // part of that interface in the first place, or whether we could compute it
   // downstream when needed (maybe using the FS cache as an optimisation).
-  const stat = (await cachedLstat(fsCache, path)) as Stats
+  const stat = (await cachedLstat(cache.lstatCache, path)) as Stats
   const filename = basename(path)
   const extension = extname(path)
   const name = basename(path, extension)
@@ -129,6 +128,7 @@ const processSource = async ({
 // because they include the Lambda runtime, and that's the name that AWS
 // expects for those kind of functions.
 const zipFunction: ZipFunction = async function ({
+  cache,
   config,
   destFolder,
   filename,
@@ -150,7 +150,7 @@ const zipFunction: ZipFunction = async function ({
   // the resulting binary. Otherwise, we're dealing with a binary so we zip it
   // directly.
   if (isSource) {
-    const { path: binaryPath, stat: binaryStat } = await build({ config, name: filename, srcDir })
+    const { path: binaryPath, stat: binaryStat } = await build({ cache, config, name: filename, srcDir })
 
     await zipBinary({ ...zipOptions, srcPath: binaryPath, stat: binaryStat })
   } else {

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,0 +1,35 @@
+import type { Stats } from 'fs'
+
+export type FileCache = Map<string, Promise<string>>
+export type LstatCache = Map<string, Promise<Stats>>
+export type ReaddirCache = Map<string, Promise<string[]>>
+
+interface NFTCache {
+  fileCache: FileCache
+  statCache: Map<string, unknown>
+  symlinkCache: Map<string, unknown>
+  analysisCache: Map<string, unknown>
+}
+
+export interface RuntimeCache {
+  // file content
+  fileCache: FileCache
+  lstatCache: LstatCache
+  readDirCache: ReaddirCache
+  // NFT cache, which should not be used in zisi and only supplied to NFT
+  // this cache shares the file cache with zisi
+  nftCache: Partial<NFTCache>
+}
+
+export const createNewCache = (): RuntimeCache => {
+  const cache: RuntimeCache = Object.create(null)
+
+  cache.fileCache = new Map()
+  cache.lstatCache = new Map()
+  cache.readDirCache = new Map()
+
+  cache.nftCache = Object.create(null)
+  cache.nftCache.fileCache = cache.fileCache
+
+  return cache
+}

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -15,7 +15,7 @@ export class RuntimeCache {
   fileCache: FileCache
   // Cache for fs.lstat() calls
   lstatCache: LstatCache
-  // Cache fs.readdir calls
+  // Cache fs.readdir() calls
   readdirCache: ReaddirCache
   // NFT cache, which should not be used in zisi and only supplied to NFT
   // this cache shares the file cache with zisi

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -6,30 +6,27 @@ export type ReaddirCache = Map<string, Promise<string[]>>
 
 interface NFTCache {
   fileCache: FileCache
-  statCache: Map<string, unknown>
-  symlinkCache: Map<string, unknown>
-  analysisCache: Map<string, unknown>
+  // nft actually sets even more properties on this object, but
+  // they do not have any relevance for use here
 }
 
-export interface RuntimeCache {
-  // file content
+export class RuntimeCache {
+  // Cache for fs.readFile() calls
   fileCache: FileCache
+  // Cache for fs.lstat() calls
   lstatCache: LstatCache
-  readDirCache: ReaddirCache
+  // Cache fs.readdir calls
+  readdirCache: ReaddirCache
   // NFT cache, which should not be used in zisi and only supplied to NFT
   // this cache shares the file cache with zisi
-  nftCache: Partial<NFTCache>
-}
+  nftCache: NFTCache
 
-export const createNewCache = (): RuntimeCache => {
-  const cache: RuntimeCache = Object.create(null)
+  constructor() {
+    this.fileCache = new Map()
+    this.lstatCache = new Map()
+    this.readdirCache = new Map()
 
-  cache.fileCache = new Map()
-  cache.lstatCache = new Map()
-  cache.readDirCache = new Map()
-
-  cache.nftCache = Object.create(null)
-  cache.nftCache.fileCache = cache.fileCache
-
-  return cache
+    this.nftCache = Object.create(null)
+    this.nftCache.fileCache = this.fileCache
+  }
 }

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -7,7 +7,7 @@ export type ReaddirCache = Map<string, Promise<string[]>>
 interface NFTCache {
   fileCache: FileCache
   // nft actually sets even more properties on this object, but
-  // they do not have any relevance for use here
+  // they do not have any relevance for us here
 }
 
 export class RuntimeCache {

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -11,7 +11,7 @@ import { createManifest } from './manifest.js'
 import { getFunctionsFromPaths } from './runtimes/index.js'
 import { ModuleFormat } from './runtimes/node/utils/module_format.js'
 import { addArchiveSize } from './utils/archive_size.js'
-import { createNewCache } from './utils/cache.js'
+import { RuntimeCache } from './utils/cache.js'
 import { formatZipResult } from './utils/format_result.js'
 import { listFunctionsDirectories, resolveFunctionsDirectories } from './utils/fs.js'
 import { nonNullable } from './utils/non_nullable.js'
@@ -58,7 +58,7 @@ export const zipFunctions = async function (
 ) {
   validateArchiveFormat(archiveFormat)
 
-  const cache = createNewCache()
+  const cache = new RuntimeCache()
   const featureFlags = getFlags(inputFeatureFlags)
   const srcFolders = resolveFunctionsDirectories(relativeSrcFolders)
   const [paths] = await Promise.all([listFunctionsDirectories(srcFolders), fs.mkdir(destFolder, { recursive: true })])
@@ -134,7 +134,7 @@ export const zipFunction = async function (
 
   const featureFlags = getFlags(inputFeatureFlags)
   const srcPath = resolve(relativeSrcPath)
-  const cache = createNewCache()
+  const cache = new RuntimeCache()
   const functions = await getFunctionsFromPaths([srcPath], { cache, config: inputConfig, dedupe: true, featureFlags })
 
   if (functions.size === 0) {

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -11,6 +11,7 @@ import { createManifest } from './manifest.js'
 import { getFunctionsFromPaths } from './runtimes/index.js'
 import { ModuleFormat } from './runtimes/node/utils/module_format.js'
 import { addArchiveSize } from './utils/archive_size.js'
+import { createNewCache } from './utils/cache.js'
 import { formatZipResult } from './utils/format_result.js'
 import { listFunctionsDirectories, resolveFunctionsDirectories } from './utils/fs.js'
 import { nonNullable } from './utils/non_nullable.js'
@@ -57,10 +58,17 @@ export const zipFunctions = async function (
 ) {
   validateArchiveFormat(archiveFormat)
 
+  const cache = createNewCache()
   const featureFlags = getFlags(inputFeatureFlags)
   const srcFolders = resolveFunctionsDirectories(relativeSrcFolders)
   const [paths] = await Promise.all([listFunctionsDirectories(srcFolders), fs.mkdir(destFolder, { recursive: true })])
-  const functions = await getFunctionsFromPaths(paths, { config, configFileDirectories, dedupe: true, featureFlags })
+  const functions = await getFunctionsFromPaths(paths, {
+    cache,
+    config,
+    configFileDirectories,
+    dedupe: true,
+    featureFlags,
+  })
   const results = await pMap(
     functions.values(),
     async (func) => {
@@ -75,6 +83,7 @@ export const zipFunctions = async function (
       const zipResult = await func.runtime.zipFunction({
         archiveFormat,
         basePath,
+        cache,
         config: func.config,
         destFolder,
         extension: func.extension,
@@ -125,7 +134,8 @@ export const zipFunction = async function (
 
   const featureFlags = getFlags(inputFeatureFlags)
   const srcPath = resolve(relativeSrcPath)
-  const functions = await getFunctionsFromPaths([srcPath], { config: inputConfig, dedupe: true, featureFlags })
+  const cache = createNewCache()
+  const functions = await getFunctionsFromPaths([srcPath], { cache, config: inputConfig, dedupe: true, featureFlags })
 
   if (functions.size === 0) {
     return
@@ -154,6 +164,7 @@ export const zipFunction = async function (
   const zipResult = await runtime.zipFunction({
     archiveFormat,
     basePath,
+    cache,
     config,
     destFolder,
     extension,

--- a/tests/unit/runtimes/node/utils/package_json.test.ts
+++ b/tests/unit/runtimes/node/utils/package_json.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, test } from 'vitest'
 
-import { sanitisePackageJson } from '../../../../../src/runtimes/node/utils/package_json.js'
+import { sanitizePackageJson } from '../../../../../src/runtimes/node/utils/package_json.js'
 
-describe('sanitisePackageJson', () => {
+describe('sanitizePackageJson', () => {
   test('removes nulls from files', () => {
-    const result = sanitisePackageJson({
+    const result = sanitizePackageJson({
       files: ['a.js', null, 'b.js'],
     })
 
@@ -14,7 +14,7 @@ describe('sanitisePackageJson', () => {
   })
 
   test('does not crash on invalid files entries', () => {
-    const result = sanitisePackageJson({
+    const result = sanitizePackageJson({
       files: { 'a.js': true, 'b.js': false },
     })
 


### PR DESCRIPTION
#### Summary

Based on #1243 

Ref: https://github.com/netlify/pod-compute/issues/252

There is also another PR that I created in NFT, as NFT does not correctly cache, which will bring another small performance boost. vercel/nft#320

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/zip-it-and-ship-it/issues/new/choose) before writing your code 🧑‍💻.
      This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing
      a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
