### PR TITLE
feat: update node version to 18

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ The following properties are accepted:
 - `nodeVersion`
 
   - _Type_: `string`\
-  - _Default value_: `16`
+  - _Default value_: `18`
 
   The version of Node.js to use as the compilation target for bundlers. This is also used to determine the runtime
   reported in the manifest. Any valid and supported Node.js version is accepted. Examples:
@@ -478,9 +478,9 @@ need to be the same as the one used when installing those native modules.
 
 In Netlify, this is done by ensuring that the following Node.js versions are the same:
 
-- Build-time Node.js version: this defaults to Node `16`, but can be
+- Build-time Node.js version: this defaults to Node `18`, but can be
   [overridden with a `.nvmrc` or `NODE_VERSION` environment variable](https://docs.netlify.com/configure-builds/manage-dependencies/#node-js-and-javascript).
-- Function runtime Node.js version: this defaults to `nodejs16.x` but can be
+- Function runtime Node.js version: this defaults to `nodejs18.x` but can be
   [overridden with a `AWS_LAMBDA_JS_RUNTIME` environment variable](https://docs.netlify.com/functions/optional-configuration/?fn-language=js#node-js-version-for-runtime-2).
 
 Note that this problem might not apply for Node.js native modules using the [N-API](https://nodejs.org/api/n-api.html).

--- a/src/runtimes/node/utils/node_version.ts
+++ b/src/runtimes/node/utils/node_version.ts
@@ -5,7 +5,7 @@ export interface NodeVersionSupport {
 }
 
 // Must match the default version used in Bitballoon.
-export const DEFAULT_NODE_VERSION = 16
+export const DEFAULT_NODE_VERSION = 18
 
 export const getNodeVersion = (configVersion?: string) => parseVersion(configVersion) ?? DEFAULT_NODE_VERSION
 

--- a/tests/unit/runtimes/node/utils/node_version.test.ts
+++ b/tests/unit/runtimes/node/utils/node_version.test.ts
@@ -11,6 +11,7 @@ describe('getNodeVersion', () => {
     ['nodejs14.x', 14],
     ['nodejs12.x', 12],
     ['nodejs16.x', 16],
+    ['nodejs18.x', 18],
     ['18.x', 18],
     ['node16', 16],
     ['14.1.1', 14],


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

_This is a copy of the [past PR](https://github.com/netlify/zip-it-and-ship-it/pull/1138/files)_

Fixes the update for node js version to 18

I found another usage of node 16 [in here](https://github.com/netlify/zip-it-and-ship-it/blob/c8e1d4d64182ac4a71d0cf25cecdc1326b77c112/tsconfig.json#L6), but updating it breaks the tests. Does anyone knows why?

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/zip-it-and-ship-it/issues/new/choose) before writing your code 🧑‍💻.
      This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing
      a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [x] Update or add tests (if any source code was changed or added) 🧪
- [x] Update or add documentation (if features were changed or added) 📝
- [x] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
