### PR TITLE
fix: detect when a JS file imports a TS file

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -123,7 +123,7 @@ export const listFunctionsFiles = async function (
     ? await Promise.all(functions.map((func) => augmentWithISC(func, featureFlags)))
     : functions
   const listedFunctionsFiles = await Promise.all(
-    augmentedFunctions.map((func) => getListedFunctionFiles(func, { basePath, featureFlags })),
+    augmentedFunctions.map((func) => getListedFunctionFiles(func, { basePath, cache, featureFlags })),
   )
 
   return listedFunctionsFiles.flat()
@@ -151,7 +151,7 @@ const getListedFunction = function ({
 
 const getListedFunctionFiles = async function (
   func: AugmentedFunctionSource,
-  options: { basePath?: string; featureFlags: FeatureFlags },
+  options: { basePath?: string; cache: RuntimeCache; featureFlags: FeatureFlags },
 ): Promise<ListedFunctionFile[]> {
   const srcFiles = await getSrcFiles({
     ...func,

--- a/src/runtimes/node/index.ts
+++ b/src/runtimes/node/index.ts
@@ -16,9 +16,10 @@ import { zipNodeJs } from './utils/zip.js'
 
 // A proxy for the `getSrcFiles` that calls `getSrcFiles` on the bundler
 const getSrcFilesWithBundler: GetSrcFilesFunction = async (parameters) => {
-  const { config, extension, featureFlags, mainFile, runtimeAPIVersion, srcDir } = parameters
+  const { cache, config, extension, featureFlags, mainFile, runtimeAPIVersion, srcDir } = parameters
   const pluginsModulesPath = await getPluginsModulesPath(srcDir)
   const bundlerName = await getBundlerName({
+    cache,
     config,
     extension,
     featureFlags,
@@ -64,6 +65,7 @@ const zipFunction: ZipFunction = async function ({
   const runtimeAPIVersion = inSourceConfig.runtimeAPIVersion === 2 ? 2 : 1
   const pluginsModulesPath = await getPluginsModulesPath(srcDir)
   const bundlerName = await getBundlerName({
+    cache,
     config,
     extension,
     featureFlags,

--- a/src/runtimes/node/utils/detect_ts_imports.ts
+++ b/src/runtimes/node/utils/detect_ts_imports.ts
@@ -1,0 +1,17 @@
+import { extname } from 'path'
+
+import { nodeFileTrace } from '@vercel/nft'
+
+import { RuntimeCache } from '../../../utils/cache.js'
+
+const detectTSImports = async (entrypoint: string, cache: RuntimeCache): Promise<boolean> => {
+  const { fileList } = await nodeFileTrace([entrypoint], {
+    // we only need to look at user-written files, node_modules is expected to be JS
+    ignore: ['node_modules'],
+    cache: cache.nftCache,
+  })
+
+  return [...fileList].some((file) => extname(file).includes('ts'))
+}
+
+export default detectTSImports

--- a/src/runtimes/runtime.ts
+++ b/src/runtimes/runtime.ts
@@ -32,6 +32,7 @@ export type FindFunctionInPathFunction = (args: {
 export type GetSrcFilesFunction = (
   args: {
     basePath?: string
+    cache: RuntimeCache
     config: FunctionConfig
     featureFlags: FeatureFlags
     repositoryRoot?: string

--- a/tests/fixtures/node-typescript-imported-by-javascript/function/function.js
+++ b/tests/fixtures/node-typescript-imported-by-javascript/function/function.js
@@ -1,8 +1,3 @@
 import { add } from "./maths"
 
-export function handler() {
-  return {
-    statusCode: 200,
-    body: JSON.stringify(add(1, 2))
-  }
-}
+export const number = add(1, 2)

--- a/tests/fixtures/node-typescript-imported-by-javascript/function/function.js
+++ b/tests/fixtures/node-typescript-imported-by-javascript/function/function.js
@@ -1,0 +1,8 @@
+import { add } from "./maths"
+
+export function handler() {
+  return {
+    statusCode: 200,
+    body: JSON.stringify(add(1, 2))
+  }
+}

--- a/tests/fixtures/node-typescript-imported-by-javascript/function/maths.ts
+++ b/tests/fixtures/node-typescript-imported-by-javascript/function/maths.ts
@@ -1,0 +1,3 @@
+export function add(a: number, b: number): number {
+  return a + b
+}

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -919,6 +919,19 @@ describe('zip-it-and-ship-it', () => {
   )
 
   testMany(
+    'Handles a JavaScript function importing TypeScript',
+    ['bundler_default', 'bundler_esbuild', 'bundler_esbuild_zisi', 'bundler_default_nft', 'todo:bundler_nft'],
+    async (options) => {
+      const { files } = await zipFixture('node-typescript-imported-by-javascript', {
+        opts: options,
+      })
+      const unzippedFunctions = await unzipFiles(files)
+      const { type } = await importFunctionFile(`${unzippedFunctions[0].unzipPath}/function.js`)
+      expect(type).toBeTypeOf('string')
+    },
+  )
+
+  testMany(
     'Handles a JavaScript function ({name}.mjs, {name}/{name}.mjs, {name}/index.mjs)',
     ['bundler_esbuild', 'bundler_default'],
     async (options) => {

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -918,7 +918,7 @@ describe('zip-it-and-ship-it', () => {
     },
   )
 
-  testMany.only(
+  testMany(
     'Handles a JavaScript function importing TypeScript',
     ['todo:bundler_default', 'bundler_esbuild', 'bundler_esbuild_zisi', 'bundler_default_nft', 'todo:bundler_nft'],
     async (options) => {

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -918,16 +918,16 @@ describe('zip-it-and-ship-it', () => {
     },
   )
 
-  testMany(
+  testMany.only(
     'Handles a JavaScript function importing TypeScript',
-    ['bundler_default', 'bundler_esbuild', 'bundler_esbuild_zisi', 'bundler_default_nft', 'todo:bundler_nft'],
+    ['todo:bundler_default', 'bundler_esbuild', 'bundler_esbuild_zisi', 'bundler_default_nft', 'todo:bundler_nft'],
     async (options) => {
       const { files } = await zipFixture('node-typescript-imported-by-javascript', {
         opts: options,
       })
       const unzippedFunctions = await unzipFiles(files)
-      const { type } = await importFunctionFile(`${unzippedFunctions[0].unzipPath}/function.js`)
-      expect(type).toBeTypeOf('string')
+      const { number } = await importFunctionFile(`${unzippedFunctions[0].unzipPath}/function.js`)
+      expect(number).toBeTypeOf('number')
     },
   )
 


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

While working on #1478, I discovered that we're only transpiling TypeScript files if a function's entrypoint is a TypeScript file. This breaks when the entrypoint is a JavaScript file.

This PR adds a reproduction test. I added a fix for cases where `traceWithNft` is enabled, where we're using `nft` to detect if a `ts` file is part of the function. If it is, we default to use `esbuild` for bundling.

Fixes https://github.com/netlify/pod-dev-foundations/issues/543

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/zip-it-and-ship-it/issues/new/choose) before writing your code 🧑‍💻.
      This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing
      a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
