### PR TITLE
fix: select at least Node.js 18 when v2 function detected

### DIFF
--- a/src/runtimes/node/index.ts
+++ b/src/runtimes/node/index.ts
@@ -10,7 +10,7 @@ import { getBundler, getBundlerName } from './bundlers/index.js'
 import { NODE_BUNDLER } from './bundlers/types.js'
 import { findFunctionsInPaths, findFunctionInPath } from './finder.js'
 import { findISCDeclarationsInPath } from './in_source_config/index.js'
-import { getNodeRuntime } from './utils/node_runtime.js'
+import { getNodeRuntime, getNodeRuntimeForV2 } from './utils/node_runtime.js'
 import { createAliases as createPluginsModulesPathAliases, getPluginsModulesPath } from './utils/plugin_modules_path.js'
 import { zipNodeJs } from './utils/zip.js'
 
@@ -137,6 +137,9 @@ const zipFunction: ZipFunction = async function ({
     bundler: bundlerName,
     bundlerWarnings,
     config,
+    displayName: config?.name,
+    entryFilename: zipPath.entryFilename,
+    generator: config?.generator || getInternalValue(isInternal),
     inputs,
     includedFiles,
     inSourceConfig,
@@ -144,10 +147,8 @@ const zipFunction: ZipFunction = async function ({
     nativeNodeModules,
     nodeModulesWithDynamicImports,
     path: zipPath.path,
-    entryFilename: zipPath.entryFilename,
-    runtimeVersion: getNodeRuntime(config.nodeVersion),
-    displayName: config?.name,
-    generator: config?.generator || getInternalValue(isInternal),
+    runtimeVersion:
+      runtimeAPIVersion === 2 ? getNodeRuntimeForV2(config.nodeVersion) : getNodeRuntime(config.nodeVersion),
   }
 }
 

--- a/src/runtimes/node/utils/node_runtime.ts
+++ b/src/runtimes/node/utils/node_runtime.ts
@@ -1,4 +1,4 @@
-import { parseVersion } from './node_version.js'
+import { DEFAULT_NODE_VERSION, parseVersion } from './node_version.js'
 
 const validRuntimeMap = {
   14: 'nodejs14.x',
@@ -6,10 +6,34 @@ const validRuntimeMap = {
   18: 'nodejs18.x',
 } as const
 
+const minimumV2Version = 18
+
 export const getNodeRuntime = (input: string | undefined): string | undefined => {
   const version = parseVersion(input)
 
+  // return undefined to defer the version selection to BB/FO
   if (!version || !(version in validRuntimeMap)) {
+    return
+  }
+
+  return validRuntimeMap[version as keyof typeof validRuntimeMap]
+}
+
+export const getNodeRuntimeForV2 = (input: string | undefined): string | undefined => {
+  const version = parseVersion(input)
+
+  // If version was unable to be parsed or if the version is older than Node.js 18
+  // we return the current default Node.js version (which was Node.js 18 while writing this).
+  // Here we do not want BB/FO to decide on the version, because they value AWS_LAMBDA_JS_RUNTIME, which
+  // might be set to an too old version
+  if (!version || version < minimumV2Version) {
+    return validRuntimeMap[DEFAULT_NODE_VERSION]
+  }
+
+  // We already know that the version is Node.js 18 or newer, because of the above statement. So if
+  // we do not have it in the runtime map, we can defer to the default version handling in BB/FO.
+  // This works because we know that the `input` is the value of `AWS_LAMBDA_JS_RUNTIME` set by build.
+  if (!(version in validRuntimeMap)) {
     return
   }
 

--- a/tests/unit/runtimes/node/utils/node_runtime.test.ts
+++ b/tests/unit/runtimes/node/utils/node_runtime.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
 
-import { getNodeRuntime } from '../../../../../src/runtimes/node/utils/node_runtime.js'
+import { getNodeRuntime, getNodeRuntimeForV2 } from '../../../../../src/runtimes/node/utils/node_runtime.js'
 
 describe('getNodeRuntime', () => {
   test.each([
@@ -15,5 +15,25 @@ describe('getNodeRuntime', () => {
     [':shrug:', undefined],
   ])('handles `%s`', (input, expected) => {
     expect(getNodeRuntime(input)).toBe(expected)
+  })
+})
+
+describe('getNodeRuntimeForV2', () => {
+  test.each([
+    ['nodejs12.x', 'nodejs18.x'],
+    ['nodejs16.x', 'nodejs18.x'],
+    ['nodejs18.x', 'nodejs18.x'],
+    // enable once supported
+    // ['nodejs20.x', 'nodejs20.x'],
+    ['14.x', 'nodejs18.x'],
+    ['v16.x', 'nodejs18.x'],
+    ['18.0.0', 'nodejs18.x'],
+    // ['20.0.0', 'nodejs20.x'],
+    ['v14.2.0', 'nodejs18.x'],
+    ['14.1', 'nodejs18.x'],
+    [':shrug:', 'nodejs18.x'],
+    ['99.0.0', undefined],
+  ])('handles `%s`', (input, expected) => {
+    expect(getNodeRuntimeForV2(input)).toBe(expected)
   })
 })


### PR DESCRIPTION
#### Summary

Currently when a site is using node 16, zisi will set the runtime to `nodejs16.x` even though a v2 function is used. 

This change ensures that we always set at least Node.js 18 for the v2 functions.

