### PR TITLE
fix: update esbuild to 0.14.39-1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@babel/parser": "^7.22.5",
         "@netlify/binary-info": "^1.0.0",
-        "@netlify/esbuild": "0.14.39",
+        "@netlify/esbuild": "0.14.39-1",
         "@netlify/serverless-functions-api": "^1.6.0",
         "@vercel/nft": "^0.23.0",
         "archiver": "^5.3.0",
@@ -1846,9 +1846,9 @@
       "integrity": "sha512-4wMPu9iN3/HL97QblBsBay3E1etIciR84izI3U+4iALY+JHCrI+a2jO0qbAZ/nxKoegypYEaiiqWXylm+/zfrw=="
     },
     "node_modules/@netlify/esbuild": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild/-/esbuild-0.14.39.tgz",
-      "integrity": "sha512-C3xpwdT2xw6SnSb+hLQoxjtikAKiz6BjQjzlIaysHDpGbmIcmUHZ/X+dyLtCqAvf15WNK5GSBZYOlpgcOE0WZA==",
+      "version": "0.14.39-1",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild/-/esbuild-0.14.39-1.tgz",
+      "integrity": "sha512-FkS9R3aeD1JvPhEZh9r4GfXGLHoqzAsS3haqIeFfQ907irkGzCg1w5r5OWuSqPtLNyaGklVWz/HU0IsM8thyZw==",
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
@@ -1857,32 +1857,32 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "@netlify/esbuild-android-64": "0.14.39",
-        "@netlify/esbuild-android-arm64": "0.14.39",
-        "@netlify/esbuild-darwin-64": "0.14.39",
-        "@netlify/esbuild-darwin-arm64": "0.14.39",
-        "@netlify/esbuild-freebsd-64": "0.14.39",
-        "@netlify/esbuild-freebsd-arm64": "0.14.39",
-        "@netlify/esbuild-linux-32": "0.14.39",
-        "@netlify/esbuild-linux-64": "0.14.39",
-        "@netlify/esbuild-linux-arm": "0.14.39",
-        "@netlify/esbuild-linux-arm64": "0.14.39",
-        "@netlify/esbuild-linux-mips64le": "0.14.39",
-        "@netlify/esbuild-linux-ppc64le": "0.14.39",
-        "@netlify/esbuild-linux-riscv64": "0.14.39",
-        "@netlify/esbuild-linux-s390x": "0.14.39",
-        "@netlify/esbuild-netbsd-64": "0.14.39",
-        "@netlify/esbuild-openbsd-64": "0.14.39",
-        "@netlify/esbuild-sunos-64": "0.14.39",
-        "@netlify/esbuild-windows-32": "0.14.39",
-        "@netlify/esbuild-windows-64": "0.14.39",
-        "@netlify/esbuild-windows-arm64": "0.14.39"
+        "@netlify/esbuild-android-64": "0.14.39-1",
+        "@netlify/esbuild-android-arm64": "0.14.39-1",
+        "@netlify/esbuild-darwin-64": "0.14.39-1",
+        "@netlify/esbuild-darwin-arm64": "0.14.39-1",
+        "@netlify/esbuild-freebsd-64": "0.14.39-1",
+        "@netlify/esbuild-freebsd-arm64": "0.14.39-1",
+        "@netlify/esbuild-linux-32": "0.14.39-1",
+        "@netlify/esbuild-linux-64": "0.14.39-1",
+        "@netlify/esbuild-linux-arm": "0.14.39-1",
+        "@netlify/esbuild-linux-arm64": "0.14.39-1",
+        "@netlify/esbuild-linux-mips64le": "0.14.39-1",
+        "@netlify/esbuild-linux-ppc64le": "0.14.39-1",
+        "@netlify/esbuild-linux-riscv64": "0.14.39-1",
+        "@netlify/esbuild-linux-s390x": "0.14.39-1",
+        "@netlify/esbuild-netbsd-64": "0.14.39-1",
+        "@netlify/esbuild-openbsd-64": "0.14.39-1",
+        "@netlify/esbuild-sunos-64": "0.14.39-1",
+        "@netlify/esbuild-windows-32": "0.14.39-1",
+        "@netlify/esbuild-windows-64": "0.14.39-1",
+        "@netlify/esbuild-windows-arm64": "0.14.39-1"
       }
     },
     "node_modules/@netlify/esbuild-android-64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-android-64/-/esbuild-android-64-0.14.39.tgz",
-      "integrity": "sha512-azq+lsvjRsKLap8ubIwSJXGyknUACqYu5h98Fvyoh40Qk4QXIVKl16JIJ4s+B7jy2k9qblEc5c4nxdDA3aGbVA==",
+      "version": "0.14.39-1",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-android-64/-/esbuild-android-64-0.14.39-1.tgz",
+      "integrity": "sha512-/rZn0xVfTLVjx0SLvToydTTpvNwrlFqxW++Lqen7CXubTJNFnZQH0hP/qMCILac41zvSipxyU5/Di9mWHoLv9Q==",
       "cpu": [
         "x64"
       ],
@@ -1895,9 +1895,9 @@
       }
     },
     "node_modules/@netlify/esbuild-android-arm64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-android-arm64/-/esbuild-android-arm64-0.14.39.tgz",
-      "integrity": "sha512-WhIP7ePq4qMC1sxoaeB9SsJqSW6uzW7XDj/IuWl1l9r94nwxywU1sYdVLaF2mZr15njviazYjVr8x1d+ipwL3w==",
+      "version": "0.14.39-1",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-android-arm64/-/esbuild-android-arm64-0.14.39-1.tgz",
+      "integrity": "sha512-Wnjsv5djKQ2NwKaDj2P5DpvNAFhQIQBer2IqVCQ8u0ykdyr+y+u5CmM1ZnrzBnDUULk5TYwPlUNt3p2NctSnLQ==",
       "cpu": [
         "arm64"
       ],
@@ -1910,9 +1910,9 @@
       }
     },
     "node_modules/@netlify/esbuild-darwin-64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-darwin-64/-/esbuild-darwin-64-0.14.39.tgz",
-      "integrity": "sha512-eF4GvLYiDxtcyjFT55+h+8c8A2HltjeMezCqkt3AQSgOdu1nhlvwbBhIdg2dyM6gKEaEm5hBtTbicEDSwsLodA==",
+      "version": "0.14.39-1",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-darwin-64/-/esbuild-darwin-64-0.14.39-1.tgz",
+      "integrity": "sha512-rHQmZcS+1qC9bL1EwFQ8SGqiKrIUQLam9ty2bcsEH78525NoAW8f/ENollQlso1K8lSkcn+KzX7i09FdRL0TLQ==",
       "cpu": [
         "x64"
       ],
@@ -1925,9 +1925,9 @@
       }
     },
     "node_modules/@netlify/esbuild-darwin-arm64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.39.tgz",
-      "integrity": "sha512-b7rtnX/VtYwNbUCxs3eulrCWJ+u2YvqDcXiIV1ka+od+N0fTx+4RrVkVp1lha9L0wEJYK9J7UWZOMLMyd1ynRg==",
+      "version": "0.14.39-1",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.39-1.tgz",
+      "integrity": "sha512-Ytz9SY7BjtBnrZL4qCsKJ/xyjJyH2LFLV3kv3DhY5X+eUUBsjdCAq2VVY9zLnvkNf5Sef/U35Jie2O0sl+3E1g==",
       "cpu": [
         "arm64"
       ],
@@ -1940,9 +1940,9 @@
       }
     },
     "node_modules/@netlify/esbuild-freebsd-64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.39.tgz",
-      "integrity": "sha512-XtusxDJt2hUKUdggbTFolMx0kJL2zEa4STI7YwpB+ukEWoW5rODZjiLZbqqYLcjDH8k4YwHaMxs103L8eButEQ==",
+      "version": "0.14.39-1",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.39-1.tgz",
+      "integrity": "sha512-TsOZCldbxEOB4Rv5tudYCkPkfHklmOWQgRPoz3wsmJDUpLwljOQFru4J0uCRqKKGLALo1qBBQvzofQi+5dvTzQ==",
       "cpu": [
         "x64"
       ],
@@ -1955,9 +1955,9 @@
       }
     },
     "node_modules/@netlify/esbuild-freebsd-arm64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.39.tgz",
-      "integrity": "sha512-A9XZKai+k6kfndCtN6Dh2usT28V0+OGxzFdZsANONPQiEUTrGZCgwcHWiVlVn7SeAwPR1tKZreTnvrfj8cj7hA==",
+      "version": "0.14.39-1",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.39-1.tgz",
+      "integrity": "sha512-wJbKm1eijTiots/RgDOZjbqcZaCVElPjegRit0LkbAQnqfBc2B8F6j7CkUgbWg1hU2+YJFiMGhaRMljN9jpCVQ==",
       "cpu": [
         "arm64"
       ],
@@ -1970,9 +1970,9 @@
       }
     },
     "node_modules/@netlify/esbuild-linux-32": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-32/-/esbuild-linux-32-0.14.39.tgz",
-      "integrity": "sha512-ZQnqk/82YRvINY+aF+LlGfRZ19c5mH0jaxsO046GpIOPx6PcXHG8JJ2lg+vLJVe4zFPohxzabcYpwFuT4cg/GA==",
+      "version": "0.14.39-1",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-32/-/esbuild-linux-32-0.14.39-1.tgz",
+      "integrity": "sha512-rSCpXot5p3zUpwnC9ttKtP+vWf3gT1CkzJwEBHqqIr0GmgTLoADMaZ1AZqq125DyCvPf2s9f98XtSWaHmIqN8w==",
       "cpu": [
         "ia32"
       ],
@@ -1985,9 +1985,9 @@
       }
     },
     "node_modules/@netlify/esbuild-linux-64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-64/-/esbuild-linux-64-0.14.39.tgz",
-      "integrity": "sha512-IQtswVw7GAKNX/3yV390wSfSXvMWy0d5cw8csAffwBk9gupftY2lzepK4Cn6uD/aqLt3Iku33FbHop/2nPGfQA==",
+      "version": "0.14.39-1",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-64/-/esbuild-linux-64-0.14.39-1.tgz",
+      "integrity": "sha512-lx+tQR7OW9Sq8WrP+zJ20lpJFHe4jvO56czUjJe7iSYtu0mpbApnJc2p4KqakU4xdjMdlqsUDG6L7GqE4+dNxQ==",
       "cpu": [
         "x64"
       ],
@@ -2000,9 +2000,9 @@
       }
     },
     "node_modules/@netlify/esbuild-linux-arm": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-arm/-/esbuild-linux-arm-0.14.39.tgz",
-      "integrity": "sha512-QdOzQniOed0Bz1cTC9TMMwvtAqKayYv66H4edJlbvElC81yJZF/c9XhmYWJ6P5g4nkChZubQ5RcQwTLmrFGexg==",
+      "version": "0.14.39-1",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-arm/-/esbuild-linux-arm-0.14.39-1.tgz",
+      "integrity": "sha512-O2w4oRYNoavKyednlkCnxr7VnfizpWurCxKraRyKQ4XIQbv3bqtgK/VSt1cJMwm+7+BdGNsqux4wAKmwsdW+Zw==",
       "cpu": [
         "arm"
       ],
@@ -2015,9 +2015,9 @@
       }
     },
     "node_modules/@netlify/esbuild-linux-arm64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.39.tgz",
-      "integrity": "sha512-4Jie4QV6pWWuGN7TAshNMGbdTA9+VbRkv3rPIxhgK5gBfmsAV1yRKsumE4Y77J0AZNRiOriyoec4zc1qkmI3zg==",
+      "version": "0.14.39-1",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.39-1.tgz",
+      "integrity": "sha512-e1gEB3+1WWsvBNDrPIq43hkUmWx9CkN5DVfcHa9Ar55DY8G9DRl5MyCFVpYVPctoWLRMlt1VRwPuc5YfSTXZbw==",
       "cpu": [
         "arm64"
       ],
@@ -2030,9 +2030,9 @@
       }
     },
     "node_modules/@netlify/esbuild-linux-mips64le": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.39.tgz",
-      "integrity": "sha512-Htozxr95tw4tSd86YNbCLs1eoYQzNu/cHpzFIkuJoztZueUhl8XpRvBdob7n3kEjW1gitLWAIn8XUwSt+aJ1Tg==",
+      "version": "0.14.39-1",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.39-1.tgz",
+      "integrity": "sha512-SKDBxNiJmTD1HYlmq6GWbz7dBtz1lYg28Y8RLo2Yj/jZtkVzZbMS0sVhB05FAzQhGT+m1bFLSrbLJkfmbzoQXg==",
       "cpu": [
         "mips64el"
       ],
@@ -2045,9 +2045,9 @@
       }
     },
     "node_modules/@netlify/esbuild-linux-ppc64le": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.39.tgz",
-      "integrity": "sha512-tFy0ufWIdjeuk1rPHee00TZlhr9OSF00Ufb4ROFyt2ArKuMSkWRJuDgx6MtZcAnCIN4cybo/xWl3MKTM+scnww==",
+      "version": "0.14.39-1",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.39-1.tgz",
+      "integrity": "sha512-cKIoVrHn6qJf1cTKCaOQvXKpcpSwCShzNkEQNtWCEFvlHJ817lsVaWqQm01qDQ9pGrDbhZRsUAIOkwsjLrKDmA==",
       "cpu": [
         "ppc64"
       ],
@@ -2060,9 +2060,9 @@
       }
     },
     "node_modules/@netlify/esbuild-linux-riscv64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.39.tgz",
-      "integrity": "sha512-ZzfKvwIxL7wQnYbVFpyNW0wotnLoKageUEM57RbjekesJoNQnqUR6Usm+LDZoB8iRsI58VX1IxnstP0cX8vOHw==",
+      "version": "0.14.39-1",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.39-1.tgz",
+      "integrity": "sha512-W6gQyJc52lFoPj0w6AoQCfa8/fmwsC6CrT80JKe+fF4mYwBUnySbRVldMDb/cb6qCqHt5m3X+w7HFS5soPGT5Q==",
       "cpu": [
         "riscv64"
       ],
@@ -2075,9 +2075,9 @@
       }
     },
     "node_modules/@netlify/esbuild-linux-s390x": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.39.tgz",
-      "integrity": "sha512-yjC0mFwnuMRoh0WcF0h71MF71ytZBFEQQTRdgiGT0+gbC4UApBqnTkJdLx32RscBKi9skbMChiJ748hDJou6FA==",
+      "version": "0.14.39-1",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.39-1.tgz",
+      "integrity": "sha512-IN4agxUutc0BbcAMDDVuz60bDKFEGlq+vZlPzeLnketkVs/5BZj1vfoS8hJJelvR/mB99G9YjyOm08EthqoyHw==",
       "cpu": [
         "s390x"
       ],
@@ -2090,9 +2090,9 @@
       }
     },
     "node_modules/@netlify/esbuild-netbsd-64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.39.tgz",
-      "integrity": "sha512-mIq4znOoz3YfTVdv3sIWfR4Zx5JgMnT4srlhC5KYVHibhxvyDdin5txldYXmR4Zv4dZd6DSuWFsn441aUegHeA==",
+      "version": "0.14.39-1",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.39-1.tgz",
+      "integrity": "sha512-cnvcQ6u7QtjnxFcMYtEUqOYg8wTfLOSoc6nFPhjIE4074Tw/H48LFqFq0v2Gtgvc5neUZtxBF2+6QMX4Q91vwQ==",
       "cpu": [
         "x64"
       ],
@@ -2105,9 +2105,9 @@
       }
     },
     "node_modules/@netlify/esbuild-openbsd-64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.39.tgz",
-      "integrity": "sha512-+t6QdzJCngH19hV7ClpFAeFDI2ko/HNcFbiNwaXTMVLB3hWi1sJtn+fzZck5HfzN4qsajAVqZq4nwX69SSt25A==",
+      "version": "0.14.39-1",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.39-1.tgz",
+      "integrity": "sha512-14fDX08hM0rWzUO7uf7Wxg9uL5SK5AqSDe+vXviIL+gWGN2vHoakRbzZoLVHFwoTLT5/1oIUYDJfcmcrFm1rjw==",
       "cpu": [
         "x64"
       ],
@@ -2120,9 +2120,9 @@
       }
     },
     "node_modules/@netlify/esbuild-sunos-64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-sunos-64/-/esbuild-sunos-64-0.14.39.tgz",
-      "integrity": "sha512-HLfXG6i2p3wyyyWHeeP4ShGDJ1zRMnf9YLJLe2ezv2KqvcKw/Un/m/FBuDW1p13oSUO7ShISMzgc1dw1GGBEOQ==",
+      "version": "0.14.39-1",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-sunos-64/-/esbuild-sunos-64-0.14.39-1.tgz",
+      "integrity": "sha512-TDUJGI077mAM3qotUfN/DcKaBq3nLeAdNwjsWulKgdC3UwC/iqyrYrnmZipEbiHO2jt4+wRFUz/s/x+HeDiblg==",
       "cpu": [
         "x64"
       ],
@@ -2135,9 +2135,9 @@
       }
     },
     "node_modules/@netlify/esbuild-windows-32": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-windows-32/-/esbuild-windows-32-0.14.39.tgz",
-      "integrity": "sha512-ZpSQcKbVSCU3ln7mHpsL/5dWsUqCNdTnC5YAArnaOwdrlIunrsbo5j4MOZRRcGExb2uvTc/rb+D3mlGb8j1rkA==",
+      "version": "0.14.39-1",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-windows-32/-/esbuild-windows-32-0.14.39-1.tgz",
+      "integrity": "sha512-Jyf5OUm+Guo7+SoIURTfmzqri10xj18qdgxwy3NNsQG/Eg1XLETDORWH0cKy6YTiRDuqeCsZeXDoAQABOs30gQ==",
       "cpu": [
         "ia32"
       ],
@@ -2150,9 +2150,9 @@
       }
     },
     "node_modules/@netlify/esbuild-windows-64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-windows-64/-/esbuild-windows-64-0.14.39.tgz",
-      "integrity": "sha512-I3gCdO8+6IDhT4Y1ZmV4o2Gg0oELv7N4kCcE4kqclz10fWHNjf19HQNHyBJe0AWnFV5ZfT154VVD31dqgwpgFw==",
+      "version": "0.14.39-1",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-windows-64/-/esbuild-windows-64-0.14.39-1.tgz",
+      "integrity": "sha512-D41xhwJN90qeLebZrb853zhGJahIlCf+HPKwxVZx+Nk8BNV09jQyJ2GYqmmwRxNOrbzqD80+pgvoYkq4a4OV0g==",
       "cpu": [
         "x64"
       ],
@@ -2165,9 +2165,9 @@
       }
     },
     "node_modules/@netlify/esbuild-windows-arm64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.39.tgz",
-      "integrity": "sha512-WX52W8U1lsfWcz6NWoSpDs57lgiiMHN23seq8G2bvxzGS/tvYD3dxVLLW5UPoKSnFDyVQT7b6Zkt6AkBten1yQ==",
+      "version": "0.14.39-1",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.39-1.tgz",
+      "integrity": "sha512-EGzYwc+MoKhWnz+6iUbXQKcQKV8FbPovDJkmY9YWGkgSwZALPo4DpjSaMLW6hv42YRyoBRM1NP/v/qmVtgeJjQ==",
       "cpu": [
         "arm64"
       ],
@@ -12230,150 +12230,150 @@
       "integrity": "sha512-4wMPu9iN3/HL97QblBsBay3E1etIciR84izI3U+4iALY+JHCrI+a2jO0qbAZ/nxKoegypYEaiiqWXylm+/zfrw=="
     },
     "@netlify/esbuild": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild/-/esbuild-0.14.39.tgz",
-      "integrity": "sha512-C3xpwdT2xw6SnSb+hLQoxjtikAKiz6BjQjzlIaysHDpGbmIcmUHZ/X+dyLtCqAvf15WNK5GSBZYOlpgcOE0WZA==",
+      "version": "0.14.39-1",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild/-/esbuild-0.14.39-1.tgz",
+      "integrity": "sha512-FkS9R3aeD1JvPhEZh9r4GfXGLHoqzAsS3haqIeFfQ907irkGzCg1w5r5OWuSqPtLNyaGklVWz/HU0IsM8thyZw==",
       "requires": {
-        "@netlify/esbuild-android-64": "0.14.39",
-        "@netlify/esbuild-android-arm64": "0.14.39",
-        "@netlify/esbuild-darwin-64": "0.14.39",
-        "@netlify/esbuild-darwin-arm64": "0.14.39",
-        "@netlify/esbuild-freebsd-64": "0.14.39",
-        "@netlify/esbuild-freebsd-arm64": "0.14.39",
-        "@netlify/esbuild-linux-32": "0.14.39",
-        "@netlify/esbuild-linux-64": "0.14.39",
-        "@netlify/esbuild-linux-arm": "0.14.39",
-        "@netlify/esbuild-linux-arm64": "0.14.39",
-        "@netlify/esbuild-linux-mips64le": "0.14.39",
-        "@netlify/esbuild-linux-ppc64le": "0.14.39",
-        "@netlify/esbuild-linux-riscv64": "0.14.39",
-        "@netlify/esbuild-linux-s390x": "0.14.39",
-        "@netlify/esbuild-netbsd-64": "0.14.39",
-        "@netlify/esbuild-openbsd-64": "0.14.39",
-        "@netlify/esbuild-sunos-64": "0.14.39",
-        "@netlify/esbuild-windows-32": "0.14.39",
-        "@netlify/esbuild-windows-64": "0.14.39",
-        "@netlify/esbuild-windows-arm64": "0.14.39"
+        "@netlify/esbuild-android-64": "0.14.39-1",
+        "@netlify/esbuild-android-arm64": "0.14.39-1",
+        "@netlify/esbuild-darwin-64": "0.14.39-1",
+        "@netlify/esbuild-darwin-arm64": "0.14.39-1",
+        "@netlify/esbuild-freebsd-64": "0.14.39-1",
+        "@netlify/esbuild-freebsd-arm64": "0.14.39-1",
+        "@netlify/esbuild-linux-32": "0.14.39-1",
+        "@netlify/esbuild-linux-64": "0.14.39-1",
+        "@netlify/esbuild-linux-arm": "0.14.39-1",
+        "@netlify/esbuild-linux-arm64": "0.14.39-1",
+        "@netlify/esbuild-linux-mips64le": "0.14.39-1",
+        "@netlify/esbuild-linux-ppc64le": "0.14.39-1",
+        "@netlify/esbuild-linux-riscv64": "0.14.39-1",
+        "@netlify/esbuild-linux-s390x": "0.14.39-1",
+        "@netlify/esbuild-netbsd-64": "0.14.39-1",
+        "@netlify/esbuild-openbsd-64": "0.14.39-1",
+        "@netlify/esbuild-sunos-64": "0.14.39-1",
+        "@netlify/esbuild-windows-32": "0.14.39-1",
+        "@netlify/esbuild-windows-64": "0.14.39-1",
+        "@netlify/esbuild-windows-arm64": "0.14.39-1"
       }
     },
     "@netlify/esbuild-android-64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-android-64/-/esbuild-android-64-0.14.39.tgz",
-      "integrity": "sha512-azq+lsvjRsKLap8ubIwSJXGyknUACqYu5h98Fvyoh40Qk4QXIVKl16JIJ4s+B7jy2k9qblEc5c4nxdDA3aGbVA==",
+      "version": "0.14.39-1",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-android-64/-/esbuild-android-64-0.14.39-1.tgz",
+      "integrity": "sha512-/rZn0xVfTLVjx0SLvToydTTpvNwrlFqxW++Lqen7CXubTJNFnZQH0hP/qMCILac41zvSipxyU5/Di9mWHoLv9Q==",
       "optional": true
     },
     "@netlify/esbuild-android-arm64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-android-arm64/-/esbuild-android-arm64-0.14.39.tgz",
-      "integrity": "sha512-WhIP7ePq4qMC1sxoaeB9SsJqSW6uzW7XDj/IuWl1l9r94nwxywU1sYdVLaF2mZr15njviazYjVr8x1d+ipwL3w==",
+      "version": "0.14.39-1",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-android-arm64/-/esbuild-android-arm64-0.14.39-1.tgz",
+      "integrity": "sha512-Wnjsv5djKQ2NwKaDj2P5DpvNAFhQIQBer2IqVCQ8u0ykdyr+y+u5CmM1ZnrzBnDUULk5TYwPlUNt3p2NctSnLQ==",
       "optional": true
     },
     "@netlify/esbuild-darwin-64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-darwin-64/-/esbuild-darwin-64-0.14.39.tgz",
-      "integrity": "sha512-eF4GvLYiDxtcyjFT55+h+8c8A2HltjeMezCqkt3AQSgOdu1nhlvwbBhIdg2dyM6gKEaEm5hBtTbicEDSwsLodA==",
+      "version": "0.14.39-1",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-darwin-64/-/esbuild-darwin-64-0.14.39-1.tgz",
+      "integrity": "sha512-rHQmZcS+1qC9bL1EwFQ8SGqiKrIUQLam9ty2bcsEH78525NoAW8f/ENollQlso1K8lSkcn+KzX7i09FdRL0TLQ==",
       "optional": true
     },
     "@netlify/esbuild-darwin-arm64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.39.tgz",
-      "integrity": "sha512-b7rtnX/VtYwNbUCxs3eulrCWJ+u2YvqDcXiIV1ka+od+N0fTx+4RrVkVp1lha9L0wEJYK9J7UWZOMLMyd1ynRg==",
+      "version": "0.14.39-1",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.39-1.tgz",
+      "integrity": "sha512-Ytz9SY7BjtBnrZL4qCsKJ/xyjJyH2LFLV3kv3DhY5X+eUUBsjdCAq2VVY9zLnvkNf5Sef/U35Jie2O0sl+3E1g==",
       "optional": true
     },
     "@netlify/esbuild-freebsd-64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.39.tgz",
-      "integrity": "sha512-XtusxDJt2hUKUdggbTFolMx0kJL2zEa4STI7YwpB+ukEWoW5rODZjiLZbqqYLcjDH8k4YwHaMxs103L8eButEQ==",
+      "version": "0.14.39-1",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.39-1.tgz",
+      "integrity": "sha512-TsOZCldbxEOB4Rv5tudYCkPkfHklmOWQgRPoz3wsmJDUpLwljOQFru4J0uCRqKKGLALo1qBBQvzofQi+5dvTzQ==",
       "optional": true
     },
     "@netlify/esbuild-freebsd-arm64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.39.tgz",
-      "integrity": "sha512-A9XZKai+k6kfndCtN6Dh2usT28V0+OGxzFdZsANONPQiEUTrGZCgwcHWiVlVn7SeAwPR1tKZreTnvrfj8cj7hA==",
+      "version": "0.14.39-1",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.39-1.tgz",
+      "integrity": "sha512-wJbKm1eijTiots/RgDOZjbqcZaCVElPjegRit0LkbAQnqfBc2B8F6j7CkUgbWg1hU2+YJFiMGhaRMljN9jpCVQ==",
       "optional": true
     },
     "@netlify/esbuild-linux-32": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-32/-/esbuild-linux-32-0.14.39.tgz",
-      "integrity": "sha512-ZQnqk/82YRvINY+aF+LlGfRZ19c5mH0jaxsO046GpIOPx6PcXHG8JJ2lg+vLJVe4zFPohxzabcYpwFuT4cg/GA==",
+      "version": "0.14.39-1",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-32/-/esbuild-linux-32-0.14.39-1.tgz",
+      "integrity": "sha512-rSCpXot5p3zUpwnC9ttKtP+vWf3gT1CkzJwEBHqqIr0GmgTLoADMaZ1AZqq125DyCvPf2s9f98XtSWaHmIqN8w==",
       "optional": true
     },
     "@netlify/esbuild-linux-64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-64/-/esbuild-linux-64-0.14.39.tgz",
-      "integrity": "sha512-IQtswVw7GAKNX/3yV390wSfSXvMWy0d5cw8csAffwBk9gupftY2lzepK4Cn6uD/aqLt3Iku33FbHop/2nPGfQA==",
+      "version": "0.14.39-1",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-64/-/esbuild-linux-64-0.14.39-1.tgz",
+      "integrity": "sha512-lx+tQR7OW9Sq8WrP+zJ20lpJFHe4jvO56czUjJe7iSYtu0mpbApnJc2p4KqakU4xdjMdlqsUDG6L7GqE4+dNxQ==",
       "optional": true
     },
     "@netlify/esbuild-linux-arm": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-arm/-/esbuild-linux-arm-0.14.39.tgz",
-      "integrity": "sha512-QdOzQniOed0Bz1cTC9TMMwvtAqKayYv66H4edJlbvElC81yJZF/c9XhmYWJ6P5g4nkChZubQ5RcQwTLmrFGexg==",
+      "version": "0.14.39-1",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-arm/-/esbuild-linux-arm-0.14.39-1.tgz",
+      "integrity": "sha512-O2w4oRYNoavKyednlkCnxr7VnfizpWurCxKraRyKQ4XIQbv3bqtgK/VSt1cJMwm+7+BdGNsqux4wAKmwsdW+Zw==",
       "optional": true
     },
     "@netlify/esbuild-linux-arm64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.39.tgz",
-      "integrity": "sha512-4Jie4QV6pWWuGN7TAshNMGbdTA9+VbRkv3rPIxhgK5gBfmsAV1yRKsumE4Y77J0AZNRiOriyoec4zc1qkmI3zg==",
+      "version": "0.14.39-1",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.39-1.tgz",
+      "integrity": "sha512-e1gEB3+1WWsvBNDrPIq43hkUmWx9CkN5DVfcHa9Ar55DY8G9DRl5MyCFVpYVPctoWLRMlt1VRwPuc5YfSTXZbw==",
       "optional": true
     },
     "@netlify/esbuild-linux-mips64le": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.39.tgz",
-      "integrity": "sha512-Htozxr95tw4tSd86YNbCLs1eoYQzNu/cHpzFIkuJoztZueUhl8XpRvBdob7n3kEjW1gitLWAIn8XUwSt+aJ1Tg==",
+      "version": "0.14.39-1",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.39-1.tgz",
+      "integrity": "sha512-SKDBxNiJmTD1HYlmq6GWbz7dBtz1lYg28Y8RLo2Yj/jZtkVzZbMS0sVhB05FAzQhGT+m1bFLSrbLJkfmbzoQXg==",
       "optional": true
     },
     "@netlify/esbuild-linux-ppc64le": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.39.tgz",
-      "integrity": "sha512-tFy0ufWIdjeuk1rPHee00TZlhr9OSF00Ufb4ROFyt2ArKuMSkWRJuDgx6MtZcAnCIN4cybo/xWl3MKTM+scnww==",
+      "version": "0.14.39-1",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.39-1.tgz",
+      "integrity": "sha512-cKIoVrHn6qJf1cTKCaOQvXKpcpSwCShzNkEQNtWCEFvlHJ817lsVaWqQm01qDQ9pGrDbhZRsUAIOkwsjLrKDmA==",
       "optional": true
     },
     "@netlify/esbuild-linux-riscv64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.39.tgz",
-      "integrity": "sha512-ZzfKvwIxL7wQnYbVFpyNW0wotnLoKageUEM57RbjekesJoNQnqUR6Usm+LDZoB8iRsI58VX1IxnstP0cX8vOHw==",
+      "version": "0.14.39-1",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.39-1.tgz",
+      "integrity": "sha512-W6gQyJc52lFoPj0w6AoQCfa8/fmwsC6CrT80JKe+fF4mYwBUnySbRVldMDb/cb6qCqHt5m3X+w7HFS5soPGT5Q==",
       "optional": true
     },
     "@netlify/esbuild-linux-s390x": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.39.tgz",
-      "integrity": "sha512-yjC0mFwnuMRoh0WcF0h71MF71ytZBFEQQTRdgiGT0+gbC4UApBqnTkJdLx32RscBKi9skbMChiJ748hDJou6FA==",
+      "version": "0.14.39-1",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.39-1.tgz",
+      "integrity": "sha512-IN4agxUutc0BbcAMDDVuz60bDKFEGlq+vZlPzeLnketkVs/5BZj1vfoS8hJJelvR/mB99G9YjyOm08EthqoyHw==",
       "optional": true
     },
     "@netlify/esbuild-netbsd-64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.39.tgz",
-      "integrity": "sha512-mIq4znOoz3YfTVdv3sIWfR4Zx5JgMnT4srlhC5KYVHibhxvyDdin5txldYXmR4Zv4dZd6DSuWFsn441aUegHeA==",
+      "version": "0.14.39-1",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.39-1.tgz",
+      "integrity": "sha512-cnvcQ6u7QtjnxFcMYtEUqOYg8wTfLOSoc6nFPhjIE4074Tw/H48LFqFq0v2Gtgvc5neUZtxBF2+6QMX4Q91vwQ==",
       "optional": true
     },
     "@netlify/esbuild-openbsd-64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.39.tgz",
-      "integrity": "sha512-+t6QdzJCngH19hV7ClpFAeFDI2ko/HNcFbiNwaXTMVLB3hWi1sJtn+fzZck5HfzN4qsajAVqZq4nwX69SSt25A==",
+      "version": "0.14.39-1",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.39-1.tgz",
+      "integrity": "sha512-14fDX08hM0rWzUO7uf7Wxg9uL5SK5AqSDe+vXviIL+gWGN2vHoakRbzZoLVHFwoTLT5/1oIUYDJfcmcrFm1rjw==",
       "optional": true
     },
     "@netlify/esbuild-sunos-64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-sunos-64/-/esbuild-sunos-64-0.14.39.tgz",
-      "integrity": "sha512-HLfXG6i2p3wyyyWHeeP4ShGDJ1zRMnf9YLJLe2ezv2KqvcKw/Un/m/FBuDW1p13oSUO7ShISMzgc1dw1GGBEOQ==",
+      "version": "0.14.39-1",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-sunos-64/-/esbuild-sunos-64-0.14.39-1.tgz",
+      "integrity": "sha512-TDUJGI077mAM3qotUfN/DcKaBq3nLeAdNwjsWulKgdC3UwC/iqyrYrnmZipEbiHO2jt4+wRFUz/s/x+HeDiblg==",
       "optional": true
     },
     "@netlify/esbuild-windows-32": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-windows-32/-/esbuild-windows-32-0.14.39.tgz",
-      "integrity": "sha512-ZpSQcKbVSCU3ln7mHpsL/5dWsUqCNdTnC5YAArnaOwdrlIunrsbo5j4MOZRRcGExb2uvTc/rb+D3mlGb8j1rkA==",
+      "version": "0.14.39-1",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-windows-32/-/esbuild-windows-32-0.14.39-1.tgz",
+      "integrity": "sha512-Jyf5OUm+Guo7+SoIURTfmzqri10xj18qdgxwy3NNsQG/Eg1XLETDORWH0cKy6YTiRDuqeCsZeXDoAQABOs30gQ==",
       "optional": true
     },
     "@netlify/esbuild-windows-64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-windows-64/-/esbuild-windows-64-0.14.39.tgz",
-      "integrity": "sha512-I3gCdO8+6IDhT4Y1ZmV4o2Gg0oELv7N4kCcE4kqclz10fWHNjf19HQNHyBJe0AWnFV5ZfT154VVD31dqgwpgFw==",
+      "version": "0.14.39-1",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-windows-64/-/esbuild-windows-64-0.14.39-1.tgz",
+      "integrity": "sha512-D41xhwJN90qeLebZrb853zhGJahIlCf+HPKwxVZx+Nk8BNV09jQyJ2GYqmmwRxNOrbzqD80+pgvoYkq4a4OV0g==",
       "optional": true
     },
     "@netlify/esbuild-windows-arm64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.39.tgz",
-      "integrity": "sha512-WX52W8U1lsfWcz6NWoSpDs57lgiiMHN23seq8G2bvxzGS/tvYD3dxVLLW5UPoKSnFDyVQT7b6Zkt6AkBten1yQ==",
+      "version": "0.14.39-1",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.39-1.tgz",
+      "integrity": "sha512-EGzYwc+MoKhWnz+6iUbXQKcQKV8FbPovDJkmY9YWGkgSwZALPo4DpjSaMLW6hv42YRyoBRM1NP/v/qmVtgeJjQ==",
       "optional": true
     },
     "@netlify/eslint-config-node": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@babel/parser": "^7.22.5",
     "@netlify/binary-info": "^1.0.0",
-    "@netlify/esbuild": "0.14.39",
+    "@netlify/esbuild": "0.14.39-1",
     "@netlify/serverless-functions-api": "^1.6.0",
     "@vercel/nft": "^0.23.0",
     "archiver": "^5.3.0",


### PR DESCRIPTION
Updates @netlify/esbuild to an updated version of our fork, where something in the installation script was fixed. Because the new version has the same semver version, Renovate won't pick this up - that's why you see me opening this PR manually.