### PR TITLE
fix: correctly detect conflicting function names consistently

### DIFF
--- a/src/runtimes/node/finder.ts
+++ b/src/runtimes/node/finder.ts
@@ -74,6 +74,8 @@ const getMainFile = async function (srcPath: string, filename: string, stat: Sta
   if (stat.isDirectory()) {
     return await locatePath(
       [
+        // The order of these declarations is important, so that we always bundle the same way
+        // even if multiple files are found
         join(srcPath, `${filename}.js`),
         join(srcPath, 'index.js'),
         join(srcPath, `${filename}.ts`),
@@ -89,7 +91,7 @@ const getMainFile = async function (srcPath: string, filename: string, stat: Sta
         join(srcPath, `${filename}.cts`),
         join(srcPath, 'index.cts'),
       ],
-      { type: 'file', preserveOrder: false },
+      { type: 'file' },
     )
   }
 

--- a/tests/helpers/main.ts
+++ b/tests/helpers/main.ts
@@ -47,6 +47,8 @@ export const zipFixture = async function (
   const bundlerString = getBundlerNameFromConfig(config) || 'default'
   const { path: tmpDir } = await getTmpDir({
     prefix: `zip-it-test-bundler-${bundlerString}`,
+    // Cleanup the folder on process exit even if there are still files in them
+    unsafeCleanup: true,
   })
 
   if (env.ZISI_KEEP_TEMP_DIRS !== undefined) {

--- a/tests/helpers/test_many.ts
+++ b/tests/helpers/test_many.ts
@@ -73,7 +73,7 @@ export const makeTestMany = <M extends string>(
   const testFns = ['fails', 'only', 'concurrent', 'skip', 'todo']
 
   testFns.forEach((fn) => {
-    testBundlers[fn] = ((...args) => testBundlers(...args, test[fn])) as TestMany<M>
+    testBundlers[fn] = ((...args) => testBundlers(...args, testAPI[fn])) as TestMany<M>
   })
 
   return testBundlers as TestManyAPI<M | `todo:${M}`>


### PR DESCRIPTION
#### Summary

I was investigating why the tests fail sometimes. The tests ensure that when multiple files for the same function exist we always use the same order in how we detect them.

My first thought was it has to do with async stuff in the tests, just to figure out during my perf change I did change `locate-path` to not preserve order, which triggers this flaky behavior.

This reverts this change, plus some additional fixes for the tests, I run into on the way.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/zip-it-and-ship-it/issues/new/choose) before writing your code 🧑‍💻.
      This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing
      a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
