### PR TITLE
feat: log dynamic import expressions

### DIFF
--- a/src/runtimes/node/bundlers/esbuild/bundler.ts
+++ b/src/runtimes/node/bundlers/esbuild/bundler.ts
@@ -80,6 +80,7 @@ export const bundleJsFile = async function ({
     getDynamicImportsPlugin({
       basePath,
       includedPaths: dynamicImportsIncludedPaths,
+      logger: featureFlags.zisi_log_dynamic_imports ? logger : undefined,
       moduleNames: nodeModulesWithDynamicImports,
       processImports: config.processDynamicNodeImports !== false,
       srcDir,
@@ -149,13 +150,6 @@ let require=___nfyCreateRequire(import.meta.url);
     const inputs = Object.keys(metafile.inputs).map((path) => resolve(path))
     const cleanTempFiles = getCleanupFunction([...bundlePaths.keys()])
     const additionalPaths = [...dynamicImportsIncludedPaths, ...includedFilesFromModuleDetection]
-
-    if (featureFlags.zisi_log_dynamic_imports && dynamicImportsIncludedPaths.size !== 0) {
-      // Capping the number of paths to avoid large log volumes.
-      const paths = [...dynamicImportsIncludedPaths].slice(0, 20).join(', ')
-
-      logger.system(`Functions bundling included paths by parsing dynamic import: ${paths}`)
-    }
 
     return {
       additionalPaths,

--- a/src/runtimes/node/bundlers/esbuild/plugin_dynamic_imports.ts
+++ b/src/runtimes/node/bundlers/esbuild/plugin_dynamic_imports.ts
@@ -4,6 +4,7 @@ import type { Plugin } from '@netlify/esbuild'
 import { findUp, findUpStop, pathExists } from 'find-up'
 import normalizePath from 'normalize-path'
 
+import { Logger } from '../../../../utils/logger.js'
 import { parseExpression } from '../../parser/index.js'
 import { readPackageJson } from '../../utils/package_json.js'
 
@@ -19,12 +20,14 @@ type PackageCache = Map<string, Promise<string | undefined>>
 export const getDynamicImportsPlugin = ({
   basePath,
   includedPaths,
+  logger,
   moduleNames,
   processImports,
   srcDir,
 }: {
   basePath?: string
   includedPaths: Set<string>
+  logger?: Logger
   moduleNames: Set<string>
   processImports: boolean
   srcDir: string
@@ -47,6 +50,8 @@ export const getDynamicImportsPlugin = ({
           // The parser has found a glob of paths that should be included in the
           // bundle to make this import work, so we add it to `includedPaths`.
           includedPaths.add(includedPathsGlob)
+
+          logger?.system(`Functions bundling processed dynamic import with expression: ${expression}`)
 
           // Create the shim that will handle the import at runtime.
           const contents = getShimContents({ expressionType, resolveDir, srcDir })

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -1569,13 +1569,25 @@ describe('zip-it-and-ship-it', () => {
     expect(() => func('two')).toThrowError()
     expect(files[0].nodeModulesWithDynamicImports).toHaveLength(0)
 
-    const pathsFromDynamicImports = [
-      join('node_modules', '@org', 'test', 'files', '**'),
-      join('node_modules', '@org', 'test', 'files', '**.js'),
-    ]
-
     expect(systemLog).toHaveBeenCalledWith(
-      `Functions bundling included paths by parsing dynamic import: ${pathsFromDynamicImports.join(', ')}`,
+      // eslint-disable-next-line no-template-curly-in-string
+      'Functions bundling processed dynamic import with expression: require(`./files/${parent.child}`)',
+    )
+    expect(systemLog).toHaveBeenCalledWith(
+      // eslint-disable-next-line no-template-curly-in-string
+      "Functions bundling processed dynamic import with expression: require(`./files/${number.length > 0 ? number : 'uh-oh'}`)",
+    )
+    expect(systemLog).toHaveBeenCalledWith(
+      // eslint-disable-next-line no-template-curly-in-string
+      'Functions bundling processed dynamic import with expression: require(`./files/${number}`)',
+    )
+    expect(systemLog).toHaveBeenCalledWith(
+      // eslint-disable-next-line no-template-curly-in-string
+      'Functions bundling processed dynamic import with expression: require(`./files/${arr[0]}`)',
+    )
+    expect(systemLog).toHaveBeenCalledWith(
+      // eslint-disable-next-line no-template-curly-in-string
+      'Functions bundling processed dynamic import with expression: require(`./files/${number}.js`)',
     )
   })
 


### PR DESCRIPTION
#### Summary

As of version 0.19.0, [esbuild can now process some dynamic imports](https://esbuild.github.io/api/#glob), albeit just a subset of the expressions our custom plugin can process. I'd like to understand how many of the expressions people are using in the wild would be supported natively by esbuild, with the view of decommissioning our fork entirely.

With https://github.com/netlify/zip-it-and-ship-it/pull/1445, we started logging any instances where the dynamic imports plugin from our esbuild fork was used to process a dynamic import expression, but we're logging the paths that will be included in the bundle, which is not the most useful piece of informaiton.

This PR changes that so we log the actual dynamic import expression that was used. We can then compare those against the list of expressions that esbuild supports.