### PR TITLE
fix: (backport) make esbuild work with ESM and require calls (#1257)

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -9,6 +9,7 @@ module.exports = {
     // unsupported by Node 12, i.e. optional chaining
     // TODO: re-enable after dropping support for Node 12
     'n/no-unsupported-features/es-syntax': 'off',
+    'max-lines-per-function': 'off',
     // This rule enforces using Buffers with `JSON.parse()`. However, TypeScript
     // does not recognize yet that `JSON.parse()` accepts Buffers as argument.
     'unicorn/prefer-json-parse-buffer': 'off',

--- a/src/feature_flags.ts
+++ b/src/feature_flags.ts
@@ -20,6 +20,9 @@ export const defaultFlags: Record<string, boolean> = {
 
   // Load configuration from per-function JSON files.
   project_deploy_configuration_api_use_per_function_configuration_files: false,
+
+  // Provide banner to esbuild which allows requires in ESM output
+  zisi_esbuild_require_banner: false,
 }
 
 export type FeatureFlag = keyof typeof defaultFlags

--- a/tests/fixtures/node-require-in-esm/functions/func1.mjs
+++ b/tests/fixtures/node-require-in-esm/functions/func1.mjs
@@ -1,0 +1,3 @@
+import include from '../include.cjs'
+
+export const handler = () => true

--- a/tests/fixtures/node-require-in-esm/include.cjs
+++ b/tests/fixtures/node-require-in-esm/include.cjs
@@ -1,0 +1,3 @@
+const path = require('path')
+
+export default 1


### PR DESCRIPTION
#### Summary

Same as #1257 but for 7.x

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/zip-it-and-ship-it/issues/new/choose) before writing your code 🧑‍💻.
      This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing
      a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
