### PR TITLE
fix: make esbuild work with ESM and require calls

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -9,6 +9,7 @@ module.exports = {
     'import/extensions': ['error', 'ignorePackages'],
     'n/no-missing-import': 'off',
     'no-magic-numbers': 'off',
+    'max-lines-per-function': 'off',
     // This rule enforces using Buffers with `JSON.parse()`. However, TypeScript
     // does not recognize yet that `JSON.parse()` accepts Buffers as argument.
     'unicorn/prefer-json-parse-buffer': 'off',

--- a/src/feature_flags.ts
+++ b/src/feature_flags.ts
@@ -20,6 +20,9 @@ export const defaultFlags: Record<string, boolean> = {
 
   // Load configuration from per-function JSON files.
   project_deploy_configuration_api_use_per_function_configuration_files: false,
+
+  // Provide banner to esbuild which allows requires in ESM output
+  zisi_esbuild_require_banner: false,
 }
 
 export type FeatureFlag = keyof typeof defaultFlags

--- a/src/runtimes/node/bundlers/esbuild/bundler.ts
+++ b/src/runtimes/node/bundlers/esbuild/bundler.ts
@@ -108,8 +108,20 @@ export const bundleJsFile = async function ({
   const outExtension =
     moduleFormat === ModuleFormat.ESM ? { [ModuleFileExtension.JS]: ModuleFileExtension.MJS } : undefined
 
+  // We add this banner so that calls to require() still work in ESM modules, especially when importing node built-ins
+  // We have to do this until this is fixed in esbuild: https://github.com/evanw/esbuild/pull/2067
+  const esmJSBanner = `
+    import {createRequire as ___nfyCreateRequire} from "module";
+    import {fileURLToPath as ___nfyFileURLToPath} from "url";
+    import {dirname as ___nfyPathDirname} from "path";
+    let __filename=___nfyFileURLToPath(import.meta.url);
+    let __dirname=___nfyPathDirname(___nfyFileURLToPath(import.meta.url));
+    let require=___nfyCreateRequire(import.meta.url);
+  `
+
   try {
     const { metafile = { inputs: {}, outputs: {} }, warnings } = await build({
+      banner: moduleFormat === ModuleFormat.ESM ? { js: esmJSBanner } : undefined,
       bundle: true,
       entryPoints: [srcFile],
       external,

--- a/src/runtimes/node/bundlers/esbuild/bundler.ts
+++ b/src/runtimes/node/bundlers/esbuild/bundler.ts
@@ -121,7 +121,8 @@ export const bundleJsFile = async function ({
 
   try {
     const { metafile = { inputs: {}, outputs: {} }, warnings } = await build({
-      banner: moduleFormat === ModuleFormat.ESM ? { js: esmJSBanner } : undefined,
+      banner:
+        moduleFormat === ModuleFormat.ESM && featureFlags.zisi_esbuild_require_banner ? { js: esmJSBanner } : undefined,
       bundle: true,
       entryPoints: [srcFile],
       external,

--- a/tests/fixtures/node-require-in-esm/functions/func1.mjs
+++ b/tests/fixtures/node-require-in-esm/functions/func1.mjs
@@ -1,0 +1,3 @@
+import include from '../include.cjs';
+
+export const handler = () => true

--- a/tests/fixtures/node-require-in-esm/include.cjs
+++ b/tests/fixtures/node-require-in-esm/include.cjs
@@ -1,0 +1,3 @@
+const path = require('path');
+
+export default 1

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -2430,6 +2430,9 @@ describe('zip-it-and-ship-it', () => {
           nodeModuleFormat: ModuleFormat.ESM,
         },
       },
+      featureFlags: {
+        zisi_esbuild_require_banner: true,
+      },
     }
     const { files, tmpDir } = await zipFixture([join(fixtureName, 'functions')], {
       opts,

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -14,9 +14,10 @@ import unixify from 'unixify'
 import { afterAll, afterEach, describe, expect, test, vi } from 'vitest'
 
 import type { Config } from '../src/config.js'
-import { NodeBundlerType } from '../src/main.js'
 import { ESBUILD_LOG_LIMIT } from '../src/runtimes/node/bundlers/esbuild/bundler.js'
+import { NodeBundlerType } from '../src/runtimes/node/bundlers/types.js'
 import { detectEsModule } from '../src/runtimes/node/utils/detect_es_module.js'
+import { ModuleFormat } from '../src/runtimes/node/utils/module_format.js'
 import { shellUtils } from '../src/utils/shell.js'
 
 import {
@@ -2419,19 +2420,18 @@ describe('zip-it-and-ship-it', () => {
     },
   )
 
-  testMany('Provides require to esbuild if output format is ESM', ['bundler_esbuild'], async (options) => {
-    const length = 1
+  test('Provides require to esbuild if output format is ESM', async () => {
     const fixtureName = 'node-require-in-esm'
-    const opts = merge(options, {
+    const opts = {
       basePath: join(FIXTURES_DIR, fixtureName),
       config: {
         '*': {
-          nodeModuleFormat: 'esm',
+          nodeBundler: NodeBundlerType.ESBUILD,
+          nodeModuleFormat: ModuleFormat.ESM,
         },
       },
-    })
+    }
     const { files, tmpDir } = await zipFixture([join(fixtureName, 'functions')], {
-      length,
       opts,
     })
 


### PR DESCRIPTION
#### Summary

This adds a banner to esbuild if the output format is set to ESM. This banner makes require() calls work again. 
This can happen when ESM modules import CJS modules which use `require`.


---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/zip-it-and-ship-it/issues/new/choose) before writing your code 🧑‍💻.
      This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing
      a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
