### PR TITLE
fix: write `methods` into manifest.json

### DIFF
--- a/src/runtimes/node/in_source_config/index.ts
+++ b/src/runtimes/node/in_source_config/index.ts
@@ -108,7 +108,6 @@ export const findISCDeclarations = (
 
   if (featureFlags.zisi_functions_api_v2 && isV2API) {
     const config: ISCValues = {
-      routes: getRoutesFromPath(configExport.path, functionName),
       runtimeAPIVersion: 2,
     }
 
@@ -121,6 +120,8 @@ export const findISCDeclarations = (
     if (configExport.method !== undefined) {
       config.methods = normalizeMethods(configExport.method, functionName)
     }
+
+    config.routes = getRoutesFromPath(configExport.path, functionName, config.methods ?? [])
 
     return config
   }

--- a/src/utils/routes.ts
+++ b/src/utils/routes.ts
@@ -3,7 +3,7 @@ import { RUNTIME } from '../runtimes/runtime.js'
 import { FunctionBundlingUserError } from './error.js'
 import { ExtendedURLPattern } from './urlpattern.js'
 
-export type Route = { pattern: string } & ({ literal: string } | { expression: string })
+export type Route = { pattern: string; methods: string[] } & ({ literal: string } | { expression: string })
 
 // Based on https://developer.mozilla.org/en-US/docs/Web/API/URL_Pattern_API.
 const isExpression = (part: string) =>
@@ -17,7 +17,7 @@ const isPathLiteral = (path: string) => {
   return parts.every((part) => !isExpression(part))
 }
 
-export const getRoutesFromPath = (path: unknown, functionName: string): Route[] => {
+export const getRoutesFromPath = (path: unknown, functionName: string, methods: string[]): Route[] => {
   if (!path) {
     return []
   }
@@ -37,7 +37,7 @@ export const getRoutesFromPath = (path: unknown, functionName: string): Route[] 
   }
 
   if (isPathLiteral(path)) {
-    return [{ pattern: path, literal: path }]
+    return [{ pattern: path, literal: path, methods }]
   }
 
   try {
@@ -52,7 +52,7 @@ export const getRoutesFromPath = (path: unknown, functionName: string): Route[] 
     // for both `/foo` and `/foo/`.
     const normalizedRegex = `^${regex}\\/?$`
 
-    return [{ pattern: path, expression: normalizedRegex }]
+    return [{ pattern: path, expression: normalizedRegex, methods }]
   } catch {
     throw new FunctionBundlingUserError(`'${path}' is not a valid path according to the URLPattern specification`, {
       functionName,

--- a/tests/fixtures-esm/v2-api-with-path/with-literal.mjs
+++ b/tests/fixtures-esm/v2-api-with-path/with-literal.mjs
@@ -7,4 +7,5 @@ export default async () =>
 
 export const config = {
   path: '/products',
+  method: ['GET', 'POST'],
 }

--- a/tests/unit/runtimes/node/in_source_config.test.ts
+++ b/tests/unit/runtimes/node/in_source_config.test.ts
@@ -298,7 +298,7 @@ describe('V2 API', () => {
 
       const { routes } = findISCDeclarations(source, options)
 
-      expect(routes).toEqual([{ pattern: '/products', literal: '/products' }])
+      expect(routes).toEqual([{ pattern: '/products', literal: '/products', methods: [] }])
     })
 
     test('Using a pattern with named groupd', () => {
@@ -316,6 +316,7 @@ describe('V2 API', () => {
         {
           pattern: '/store/:category/products/:product-id',
           expression: '^\\/store(?:\\/([^\\/]+?))\\/products(?:\\/([^\\/]+?))-id\\/?$',
+          methods: [],
         },
       ])
     })

--- a/tests/v2api.test.ts
+++ b/tests/v2api.test.ts
@@ -6,8 +6,8 @@ import { promisify } from 'util'
 import merge from 'deepmerge'
 import glob from 'glob'
 import semver from 'semver'
+import { dir as getTmpDir } from 'tmp-promise'
 import { afterEach, describe, expect, test, vi } from 'vitest'
-import { dir as getTmpDir, tmpName } from 'tmp-promise'
 
 import { ARCHIVE_FORMAT } from '../src/archive.js'
 

--- a/tests/v2api.test.ts
+++ b/tests/v2api.test.ts
@@ -1,3 +1,5 @@
+import { readFile } from 'fs/promises'
+import { join } from 'path'
 import { version as nodeVersion } from 'process'
 import { promisify } from 'util'
 
@@ -5,6 +7,7 @@ import merge from 'deepmerge'
 import glob from 'glob'
 import semver from 'semver'
 import { afterEach, describe, expect, test, vi } from 'vitest'
+import { dir as getTmpDir, tmpName } from 'tmp-promise'
 
 import { ARCHIVE_FORMAT } from '../src/archive.js'
 
@@ -214,15 +217,19 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
   })
 
   test('Extracts routes from the `path` in-source configuration property', async () => {
+    const { path: tmpDir } = await getTmpDir({ prefix: 'zip-it-test' })
+    const manifestPath = join(tmpDir, 'manifest.json')
+
     const { files } = await zipFixture('v2-api-with-path', {
       fixtureDir: FIXTURES_ESM_DIR,
       length: 3,
       opts: {
         featureFlags: { zisi_functions_api_v2: true },
+        manifest: manifestPath,
       },
     })
 
-    expect.assertions(files.length)
+    expect.assertions(files.length + 1)
 
     for (const file of files) {
       switch (file.name) {
@@ -257,6 +264,10 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
           continue
       }
     }
+
+    const manifestString = await readFile(manifestPath, { encoding: 'utf8' })
+    const manifest = JSON.parse(manifestString)
+    expect(manifest.functions[0].routes[0].methods).toEqual(['GET', 'POST'])
   })
 
   test('Flags invalid values of the `path` in-source configuration property as user errors', async () => {

--- a/tests/v2api.test.ts
+++ b/tests/v2api.test.ts
@@ -227,7 +227,7 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
     for (const file of files) {
       switch (file.name) {
         case 'with-literal':
-          expect(file.routes).toEqual([{ pattern: '/products', literal: '/products' }])
+          expect(file.routes).toEqual([{ pattern: '/products', literal: '/products', methods: ['GET', 'POST'] }])
 
           break
 
@@ -236,6 +236,7 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
             {
               pattern: '/products/:id',
               expression: '^\\/products(?:\\/([^\\/]+?))\\/?$',
+              methods: [],
             },
           ])
 
@@ -246,6 +247,7 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
             {
               pattern: '/numbers/(\\d+)',
               expression: '^\\/numbers(?:\\/(\\d+))\\/?$',
+              methods: [],
             },
           ])
 


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Follow-up to https://github.com/netlify/zip-it-and-ship-it/pull/1539 - I forgot to write `methods` into the manifest file!

This PR fixes that.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/zip-it-and-ship-it/issues/new/choose) before writing your code 🧑‍💻.
      This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing
      a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
