### PR TITLE
fix: tighten up V2 API detection mechanism

### DIFF
--- a/src/runtimes/node/in_source_config/index.ts
+++ b/src/runtimes/node/in_source_config/index.ts
@@ -153,7 +153,9 @@ export type ISCExportWithCallExpression = {
 }
 export type ISCExportWithArrowFunctionExpression = { type: 'arrow-function-expression' }
 export type ISCExportWithFunctionExpression = { type: 'function-expression' }
+export type ISCExportOther = { type: 'other' }
 export type ISCExport =
   | ISCExportWithArrowFunctionExpression
   | ISCExportWithCallExpression
   | ISCExportWithFunctionExpression
+  | ISCExportOther

--- a/src/runtimes/node/in_source_config/index.ts
+++ b/src/runtimes/node/in_source_config/index.ts
@@ -97,7 +97,12 @@ export const findISCDeclarations = (
   }
 
   const iscExports = handlerExports
-    .map(({ args, local: exportName }) => {
+    .map((exp) => {
+      if (exp.type !== 'call-expression') {
+        return null
+      }
+
+      const { args, local: exportName } = exp
       const matchingImport = imports.find(({ local: importName }) => importName === exportName)
 
       if (matchingImport === undefined) {
@@ -141,7 +146,14 @@ export const findISCDeclarations = (
 
 export type ISCHandlerArg = ArgumentPlaceholder | Expression | SpreadElement | JSXNamespacedName
 
-export interface ISCExport {
-  local: string
+export type ISCExportWithCallExpression = {
+  type: 'call-expression'
   args: ISCHandlerArg[]
+  local: string
 }
+export type ISCExportWithArrowFunctionExpression = { type: 'arrow-function-expression' }
+export type ISCExportWithFunctionExpression = { type: 'function-expression' }
+export type ISCExport =
+  | ISCExportWithArrowFunctionExpression
+  | ISCExportWithCallExpression
+  | ISCExportWithFunctionExpression

--- a/src/runtimes/node/parser/exports.ts
+++ b/src/runtimes/node/parser/exports.ts
@@ -203,6 +203,10 @@ const getExportsFromExpression = (node: Expression | undefined | null): ISCExpor
     }
 
     default: {
+      if (node !== undefined) {
+        return [{ type: 'other' }]
+      }
+
       return []
     }
   }

--- a/src/runtimes/node/parser/exports.ts
+++ b/src/runtimes/node/parser/exports.ts
@@ -182,20 +182,28 @@ const getExportsFromBindings = (specifiers: ExportNamedDeclaration['specifiers']
   return exports
 }
 
-const getExportsFromExpression = (node: Expression | undefined | null) => {
-  // We're only interested in expressions representing function calls, because
-  // the ISC patterns we implement at the moment are all helper functions.
-  if (node?.type !== 'CallExpression') {
-    return []
+const getExportsFromExpression = (node: Expression | undefined | null): ISCExport[] => {
+  switch (node?.type) {
+    case 'ArrowFunctionExpression': {
+      return [{ type: 'arrow-function-expression' as const }]
+    }
+
+    case 'CallExpression': {
+      const { arguments: args, callee } = node
+
+      if (callee.type !== 'Identifier') {
+        return []
+      }
+
+      return [{ args, local: callee.name, type: 'call-expression' as const }]
+    }
+
+    case 'FunctionExpression': {
+      return [{ type: 'function-expression' as const }]
+    }
+
+    default: {
+      return []
+    }
   }
-
-  const { arguments: args, callee } = node
-
-  if (callee.type !== 'Identifier') {
-    return []
-  }
-
-  const exports = [{ local: callee.name, args }]
-
-  return exports
 }

--- a/tests/unit/runtimes/node/in_source_config.test.ts
+++ b/tests/unit/runtimes/node/in_source_config.test.ts
@@ -100,76 +100,90 @@ describe('V2 API', () => {
     logger: getLogger(),
   }
 
-  test('ESM file with a default export and no `handler` export', () => {
-    const source = `export default async () => {
-      return new Response("Hello!")
-    }`
+  describe('Detects the correct runtime version', () => {
+    test('ESM file with a default export and no `handler` export', () => {
+      const source = `export default async () => {
+        return new Response("Hello!")
+      }`
 
-    const systemLog = vi.fn()
+      const systemLog = vi.fn()
 
-    const isc = findISCDeclarations(source, { ...options, logger: getLogger(systemLog) })
+      const isc = findISCDeclarations(source, { ...options, logger: getLogger(systemLog) })
 
-    expect(systemLog).toHaveBeenCalledOnce()
-    expect(systemLog).toHaveBeenCalledWith('detected v2 function')
-    expect(isc).toEqual({ routes: [], runtimeAPIVersion: 2 })
+      expect(systemLog).toHaveBeenCalledOnce()
+      expect(systemLog).toHaveBeenCalledWith('detected v2 function')
+      expect(isc).toEqual({ routes: [], runtimeAPIVersion: 2 })
+    })
+
+    test('ESM file with a default export and a `handler` export', () => {
+      const source = `export default async () => {
+        return new Response("Hello!")
+      }
+  
+      export const handler = function () { return { statusCode: 200, body: "Hello!" } }`
+
+      const isc = findISCDeclarations(source, options)
+
+      expect(isc).toEqual({ runtimeAPIVersion: 1 })
+    })
+
+    test('ESM file with no default export and a `handler` export', () => {
+      const source = `const handler = async () => ({ statusCode: 200, body: "Hello" })
+      
+      export { handler }`
+
+      const isc = findISCDeclarations(source, options)
+
+      expect(isc).toEqual({ runtimeAPIVersion: 1 })
+    })
+
+    test('TypeScript file with a default export and no `handler` export', () => {
+      const source = `export default async (req: Request) => {
+        return new Response("Hello!")
+      }`
+
+      const isc = findISCDeclarations(source, options)
+
+      expect(isc).toEqual({ routes: [], runtimeAPIVersion: 2 })
+    })
+
+    test('CommonJS file with a default export and a `handler` export', () => {
+      const source = `exports.default = async () => {
+        return new Response("Hello!")
+      }
+  
+      exports.handler = async () => ({ statusCode: 200, body: "Hello!" })`
+
+      const isc = findISCDeclarations(source, options)
+
+      expect(isc).toEqual({ runtimeAPIVersion: 1 })
+    })
+
+    test('CommonJS file with a default export and no `handler` export', () => {
+      const source = `exports.default = async () => {
+        return new Response("Hello!")
+      }`
+
+      const isc = findISCDeclarations(source, options)
+
+      expect(isc).toEqual({ runtimeAPIVersion: 1 })
+    })
   })
 
-  test('ESM file with a default export and a `handler` export', () => {
-    const source = `export default async () => {
-      return new Response("Hello!")
-    }
+  describe('`scheduled` property', () => {
+    test('Using a cron expression string', () => {
+      const source = `export default async () => {
+        return new Response("Hello!")
+      }
+  
+      export const config = {
+        schedule: "@daily"
+      }`
 
-    export const handler = async () => ({ statusCode: 200, body: "Hello!" })`
+      const isc = findISCDeclarations(source, options)
 
-    const isc = findISCDeclarations(source, options)
-
-    expect(isc).toEqual({ routes: [], runtimeAPIVersion: 2 })
-  })
-
-  test('TypeScript file with a default export and no `handler` export', () => {
-    const source = `export default async (req: Request) => {
-      return new Response("Hello!")
-    }`
-
-    const isc = findISCDeclarations(source, options)
-
-    expect(isc).toEqual({ routes: [], runtimeAPIVersion: 2 })
-  })
-
-  test('CommonJS file with a default export and a `handler` export', () => {
-    const source = `exports.default = async () => {
-      return new Response("Hello!")
-    }
-
-    exports.handler = async () => ({ statusCode: 200, body: "Hello!" })`
-
-    const isc = findISCDeclarations(source, options)
-
-    expect(isc).toEqual({ runtimeAPIVersion: 1 })
-  })
-
-  test('CommonJS file with a default export and no `handler` export', () => {
-    const source = `exports.default = async () => {
-      return new Response("Hello!")
-    }`
-
-    const isc = findISCDeclarations(source, options)
-
-    expect(isc).toEqual({ runtimeAPIVersion: 1 })
-  })
-
-  test('Config object with `schedule` property', () => {
-    const source = `export default async () => {
-      return new Response("Hello!")
-    }
-
-    export const config = {
-      schedule: "@daily"
-    }`
-
-    const isc = findISCDeclarations(source, options)
-
-    expect(isc).toEqual({ routes: [], runtimeAPIVersion: 2, schedule: '@daily' })
+      expect(isc).toEqual({ routes: [], runtimeAPIVersion: 2, schedule: '@daily' })
+    })
   })
 
   describe('`path` property', () => {


### PR DESCRIPTION
#### Summary

This is a small tweak to the V2 API detection mechanism. To make sure we reduce false positives during the initial phase of the rollout, we should adopt the V1 API as long as the entry file has a `handler` export.

This was always the intention as shown by [this check](https://github.com/netlify/zip-it-and-ship-it/blob/e7ac14fb5b8a7745fe59bbc370d7ae4faf296b28/src/runtimes/node/in_source_config/index.ts#L82), but the `handlerExports` is a bit misleading. Right now, it's only finding exports that are function calls, because of [this](https://github.com/netlify/zip-it-and-ship-it/blob/e7ac14fb5b8a7745fe59bbc370d7ae4faf296b28/src/runtimes/node/parser/exports.ts#L186-L190).

With this PR we start capturing all exports and categorising them based on their type.