### PR TITLE
chore: unzip in tests in series and add missing types for tmp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "@types/normalize-path": "^3.0.0",
         "@types/resolve": "^1.20.2",
         "@types/semver": "^7.3.8",
+        "@types/tmp": "^0.2.3",
         "@types/unixify": "^1.0.0",
         "@types/yargs": "^17.0.4",
         "@vitest/coverage-c8": "^0.25.0",
@@ -2073,6 +2074,12 @@
       "version": "7.3.13",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
       "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+      "dev": true
+    },
+    "node_modules/@types/tmp": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.3.tgz",
+      "integrity": "sha512-dDZH/tXzwjutnuk4UacGgFRwV+JSLaXL1ikvidfJprkb7L9Nx1njcRHHmi3Dsvt7pgqqTEeucQuOrWHPFgzVHA==",
       "dev": true
     },
     "node_modules/@types/unist": {
@@ -11753,6 +11760,12 @@
       "version": "7.3.13",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
       "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+      "dev": true
+    },
+    "@types/tmp": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.3.tgz",
+      "integrity": "sha512-dDZH/tXzwjutnuk4UacGgFRwV+JSLaXL1ikvidfJprkb7L9Nx1njcRHHmi3Dsvt7pgqqTEeucQuOrWHPFgzVHA==",
       "dev": true
     },
     "@types/unist": {

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "@types/normalize-path": "^3.0.0",
     "@types/resolve": "^1.20.2",
     "@types/semver": "^7.3.8",
+    "@types/tmp": "^0.2.3",
     "@types/unixify": "^1.0.0",
     "@types/yargs": "^17.0.4",
     "@vitest/coverage-c8": "^0.25.0",

--- a/tests/helpers/main.ts
+++ b/tests/helpers/main.ts
@@ -83,7 +83,11 @@ const requireExtractedFiles = async function (files: FunctionResult[]): Promise<
 }
 
 export const unzipFiles = async function (files: FunctionResult[], targetPathGenerator?: (path: string) => string) {
-  await Promise.all(files.map(({ path }) => unzipFile({ path, targetPathGenerator })))
+  // unzip functions in series, as on windows it sometimes fails with permission
+  // errors if two unzip calls try to create the same file
+  for (const { path } of files) {
+    await unzipFile({ path, targetPathGenerator })
+  }
 }
 
 const unzipFile = async function ({


### PR DESCRIPTION
#### Summary

Sometimes the tests in zisi fail on windows, this happens because the unzip in the tests is running in parallel for all functions. As they all extract to the same directory, permission errors happen when two functions contain the same files, which usually is [the package.json](https://github.com/netlify/zip-it-and-ship-it/blob/main/tests/fixtures/package.json) file.

Also added `@types/tmp`. We are not using tmp directly, but `tmp-promise` uses types from `@types/tmp`

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/zip-it-and-ship-it/issues/new/choose) before writing your code 🧑‍💻.
      This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing
      a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
