### PR TITLE
fix: remove zisi_functions_api_v2 flag

### DIFF
--- a/src/feature_flags.ts
+++ b/src/feature_flags.ts
@@ -24,9 +24,6 @@ export const defaultFlags = {
   // Output CJS file extension.
   zisi_output_cjs_extension: false,
 
-  // Inject the compatibility layer required for the v2 runtime API to work.
-  zisi_functions_api_v2: false,
-
   // Create unique entry file instead of a file that is based on the function name.
   zisi_unique_entry_file: false,
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,7 +45,7 @@ interface AugmentedFunctionSource extends FunctionSource {
   inSourceConfig?: ISCValues
 }
 
-const augmentWithISC = async (func: FunctionSource, featureFlags: FeatureFlags): Promise<AugmentedFunctionSource> => {
+const augmentWithISC = async (func: FunctionSource): Promise<AugmentedFunctionSource> => {
   // ISC is currently only supported in JavaScript and TypeScript functions
   // and only supports scheduled functions.
   if (func.runtime.name !== RUNTIME.JAVASCRIPT) {
@@ -54,7 +54,6 @@ const augmentWithISC = async (func: FunctionSource, featureFlags: FeatureFlags):
 
   const inSourceConfig = await findISCDeclarationsInPath(func.mainFile, {
     functionName: func.name,
-    featureFlags,
     logger: getLogger(),
   })
 
@@ -77,9 +76,7 @@ export const listFunctions = async function (
   const cache = new RuntimeCache()
   const functionsMap = await getFunctionsFromPaths(paths, { cache, config, configFileDirectories, featureFlags })
   const functions = [...functionsMap.values()]
-  const augmentedFunctions = parseISC
-    ? await Promise.all(functions.map((func) => augmentWithISC(func, featureFlags)))
-    : functions
+  const augmentedFunctions = parseISC ? await Promise.all(functions.map((func) => augmentWithISC(func))) : functions
 
   return augmentedFunctions.map(getListedFunction)
 }
@@ -102,7 +99,7 @@ export const listFunction = async function (
     return
   }
 
-  const augmentedFunction = parseISC ? await augmentWithISC(func, featureFlags) : func
+  const augmentedFunction = parseISC ? await augmentWithISC(func) : func
 
   return getListedFunction(augmentedFunction)
 }
@@ -124,9 +121,7 @@ export const listFunctionsFiles = async function (
   const cache = new RuntimeCache()
   const functionsMap = await getFunctionsFromPaths(paths, { cache, config, configFileDirectories, featureFlags })
   const functions = [...functionsMap.values()]
-  const augmentedFunctions = parseISC
-    ? await Promise.all(functions.map((func) => augmentWithISC(func, featureFlags)))
-    : functions
+  const augmentedFunctions = parseISC ? await Promise.all(functions.map((func) => augmentWithISC(func))) : functions
   const listedFunctionsFiles = await Promise.all(
     augmentedFunctions.map((func) => getListedFunctionFiles(func, { basePath, featureFlags })),
   )

--- a/src/runtimes/node/in_source_config/index.ts
+++ b/src/runtimes/node/in_source_config/index.ts
@@ -1,6 +1,5 @@
 import type { ArgumentPlaceholder, Expression, SpreadElement, JSXNamespacedName } from '@babel/types'
 
-import type { FeatureFlags } from '../../../feature_flags.js'
 import { InvocationMode, INVOCATION_MODE } from '../../../function.js'
 import { FunctionBundlingUserError } from '../../../utils/error.js'
 import { Logger } from '../../../utils/logger.js'
@@ -27,7 +26,6 @@ export type ISCValues = {
 
 interface FindISCDeclarationsOptions {
   functionName: string
-  featureFlags: FeatureFlags
   logger: Logger
 }
 
@@ -52,7 +50,7 @@ const validateScheduleFunction = (functionFound: boolean, scheduleFound: boolean
 // the property and `data` its value.
 export const findISCDeclarationsInPath = async (
   sourcePath: string,
-  { functionName, featureFlags, logger }: FindISCDeclarationsOptions,
+  { functionName, logger }: FindISCDeclarationsOptions,
 ): Promise<ISCValues> => {
   const source = await safelyReadSource(sourcePath)
 
@@ -60,7 +58,7 @@ export const findISCDeclarationsInPath = async (
     return {}
   }
 
-  return findISCDeclarations(source, { functionName, featureFlags, logger })
+  return findISCDeclarations(source, { functionName, logger })
 }
 
 /**
@@ -88,7 +86,7 @@ const normalizeMethods = (input: unknown, name: string): string[] | undefined =>
 
 export const findISCDeclarations = (
   source: string,
-  { functionName, featureFlags, logger }: FindISCDeclarationsOptions,
+  { functionName, logger }: FindISCDeclarationsOptions,
 ): ISCValues => {
   const ast = safelyParseSource(source)
 
@@ -106,7 +104,7 @@ export const findISCDeclarations = (
   const { configExport, defaultExport, handlerExports } = getExports(ast.body, getAllBindings)
   const isV2API = handlerExports.length === 0 && defaultExport !== undefined
 
-  if (featureFlags.zisi_functions_api_v2 && isV2API) {
+  if (isV2API) {
     const config: ISCValues = {
       runtimeAPIVersion: 2,
     }

--- a/src/runtimes/node/index.ts
+++ b/src/runtimes/node/index.ts
@@ -60,7 +60,7 @@ const zipFunction: ZipFunction = async function ({
     return { config, path: destPath, entryFilename: '' }
   }
 
-  const inSourceConfig = await findISCDeclarationsInPath(mainFile, { functionName: name, featureFlags, logger })
+  const inSourceConfig = await findISCDeclarationsInPath(mainFile, { functionName: name, logger })
   const runtimeAPIVersion = inSourceConfig.runtimeAPIVersion === 2 ? 2 : 1
 
   const pluginsModulesPath = await getPluginsModulesPath(srcDir)

--- a/tests/list_function.test.ts
+++ b/tests/list_function.test.ts
@@ -64,9 +64,6 @@ describe('listFunction', () => {
     test('listFunction does not include runtimeAPIVersion when parseISC false', async () => {
       const mainFile = join(FIXTURES_ESM_DIR, 'v2-api/function.js')
       const func = await listFunction(mainFile, {
-        featureFlags: {
-          zisi_functions_api_v2: true,
-        },
         parseISC: false,
       })
 
@@ -76,9 +73,6 @@ describe('listFunction', () => {
     test('listFunction includes runtimeAPIVersion when parseISC true', async () => {
       const mainFile = join(FIXTURES_ESM_DIR, 'v2-api/function.js')
       const func = await listFunction(mainFile, {
-        featureFlags: {
-          zisi_functions_api_v2: true,
-        },
         parseISC: true,
       })
 

--- a/tests/list_functions.test.ts
+++ b/tests/list_functions.test.ts
@@ -81,9 +81,6 @@ describe('listFunctions', () => {
     test('listFunctions does not include runtimeAPIVersion when parseISC is false', async () => {
       const dir = join(FIXTURES_ESM_DIR, 'v2-api')
       const [func] = await listFunctions([dir], {
-        featureFlags: {
-          zisi_functions_api_v2: true,
-        },
         parseISC: false,
       })
 
@@ -93,9 +90,6 @@ describe('listFunctions', () => {
     test('listFunctions includes runtimeAPIVersion when parseISC is true', async () => {
       const dir = join(FIXTURES_ESM_DIR, 'v2-api')
       const [func] = await listFunctions([dir], {
-        featureFlags: {
-          zisi_functions_api_v2: true,
-        },
         parseISC: true,
       })
 

--- a/tests/unit/runtimes/node/in_source_config.test.ts
+++ b/tests/unit/runtimes/node/in_source_config.test.ts
@@ -118,9 +118,6 @@ describe('`stream` helper', () => {
 describe('V2 API', () => {
   const options = {
     functionName: 'func1',
-    featureFlags: {
-      zisi_functions_api_v2: true,
-    },
     logger: getLogger(),
   }
 

--- a/tests/v2api.test.ts
+++ b/tests/v2api.test.ts
@@ -30,9 +30,7 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
     async (options) => {
       const { files } = await zipFixture('v2-api', {
         fixtureDir: FIXTURES_ESM_DIR,
-        opts: merge(options, {
-          featureFlags: { zisi_functions_api_v2: true },
-        }),
+        opts: options,
       })
 
       for (const entry of files) {
@@ -58,9 +56,7 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
     async (options) => {
       const { files } = await zipFixture('v2-api-mjs', {
         fixtureDir: FIXTURES_ESM_DIR,
-        opts: merge(options, {
-          featureFlags: { zisi_functions_api_v2: true },
-        }),
+        opts: options,
       })
 
       for (const entry of files) {
@@ -88,7 +84,6 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
         fixtureDir: FIXTURES_ESM_DIR,
         opts: merge(options, {
           archiveFormat: ARCHIVE_FORMAT.NONE,
-          featureFlags: { zisi_functions_api_v2: true },
         }),
       })
 
@@ -116,7 +111,6 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
         fixtureDir: FIXTURES_ESM_DIR,
         opts: merge(options, {
           archiveFormat: ARCHIVE_FORMAT.NONE,
-          featureFlags: { zisi_functions_api_v2: true },
         }),
       })
 
@@ -144,7 +138,6 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
     const { files } = await zipFixture('v2-api-mjs', {
       fixtureDir: FIXTURES_ESM_DIR,
       opts: {
-        featureFlags: { zisi_functions_api_v2: true },
         config: {
           '*': {
             nodeVersion: '16.0.0',
@@ -160,7 +153,6 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
     const { files } = await zipFixture('v2-api-mjs', {
       fixtureDir: FIXTURES_ESM_DIR,
       opts: {
-        featureFlags: { zisi_functions_api_v2: true },
         config: {
           '*': {
             nodeVersion: 'invalid',
@@ -176,7 +168,6 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
     const { files } = await zipFixture('v2-api-mjs', {
       fixtureDir: FIXTURES_ESM_DIR,
       opts: {
-        featureFlags: { zisi_functions_api_v2: true },
         config: {
           '*': {
             nodeVersion: '19.0.0',
@@ -194,7 +185,6 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
     await zipFixture('v2-api', {
       fixtureDir: FIXTURES_ESM_DIR,
       opts: {
-        featureFlags: { zisi_functions_api_v2: true },
         systemLog,
       },
     })
@@ -208,7 +198,6 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
 
     await zipFixture('simple', {
       opts: {
-        featureFlags: { zisi_functions_api_v2: true },
         systemLog,
       },
     })
@@ -224,7 +213,6 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
       fixtureDir: FIXTURES_ESM_DIR,
       length: 3,
       opts: {
-        featureFlags: { zisi_functions_api_v2: true },
         manifest: manifestPath,
       },
     })
@@ -276,9 +264,6 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
     try {
       await zipFixture('v2-api-with-invalid-path', {
         fixtureDir: FIXTURES_ESM_DIR,
-        opts: {
-          featureFlags: { zisi_functions_api_v2: true },
-        },
       })
     } catch (error) {
       const { customErrorInfo } = error

--- a/tests/zip_function.test.ts
+++ b/tests/zip_function.test.ts
@@ -171,7 +171,6 @@ describe('zipFunction', () => {
       const mainFile = join(FIXTURES_ESM_DIR, 'v2-api', 'function.js')
       const result = (await zipFunction(mainFile, tmpDir, {
         ...options,
-        featureFlags: { zisi_functions_api_v2: true },
       }))!
 
       expect(result).not.toBeUndefined()
@@ -195,7 +194,6 @@ describe('zipFunction', () => {
       const systemLog = vi.fn()
 
       await zipFunction(mainFile, tmpDir, {
-        featureFlags: { zisi_functions_api_v2: true },
         systemLog,
       })
 
@@ -209,7 +207,6 @@ describe('zipFunction', () => {
       const systemLog = vi.fn()
 
       await zipFunction(mainFile, tmpDir, {
-        featureFlags: { zisi_functions_api_v2: true },
         systemLog,
       })
 


### PR DESCRIPTION
This flag has been rolled out for a while now, without any problems. Let's remove it, so the functionality becomes available in the CLI as well.

Part of https://github.com/netlify/pod-dev-foundations/issues/578.