### PR TITLE
feat: add support for TypeScript to NFT

### DIFF
--- a/src/runtimes/node/bundlers/index.ts
+++ b/src/runtimes/node/bundlers/index.ts
@@ -67,10 +67,6 @@ const getDefaultBundler = async ({
   runtimeAPIVersion: number
 }): Promise<NodeBundlerName> => {
   if (runtimeAPIVersion === 2) {
-    if (ESBUILD_EXTENSIONS.has(extension)) {
-      return NODE_BUNDLER.ESBUILD
-    }
-
     return NODE_BUNDLER.NFT
   }
 

--- a/src/runtimes/node/bundlers/nft/es_modules.ts
+++ b/src/runtimes/node/bundlers/nft/es_modules.ts
@@ -209,7 +209,12 @@ const transpileESM = async ({
   await Promise.all(
     pathsToTranspile.map(async (path) => {
       const absolutePath = resolvePath(path, basePath)
-      const transpiled = await transpile(absolutePath, config, name)
+      const transpiled = await transpile({
+        config,
+        format: MODULE_FORMAT.COMMONJS,
+        name,
+        path: absolutePath,
+      })
 
       rewrites.set(absolutePath, transpiled)
     }),

--- a/src/runtimes/node/bundlers/nft/transpile.ts
+++ b/src/runtimes/node/bundlers/nft/transpile.ts
@@ -3,11 +3,18 @@ import { build } from '@netlify/esbuild'
 import type { FunctionConfig } from '../../../../config.js'
 import { FunctionBundlingUserError } from '../../../../utils/error.js'
 import { RUNTIME } from '../../../runtime.js'
-import { MODULE_FORMAT } from '../../utils/module_format.js'
+import { ModuleFormat } from '../../utils/module_format.js'
 import { getBundlerTarget } from '../esbuild/bundler_target.js'
 import { NODE_BUNDLER } from '../types.js'
 
-export const transpile = async (path: string, config: FunctionConfig, functionName: string) => {
+interface TranspileOptions {
+  config: FunctionConfig
+  format: ModuleFormat
+  name: string
+  path: string
+}
+
+export const transpile = async ({ config, format, name, path }: TranspileOptions) => {
   // The version of ECMAScript to use as the build target. This will determine
   // whether certain features are transpiled down or left untransformed.
   const nodeTarget = getBundlerTarget(config.nodeVersion)
@@ -16,7 +23,7 @@ export const transpile = async (path: string, config: FunctionConfig, functionNa
     const transpiled = await build({
       bundle: false,
       entryPoints: [path],
-      format: MODULE_FORMAT.COMMONJS,
+      format,
       logLevel: 'error',
       platform: 'node',
       sourcemap: Boolean(config.nodeSourcemap),
@@ -27,7 +34,7 @@ export const transpile = async (path: string, config: FunctionConfig, functionNa
     return transpiled.outputFiles[0].text
   } catch (error) {
     throw FunctionBundlingUserError.addCustomErrorInfo(error, {
-      functionName,
+      functionName: name,
       runtime: RUNTIME.JAVASCRIPT,
       bundler: NODE_BUNDLER.NFT,
     })

--- a/src/runtimes/node/bundlers/nft/transpile.ts
+++ b/src/runtimes/node/bundlers/nft/transpile.ts
@@ -9,7 +9,7 @@ import { NODE_BUNDLER } from '../types.js'
 
 interface TranspileOptions {
   config: FunctionConfig
-  format: ModuleFormat
+  format?: ModuleFormat
   name: string
   path: string
 }

--- a/tests/fixtures/node-typescript-directory-1/function/function.ts
+++ b/tests/fixtures/node-typescript-directory-1/function/function.ts
@@ -1,3 +1,5 @@
 type MyType = string
 
-export const type: MyType = '❤️ TypeScript'
+const type: MyType = '❤️ TypeScript'
+
+export const handler = () => type

--- a/tests/fixtures/node-typescript-directory-2/function/index.ts
+++ b/tests/fixtures/node-typescript-directory-2/function/index.ts
@@ -1,3 +1,5 @@
 type MyType = string
 
-export const type: MyType = '❤️ TypeScript'
+const type: MyType = '❤️ TypeScript'
+
+export const handler = () => type

--- a/tests/fixtures/node-typescript-with-imports/function.ts
+++ b/tests/fixtures/node-typescript-with-imports/function.ts
@@ -1,4 +1,1 @@
-// We do not rename to `./util.js` because `@vercel/nft` does not manage to
-// find the dependency `util.ts` then, even though using `.js` file extensions
-// is the recommended way to use pure ES modules with Typescript.
-export { type } from './lib/util'
+export { type } from './lib/util.js'

--- a/tests/fixtures/node-typescript-with-imports/function.ts
+++ b/tests/fixtures/node-typescript-with-imports/function.ts
@@ -1,1 +1,3 @@
-export { type } from './lib/util.js'
+import { type } from './lib/util.js'
+
+export const handler = () => type

--- a/tests/fixtures/node-typescript/function.ts
+++ b/tests/fixtures/node-typescript/function.ts
@@ -1,3 +1,5 @@
 type MyType = string
 
-export const type: MyType = '❤️ TypeScript'
+const type: MyType = '❤️ TypeScript'
+
+export const handler = () => type

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -935,8 +935,8 @@ describe('zip-it-and-ship-it', () => {
         opts: options,
       })
       const unzippedFunctions = await unzipFiles(files)
-      const { type } = await importFunctionFile(`${unzippedFunctions[0].unzipPath}/function.js`)
-      expect(type).toBeTypeOf('string')
+      const { handler } = await importFunctionFile(`${unzippedFunctions[0].unzipPath}/function.js`)
+      expect(handler()).toBe('❤️ TypeScript')
     },
   )
 
@@ -948,8 +948,8 @@ describe('zip-it-and-ship-it', () => {
         opts: options,
       })
       const unzippedFunctions = await unzipFiles(files)
-      const { type } = await importFunctionFile(`${unzippedFunctions[0].unzipPath}/function.js`)
-      expect(type).toBeTypeOf('string')
+      const { handler } = await importFunctionFile(`${unzippedFunctions[0].unzipPath}/function.js`)
+      expect(handler()).toBe('❤️ TypeScript')
     },
   )
 
@@ -961,8 +961,8 @@ describe('zip-it-and-ship-it', () => {
         opts: options,
       })
       const unzippedFunctions = await unzipFiles(files)
-      const { type } = await importFunctionFile(`${unzippedFunctions[0].unzipPath}/function.js`)
-      expect(type).toBeTypeOf('string')
+      const { handler } = await importFunctionFile(`${unzippedFunctions[0].unzipPath}/function.js`)
+      expect(handler()).toBe('❤️ TypeScript')
     },
   )
 
@@ -974,8 +974,9 @@ describe('zip-it-and-ship-it', () => {
         opts: options,
       })
       const unzippedFunctions = await unzipFiles(files)
-      const { type } = await importFunctionFile(`${unzippedFunctions[0].unzipPath}/function.js`)
-      expect(type).toBeTypeOf('string')
+      const { handler } = await importFunctionFile(`${unzippedFunctions[0].unzipPath}/function.js`)
+
+      expect(handler()).toBe('❤️ TypeScript')
     },
   )
 

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -929,7 +929,7 @@ describe('zip-it-and-ship-it', () => {
 
   testMany(
     'Handles a TypeScript function ({name}.ts)',
-    ['bundler_default', 'bundler_esbuild', 'bundler_esbuild_zisi', 'bundler_default_nft', 'todo:bundler_nft'],
+    ['bundler_default', 'bundler_esbuild', 'bundler_esbuild_zisi', 'bundler_default_nft', 'bundler_nft'],
     async (options) => {
       const { files } = await zipFixture('node-typescript', {
         opts: options,
@@ -942,7 +942,7 @@ describe('zip-it-and-ship-it', () => {
 
   testMany(
     'Handles a TypeScript function ({name}/{name}.ts)',
-    ['bundler_default', 'bundler_esbuild', 'bundler_esbuild_zisi', 'bundler_default_nft', 'todo:bundler_nft'],
+    ['bundler_default', 'bundler_esbuild', 'bundler_esbuild_zisi', 'bundler_default_nft', 'bundler_nft'],
     async (options) => {
       const { files } = await zipFixture('node-typescript-directory-1', {
         opts: options,
@@ -955,7 +955,7 @@ describe('zip-it-and-ship-it', () => {
 
   testMany(
     'Handles a TypeScript function ({name}/index.ts)',
-    ['bundler_default', 'bundler_esbuild', 'bundler_esbuild_zisi', 'bundler_default_nft', 'todo:bundler_nft'],
+    ['bundler_default', 'bundler_esbuild', 'bundler_esbuild_zisi', 'bundler_default_nft', 'bundler_nft'],
     async (options) => {
       const { files } = await zipFixture('node-typescript-directory-2', {
         opts: options,
@@ -968,7 +968,7 @@ describe('zip-it-and-ship-it', () => {
 
   testMany(
     'Handles a TypeScript function with imports',
-    ['bundler_default', 'bundler_esbuild', 'bundler_esbuild_zisi', 'bundler_default_nft', 'todo:bundler_nft'],
+    ['bundler_default', 'bundler_esbuild', 'bundler_esbuild_zisi', 'bundler_default_nft', 'bundler_nft'],
     async (options) => {
       const { files } = await zipFixture('node-typescript-with-imports', {
         opts: options,


### PR DESCRIPTION
#### Summary

Currently, TypeScript files are only supported when the bundler is set to esbuild. This PR adds support for TypeScript when using NFT as the bundler.

With that, we also change the upcoming functions API v2 to use NFT by default, instead of esbuild (https://github.com/netlify/zip-it-and-ship-it/pull/1515/commits/2779f306a52033b85e0c5873d592c18e119f3f55).