### PR TITLE
fix: don't warn on unnegated patterns

### DIFF
--- a/src/runtimes/node/bundlers/esbuild/bundler.ts
+++ b/src/runtimes/node/bundlers/esbuild/bundler.ts
@@ -38,6 +38,9 @@ const includedFilesToEsbuildExternals = (
   functionName: string,
 ) =>
   includedFiles
+    // only keep negated patterns
+    .filter((pattern) => pattern.startsWith('!'))
+    // warn about invalid patterns
     .filter((pattern) => {
       const containsMultipleStars = pattern.indexOf('*') !== pattern.lastIndexOf('*')
 
@@ -59,8 +62,6 @@ const includedFilesToEsbuildExternals = (
 
       return true
     })
-    // only keep negated patterns
-    .filter((pattern) => pattern.startsWith('!'))
     // remove the !
     .map((pattern) => pattern.slice(1))
     // esbuild expects a relative path for local files

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -1633,7 +1633,7 @@ describe('zip-it-and-ship-it', () => {
     await zipNode(fixtureName, {
       opts: {
         basePath: join(FIXTURES_DIR, fixtureName),
-        config: { '*': { includedFiles: ['!lang/**/en.*'], nodeBundler: NODE_BUNDLER.ESBUILD } },
+        config: { '*': { includedFiles: ['lang/**/de.*', '!lang/**/en.*'], nodeBundler: NODE_BUNDLER.ESBUILD } },
       },
     })
 


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Follow-up to #1546. The warning triggered on unnegated patterns, which was incorrect. This PR fixes that.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/zip-it-and-ship-it/issues/new/choose) before writing your code 🧑‍💻.
      This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing
      a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
