### PR TITLE
fix: write bootstrap also when archive format is not zip

### DIFF
--- a/src/runtimes/node/utils/zip.ts
+++ b/src/runtimes/node/utils/zip.ts
@@ -53,7 +53,7 @@ interface ZipNodeParameters {
   srcFiles: string[]
 }
 
-const ensureBootstrapPresent = function (srcFiles: string[], aliases: Map<string, string>) {
+const addBootstrapFile = function (srcFiles: string[], aliases: Map<string, string>) {
   // This is the path to the file that contains all the code for the v2
   // functions API. We add it to the list of source files and create an
   // alias so that it's written as `BOOTSTRAP_FILE_NAME` in the ZIP/Directory.
@@ -95,7 +95,7 @@ const createDirectory = async function ({
   await writeFile(join(functionFolder, entryFilename), entryContents)
 
   if (runtimeAPIVersion === 2) {
-    ensureBootstrapPresent(srcFiles, aliases)
+    addBootstrapFile(srcFiles, aliases)
   }
 
   // Copying source files.
@@ -178,7 +178,7 @@ const createZipArchive = async function ({
   }
 
   if (runtimeAPIVersion === 2) {
-    ensureBootstrapPresent(srcFiles, aliases)
+    addBootstrapFile(srcFiles, aliases)
   }
 
   const srcFilesInfos = await Promise.all(srcFiles.map((file) => addStat(cache, file)))

--- a/src/runtimes/node/utils/zip.ts
+++ b/src/runtimes/node/utils/zip.ts
@@ -53,6 +53,16 @@ interface ZipNodeParameters {
   srcFiles: string[]
 }
 
+const ensureBootstrapPresent = function (srcFiles: string[], aliases: Map<string, string>) {
+  // This is the path to the file that contains all the code for the v2
+  // functions API. We add it to the list of source files and create an
+  // alias so that it's written as `BOOTSTRAP_FILE_NAME` in the ZIP/Directory.
+  const v2APIPath = getV2APIPath()
+
+  srcFiles.push(v2APIPath)
+  aliases.set(v2APIPath, BOOTSTRAP_FILE_NAME)
+}
+
 const createDirectory = async function ({
   aliases = new Map(),
   basePath,
@@ -83,6 +93,10 @@ const createDirectory = async function ({
 
   // Writing entry file.
   await writeFile(join(functionFolder, entryFilename), entryContents)
+
+  if (runtimeAPIVersion === 2) {
+    ensureBootstrapPresent(srcFiles, aliases)
+  }
 
   // Copying source files.
   await pMap(
@@ -164,13 +178,7 @@ const createZipArchive = async function ({
   }
 
   if (runtimeAPIVersion === 2) {
-    // This is the path to the file that contains all the code for the v2
-    // functions API. We add it to the list of source files and create an
-    // alias so that it's written as `BOOTSTRAP_FILE_NAME` in the ZIP.
-    const v2APIPath = getV2APIPath()
-
-    srcFiles.push(v2APIPath)
-    aliases.set(v2APIPath, BOOTSTRAP_FILE_NAME)
+    ensureBootstrapPresent(srcFiles, aliases)
   }
 
   const srcFilesInfos = await Promise.all(srcFiles.map((file) => addStat(cache, file)))

--- a/tests/v2api.test.ts
+++ b/tests/v2api.test.ts
@@ -4,6 +4,7 @@ import merge from 'deepmerge'
 import semver from 'semver'
 import { afterEach, describe, expect, vi } from 'vitest'
 
+import { ARCHIVE_FORMAT } from '../src/archive.js'
 import { ENTRY_FILE_NAME } from '../src/runtimes/node/utils/entry_file.js'
 
 import { invokeLambda, readAsBuffer } from './helpers/lambda.js'
@@ -27,6 +28,27 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
       const unzippedFunctions = await unzipFiles(files)
 
       const func = await importFunctionFile(`${unzippedFunctions[0].unzipPath}/${ENTRY_FILE_NAME}.mjs`)
+      const { body: bodyStream, headers = {}, statusCode } = await invokeLambda(func)
+      const body = await readAsBuffer(bodyStream)
+
+      expect(body).toBe('<h1>Hello world</h1>')
+      expect(headers['content-type']).toBe('text/html')
+      expect(statusCode).toBe(200)
+    },
+  )
+
+  testMany(
+    'Handles a basic JavaScript function with archiveFormat set to `none`',
+    ['bundler_default', 'todo:bundler_esbuild', 'todo:bundler_esbuild_zisi', 'bundler_default_nft', 'bundler_nft'],
+    async (options) => {
+      const { files, tmpDir } = await zipFixture('v2-api', {
+        opts: merge(options, {
+          archiveFormat: ARCHIVE_FORMAT.NONE,
+          featureFlags: { zisi_functions_api_v2: true },
+        }),
+      })
+
+      const func = await importFunctionFile(`${tmpDir}/${files[0].name}/${ENTRY_FILE_NAME}.mjs`)
       const { body: bodyStream, headers = {}, statusCode } = await invokeLambda(func)
       const body = await readAsBuffer(bodyStream)
 


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

We did not write the bootstrap when the archiveFormat was not zip.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/zip-it-and-ship-it/issues/new/choose) before writing your code 🧑‍💻.
      This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing
      a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
