### PR TITLE
feat: add new runtimeVersion to manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ The following properties are accepted:
   - _Type_: `string`\
   - _Default value_: `16`
 
-  The version of Node.js to use as the compilation target and reported execution runtime. Any valid and supported
-  Node.js version is accepted. Examples:
+  The version of Node.js to use as the compilation target for bundlers. This is also used to determine the runtime
+  reported in the manifest. Any valid and supported Node.js version is accepted. Examples:
 
   - `14.x`
   - `16.1.0`

--- a/README.md
+++ b/README.md
@@ -128,16 +128,15 @@ The following properties are accepted:
 - `nodeVersion`
 
   - _Type_: `string`\
-  - _Default value_: `16.x`
+  - _Default value_: `16`
 
-  The version of Node.js to use as the compilation target. Possible values:
+  The version of Node.js to use as the compilation target and reported execution runtime. Any valid and supported
+  Node.js version is accepted. Examples:
 
-  - `8.x` (or `nodejs8.x`)
-  - `10.x` (or `nodejs10.x`)
-  - `12.x` (or `nodejs12.x`)
-  - `14.x` (or `nodejs14.x`)
-  - `16.x` (or `nodejs16.x`)
-  - `18.x` (or `nodejs18.x`)
+  - `14.x`
+  - `16.1.0`
+  - `v18`
+  - `nodejs18.x` (for backwards compatibility)
 
 - `rustTargetDirectory`
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,7 +7,6 @@ import mergeOptions from 'merge-options'
 
 import { FunctionSource } from './function.js'
 import type { NodeBundlerType } from './runtimes/node/bundlers/types.js'
-import type { NodeVersionString } from './runtimes/node/index.js'
 import type { ModuleFormat } from './runtimes/node/utils/module_format.js'
 import { minimatch } from './utils/matching.js'
 
@@ -18,7 +17,7 @@ interface FunctionConfig {
   ignoredNodeModules?: string[]
   nodeBundler?: NodeBundlerType
   nodeSourcemap?: boolean
-  nodeVersion?: NodeVersionString
+  nodeVersion?: string
   processDynamicNodeImports?: boolean
   rustTargetDirectory?: string
   schedule?: string

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -9,7 +9,7 @@ interface ManifestFunction {
   name: string
   path: string
   runtime: string
-  runtimeName?: string
+  runtimeVersion?: string
   schedule?: string
   displayName?: string
   bundler?: string
@@ -48,7 +48,7 @@ const formatFunctionForManifest = ({
   name,
   path,
   runtime,
-  runtimeName,
+  runtimeVersion,
   schedule,
 }: FunctionResult): ManifestFunction => ({
   bundler,
@@ -56,7 +56,7 @@ const formatFunctionForManifest = ({
   generator,
   mainFile,
   name,
-  runtimeName,
+  runtimeVersion,
   path: resolve(path),
   runtime,
   schedule,

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -9,6 +9,7 @@ interface ManifestFunction {
   name: string
   path: string
   runtime: string
+  runtimeName?: string
   schedule?: string
   displayName?: string
   bundler?: string
@@ -40,21 +41,23 @@ export const createManifest = async ({ functions, path }: { functions: FunctionR
 }
 
 const formatFunctionForManifest = ({
+  bundler,
+  displayName,
+  generator,
   mainFile,
   name,
   path,
   runtime,
+  runtimeName,
   schedule,
-  displayName,
-  bundler,
-  generator,
 }: FunctionResult): ManifestFunction => ({
+  bundler,
+  displayName,
+  generator,
   mainFile,
   name,
+  runtimeName,
   path: resolve(path),
   runtime,
   schedule,
-  displayName,
-  bundler,
-  generator,
 })

--- a/src/runtimes/node/bundlers/esbuild/bundler_target.ts
+++ b/src/runtimes/node/bundlers/esbuild/bundler_target.ts
@@ -1,32 +1,24 @@
 import { FeatureFlags } from '../../../../feature_flags.js'
 import { ModuleFileExtension, ModuleFormat } from '../../utils/module_format.js'
-import {
-  DEFAULT_NODE_VERSION,
-  getNodeSupportMatrix,
-  NodeVersionString,
-  ShortNodeVersionString,
-} from '../../utils/node_version.js'
+import { DEFAULT_NODE_VERSION, getNodeSupportMatrix, parseVersion } from '../../utils/node_version.js'
 import { getClosestPackageJson } from '../../utils/package_json.js'
 
 const versionMap = {
-  '8.x': 'node8',
-  '10.x': 'node10',
-  '12.x': 'node12',
-  '14.x': 'node14',
-  '16.x': 'node16',
-  '18.x': 'node18',
+  14: 'node14',
+  16: 'node16',
+  18: 'node18',
 } as const
 
 type VersionValues = (typeof versionMap)[keyof typeof versionMap]
 
-const getBundlerTarget = (suppliedVersion?: NodeVersionString): VersionValues => {
-  const version = normalizeVersion(suppliedVersion)
+const getBundlerTarget = (suppliedVersion?: string): VersionValues => {
+  const version = parseVersion(suppliedVersion)
 
   if (version && version in versionMap) {
-    return versionMap[version]
+    return versionMap[version as keyof typeof versionMap]
   }
 
-  return versionMap[`${DEFAULT_NODE_VERSION}.x`]
+  return versionMap[DEFAULT_NODE_VERSION]
 }
 
 const getModuleFormat = async (
@@ -35,20 +27,22 @@ const getModuleFormat = async (
   extension: string,
   configVersion?: string,
 ): Promise<{ includedFiles: string[]; moduleFormat: ModuleFormat }> => {
-  if (extension === ModuleFileExtension.MJS && featureFlags.zisi_pure_esm_mjs) {
+  if (featureFlags.zisi_pure_esm_mjs && extension === ModuleFileExtension.MJS) {
     return {
       includedFiles: [],
       moduleFormat: ModuleFormat.ESM,
     }
   }
 
-  const packageJsonFile = await getClosestPackageJson(srcDir)
-  const nodeSupport = getNodeSupportMatrix(configVersion)
+  if (featureFlags.zisi_pure_esm) {
+    const packageJsonFile = await getClosestPackageJson(srcDir)
+    const nodeSupport = getNodeSupportMatrix(configVersion)
 
-  if (featureFlags.zisi_pure_esm && packageJsonFile?.contents.type === 'module' && nodeSupport.esm) {
-    return {
-      includedFiles: [packageJsonFile.path],
-      moduleFormat: ModuleFormat.ESM,
+    if (packageJsonFile?.contents.type === 'module' && nodeSupport.esm) {
+      return {
+        includedFiles: [packageJsonFile.path],
+        moduleFormat: ModuleFormat.ESM,
+      }
     }
   }
 
@@ -56,12 +50,6 @@ const getModuleFormat = async (
     includedFiles: [],
     moduleFormat: ModuleFormat.COMMONJS,
   }
-}
-
-const normalizeVersion = (version?: NodeVersionString): ShortNodeVersionString | undefined => {
-  const match = version && (version.match(/^nodejs(.*)$/) as [string, ShortNodeVersionString])
-
-  return match ? match[1] : (version as ShortNodeVersionString)
 }
 
 export { getBundlerTarget, getModuleFormat }

--- a/src/runtimes/node/index.ts
+++ b/src/runtimes/node/index.ts
@@ -9,10 +9,9 @@ import { getBundler, getBundlerName } from './bundlers/index.js'
 import { NodeBundlerType } from './bundlers/types.js'
 import { findFunctionsInPaths, findFunctionInPath } from './finder.js'
 import { findISCDeclarationsInPath } from './in_source_config/index.js'
+import { getNodeRuntime } from './utils/node_runtime.js'
 import { createAliases as createPluginsModulesPathAliases, getPluginsModulesPath } from './utils/plugin_modules_path.js'
 import { zipNodeJs } from './utils/zip.js'
-
-export { NodeVersionString } from './utils/node_version.js'
 
 // A proxy for the `getSrcFiles` that calls `getSrcFiles` on the bundler
 const getSrcFilesWithBundler: GetSrcFilesFunction = async (parameters) => {
@@ -128,6 +127,7 @@ const zipFunction: ZipFunction = async function ({
     nativeNodeModules,
     nodeModulesWithDynamicImports,
     path: zipPath,
+    runtimeName: getNodeRuntime(config.nodeVersion),
     displayName: config?.name,
     generator: config?.generator || getInternalValue(isInternal),
   }

--- a/src/runtimes/node/index.ts
+++ b/src/runtimes/node/index.ts
@@ -127,7 +127,7 @@ const zipFunction: ZipFunction = async function ({
     nativeNodeModules,
     nodeModulesWithDynamicImports,
     path: zipPath,
-    runtimeName: getNodeRuntime(config.nodeVersion),
+    runtimeVersion: getNodeRuntime(config.nodeVersion),
     displayName: config?.name,
     generator: config?.generator || getInternalValue(isInternal),
   }

--- a/src/runtimes/node/utils/node_runtime.ts
+++ b/src/runtimes/node/utils/node_runtime.ts
@@ -1,0 +1,17 @@
+import { parseVersion } from './node_version.js'
+
+const validRuntimeMap = {
+  14: 'nodejs14.x',
+  16: 'nodejs16.x',
+  18: 'nodejs18.x',
+} as const
+
+export const getNodeRuntime = (input: string | undefined): string | undefined => {
+  const version = parseVersion(input)
+
+  if (!version || !(version in validRuntimeMap)) {
+    return
+  }
+
+  return validRuntimeMap[version as keyof typeof validRuntimeMap]
+}

--- a/src/runtimes/node/utils/node_version.ts
+++ b/src/runtimes/node/utils/node_version.ts
@@ -1,6 +1,4 @@
-type SupportedVersionNumbers = 8 | 10 | 12 | 14 | 16 | 18
-export type ShortNodeVersionString = `${SupportedVersionNumbers}.x`
-export type NodeVersionString = ShortNodeVersionString | `nodejs${SupportedVersionNumbers}.x`
+import semver from 'semver'
 
 export interface NodeVersionSupport {
   esm: boolean
@@ -8,7 +6,6 @@ export interface NodeVersionSupport {
 
 // Must match the default version used in Bitballoon.
 export const DEFAULT_NODE_VERSION = 16
-const VERSION_REGEX = /(nodejs)?(\d+)\.x/
 
 export const getNodeVersion = (configVersion?: string) => parseVersion(configVersion) ?? DEFAULT_NODE_VERSION
 
@@ -22,22 +19,10 @@ export const getNodeSupportMatrix = (configVersion?: string): NodeVersionSupport
 
 // Takes a string in the format defined by the `NodeVersion` type and returns
 // the numeric major version (e.g. "nodejs14.x" => 14).
-export const parseVersion = (input: string | undefined) => {
+export const parseVersion = (input: string | undefined): number | undefined => {
   if (input === undefined) {
     return
   }
 
-  const match = input.match(VERSION_REGEX)
-
-  if (match === null) {
-    return
-  }
-
-  const version = Number.parseInt(match[2])
-
-  if (Number.isNaN(version)) {
-    return
-  }
-
-  return version
+  return semver.coerce(input)?.major
 }

--- a/src/runtimes/runtime.ts
+++ b/src/runtimes/runtime.ts
@@ -47,7 +47,7 @@ export interface ZipFunctionResult {
   nativeNodeModules?: object
   nodeModulesWithDynamicImports?: string[]
   path: string
-  runtimeName?: string
+  runtimeVersion?: string
 }
 
 export type ZipFunction = (

--- a/src/runtimes/runtime.ts
+++ b/src/runtimes/runtime.ts
@@ -39,14 +39,15 @@ export interface ZipFunctionResult {
   bundlerErrors?: object[]
   bundlerWarnings?: object[]
   config: FunctionConfig
+  displayName?: string
+  generator?: string
   inputs?: string[]
   includedFiles?: string[]
   inSourceConfig?: ISCValues
   nativeNodeModules?: object
   nodeModulesWithDynamicImports?: string[]
   path: string
-  displayName?: string
-  generator?: string
+  runtimeName?: string
 }
 
 export type ZipFunction = (

--- a/tests/__snapshots__/main.test.ts.snap
+++ b/tests/__snapshots__/main.test.ts.snap
@@ -1,3 +1,3 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`zip-it-and-ship-it > None bundler throws when using ESM on node < 14 > bundler_none 1`] = `"Function file is an ES module, which the Node.js version specified in the config (12.x) does not support. ES modules are supported as of version 14 of Node.js."`;

--- a/tests/esbuild.test.ts
+++ b/tests/esbuild.test.ts
@@ -1,0 +1,38 @@
+import { build } from '@netlify/esbuild'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import { NodeBundlerType } from '../src/runtimes/node/bundlers/types.js'
+
+import { zipFixture } from './helpers/main.js'
+
+// eslint-disable-next-line import/no-unassigned-import
+import 'source-map-support/register'
+
+vi.mock('../src/utils/shell.js', () => ({ shellUtils: { runCommand: vi.fn() } }))
+
+vi.mock('@netlify/esbuild', async () => {
+  const esbuild = await vi.importActual<any>('@netlify/esbuild')
+
+  return {
+    ...esbuild,
+    build: vi.fn(esbuild.build),
+  }
+})
+
+describe('esbuild', () => {
+  afterEach(() => {
+    vi.mocked(build).mockReset()
+  })
+
+  test('Generates a bundle for the Node runtime version specified in the `nodeVersion` config property', async () => {
+    // Using the optional catch binding feature to assert that the bundle is
+    // respecting the Node version supplied.
+    // - in Node <10 we should see `try {} catch (e) {}`
+    // - in Node >= 10 we should see `try {} catch {}`
+    await zipFixture('node-module-optional-catch-binding', {
+      opts: { archiveFormat: 'none', config: { '*': { nodeBundler: NodeBundlerType.ESBUILD, nodeVersion: '18.x' } } },
+    })
+
+    expect(build).toHaveBeenCalledWith(expect.objectContaining({ target: ['node18'] }))
+  })
+})

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -276,7 +276,7 @@ describe('zip-it-and-ship-it', () => {
     ['bundler_default', 'bundler_esbuild', 'bundler_esbuild_zisi'],
     async (options) => {
       await expect(zipNode('invalid-package-json', { opts: options })).rejects.toThrowError(
-        /(invalid JSON|package.json:1:1: error: Expected string but found "{")/,
+        /(invalid json|package.json:1:1: error: expected string but found "{")/i,
       )
     },
   )
@@ -1266,28 +1266,6 @@ describe('zip-it-and-ship-it', () => {
       await expect(`${tmpDir}/something.md`).toPathExist()
     },
   )
-
-  test('Generates a bundle for the Node runtime version specified in the `nodeVersion` config property', async () => {
-    // Using the optional catch binding feature to assert that the bundle is
-    // respecting the Node version supplied.
-    // - in Node <10 we should see `try {} catch (e) {}`
-    // - in Node >= 10 we should see `try {} catch {}`
-    const { files: node8Files } = await zipNode('node-module-optional-catch-binding', {
-      opts: { archiveFormat: 'none', config: { '*': { nodeBundler: NodeBundlerType.ESBUILD, nodeVersion: '8.x' } } },
-    })
-
-    const node8Function = await readFile(`${node8Files[0].path}/src/function.js`, 'utf8')
-
-    expect(node8Function).toMatch(/catch \(\w+\) {/)
-
-    const { files: node12Files } = await zipNode('node-module-optional-catch-binding', {
-      opts: { archiveFormat: 'none', config: { '*': { nodeBundler: NodeBundlerType.ESBUILD, nodeVersion: '12.x' } } },
-    })
-
-    const node12Function = await readFile(`${node12Files[0].path}/src/function.js`, 'utf8')
-
-    expect(node12Function).toMatch(/catch {/)
-  })
 
   testMany('Returns an `inputs` property with all the imported paths', [...allBundleConfigs], async (options) => {
     const fixtureName = 'node-module-and-local-imports'

--- a/tests/unit/runtimes/node/utils/node_runtime.test.ts
+++ b/tests/unit/runtimes/node/utils/node_runtime.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'vitest'
+
+import { getNodeRuntime } from '../../../../../src/runtimes/node/utils/node_runtime.js'
+
+describe('getNodeRuntime', () => {
+  test.each([
+    ['nodejs14.x', 'nodejs14.x'],
+    ['nodejs16.x', 'nodejs16.x'],
+    ['nodejs18.x', 'nodejs18.x'],
+    ['14.x', 'nodejs14.x'],
+    ['v16.x', 'nodejs16.x'],
+    ['18.0.0', 'nodejs18.x'],
+    ['v14.2.0', 'nodejs14.x'],
+    ['14.1', 'nodejs14.x'],
+    [':shrug:', undefined],
+  ])('handles `%s`', (input, expected) => {
+    expect(getNodeRuntime(input)).toBe(expected)
+  })
+})

--- a/tests/unit/runtimes/node/utils/node_version.test.ts
+++ b/tests/unit/runtimes/node/utils/node_version.test.ts
@@ -10,10 +10,11 @@ describe('getNodeVersion', () => {
   test.each([
     ['nodejs14.x', 14],
     ['nodejs12.x', 12],
-    ['nodejs8.x', 8],
-    ['12.x', 12],
-    ['8.x', 8],
-    ['node16', DEFAULT_NODE_VERSION],
+    ['nodejs16.x', 16],
+    ['18.x', 18],
+    ['node16', 16],
+    ['14.1.1', 14],
+    ['v14.1', 14],
     [':shrug:', DEFAULT_NODE_VERSION],
   ])('handles `%s`', (input, expected) => {
     expect(getNodeVersion(input)).toBe(expected)
@@ -24,10 +25,11 @@ describe('parseVersion', () => {
   test.each([
     ['nodejs14.x', 14],
     ['nodejs12.x', 12],
-    ['nodejs8.x', 8],
-    ['12.x', 12],
-    ['8.x', 8],
-    ['node16', undefined],
+    ['nodejs18.x', 18],
+    ['18.x', 18],
+    ['node14', 14],
+    ['14.1.1', 14],
+    ['v14.1', 14],
     [':shrug:', undefined],
   ])('handles `%s`', (input, expected) => {
     expect(parseVersion(input)).toBe(expected)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   test: {
     setupFiles: ['./tests/helpers/vitest_setup.ts'],
     include: ['tests/**/*.test.ts'],
-    testTimeout: 30_000,
+    testTimeout: 60_000,
     deps: {
       external: ['**/fixtures/**', '**/node_modules/**', '**/dist/**'],
       interopDefault: false,


### PR DESCRIPTION
#### Summary

The option `nodeVersion` now works differently and allows different styles of how the Node.js version is specified.
If it cannot be coerced to a Node.js version, the `undefined` is added to the manifest, leaving the choice of runtime to origin. We could also change this to have zisi add the default to the manifest, but I didn't do it because I feel its nicer to have the default version only in one place.

How it is supposed to work is that `@netlify/build` sets `nodeVersion` to `AWS_LAMBDA_JS_VERSION || buildUserNodeVersion` and based on this input we set a new field `runtimeVersion` in the manifest, or not if it is not a valid runtime version.
open-api reads the manifest and sends `runtimeVersion || runtime`.  In the origin we then detect if it is a runtime shortcut 'js' or a full runtime image name.

Ref: netlify/pod-compute#33
Ref: netlify/pod-compute#64

This would also allow the runtime being set by the deployment config API.

