### PR TITLE
feat: return displayName with json config from listFunction, listFunctions and listFunctionsFiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,10 @@ Each object has the following properties:
   Function's name. This is the one used in the Function URL. For example, if a Function is a `myFunc.js` regular file,
   the `name` is `myFunc` and the URL is `https://{hostname}/.netlify/functions/myFunc`.
 
+- `displayName` `string`
+
+  If there was a user-defined configuration object applied to the function, and it had a `name` defined. This will be returned here.
+
 - `mainFile`: `string`
 
   Absolute path to the Function's main file. If the Function is a Node.js directory, this is its `index.js` or

--- a/src/runtimes/index.ts
+++ b/src/runtimes/index.ts
@@ -121,13 +121,23 @@ export const getFunctionsFromPaths = async (
  */
 export const getFunctionFromPath = async (
   path: string,
-  { cache, config, featureFlags = defaultFlags }: { cache: RuntimeCache; config?: Config; featureFlags?: FeatureFlags },
+  {
+    cache,
+    config,
+    configFileDirectories,
+    featureFlags = defaultFlags,
+  }: { cache: RuntimeCache; config?: Config; configFileDirectories?: string[]; featureFlags?: FeatureFlags },
 ): Promise<FunctionSource | undefined> => {
   for (const runtime of RUNTIMES) {
     const func = await runtime.findFunctionInPath({ path, cache, featureFlags })
 
     if (func) {
-      const functionConfig = await getConfigForFunction({ config, func: { ...func, runtime }, featureFlags })
+      const functionConfig = await getConfigForFunction({
+        config,
+        configFileDirectories,
+        func: { ...func, runtime },
+        featureFlags,
+      })
 
       return {
         ...func,

--- a/tests/fixtures/json-config/.netlify/functions-internal/simple.js
+++ b/tests/fixtures/json-config/.netlify/functions-internal/simple.js
@@ -1,0 +1,5 @@
+const handler = async () => ({
+    body: `Hello world! A whole new one!`,
+  })
+
+export { handler };

--- a/tests/fixtures/json-config/.netlify/functions-internal/simple.json
+++ b/tests/fixtures/json-config/.netlify/functions-internal/simple.json
@@ -1,0 +1,4 @@
+{
+  "config": { "name": "A Display Name" },
+  "version": 1
+}

--- a/tests/list_function.test.ts
+++ b/tests/list_function.test.ts
@@ -20,4 +20,22 @@ describe('listFunction', () => {
       schedule: '@daily',
     })
   })
+
+  test('listFunction includes json configured functions with a name and returns it as a displayName', async () => {
+    const dir = join(FIXTURES_DIR, 'json-config/.netlify/functions-internal/')
+    const mainFile = join(dir, 'simple.js')
+    const func = await listFunction(mainFile, {
+      configFileDirectories: [dir],
+      featureFlags: {
+        project_deploy_configuration_api_use_per_function_configuration_files: true,
+      },
+    })
+    expect(func).toEqual({
+      displayName: 'A Display Name',
+      extension: '.js',
+      mainFile,
+      name: 'simple',
+      runtime: 'js',
+    })
+  })
 })

--- a/tests/list_functions.test.ts
+++ b/tests/list_functions.test.ts
@@ -86,4 +86,16 @@ describe('listFunctions', () => {
       expect(func.schedule).toBe('@daily')
     })
   })
+
+  test('listFunctions includes json configured functions with a name and returns it as a displayName', async () => {
+    const dir = join(FIXTURES_DIR, 'json-config/.netlify/functions-internal/')
+    const [func] = await listFunctions([dir], {
+      configFileDirectories: [dir],
+      featureFlags: {
+        project_deploy_configuration_api_use_per_function_configuration_files: true,
+      },
+    })
+
+    expect(func.displayName).toBe('A Display Name')
+  })
 })

--- a/tests/list_functions_files.test.ts
+++ b/tests/list_functions_files.test.ts
@@ -251,4 +251,16 @@ describe('listFunctionsFiles', () => {
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('Darwin/Arm64'))
     warn.mockRestore()
   })
+
+  test('listFunctionsFiles includes json configured functions with a name and returns it as a displayName', async () => {
+    const dir = join(FIXTURES_DIR, 'json-config/.netlify/functions-internal/')
+    const [func] = await listFunctionsFiles([dir], {
+      configFileDirectories: [dir],
+      featureFlags: {
+        project_deploy_configuration_api_use_per_function_configuration_files: true,
+      },
+    })
+
+    expect(func.displayName).toBe('A Display Name')
+  })
 })


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Because we want to be able to show the display name in the cli when running `netlify dev` we need to return the displayname from listFunction, listFunctions and listFunctionsFiles.

Connected issue: https://github.com/netlify/pod-compute/issues/373


---

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/zip-it-and-ship-it/issues/new/choose) before writing your code 🧑‍💻.
      This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing
      a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [x] Update or add tests (if any source code was changed or added) 🧪
- [x] Update or add documentation (if features were changed or added) 📝
- [x] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
