### PR TITLE
chore: fix integration test caching and remove recording

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -33,7 +33,7 @@ jobs:
           cache-dependency-path: |
             zip-it-and-ship-it/package-lock.json
             test-site/package-lock.json
-            netlify-cli/npm-shrinkwrap.json
+            netlify-cli/package-lock.json
       - name: Installing netlify-cli
         run: npm ci
         working-directory: netlify-cli

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           working-directory: test-site
           browser: chrome
-          record: false
+          record: true
           parallel: true
           config-file: cypress/config/ci.config.ts
           group: 'ZISI Integration Test - Next'

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           working-directory: test-site
           browser: chrome
-          record: true
+          record: false
           parallel: true
           config-file: cypress/config/ci.config.ts
           group: 'ZISI Integration Test - Next'
@@ -78,7 +78,6 @@ jobs:
           DEBUG: '@cypress/github-action'
           CYPRESS_baseUrl: ${{ env.deploy_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CYPRESS_RECORD_KEY: ${{ secrets.DEFAULT_CYPRESS_RECORD_KEY }}
       - name: Find Comment
         uses: peter-evans/find-comment@v2
         id: fc


### PR DESCRIPTION
cli has no shrinkwrap anymore in the repository.

recording disabled as the key is not set anyway

```
Warning: It looks like you are trying to record this run from a forked PR.

The Record Key is missing. Your CI provider is likely not passing private environment variables to builds from forks.

These results will not be recorded.

This error will not affect or change the exit code.
```
