### PR TITLE
fix: remove functions_inherit_build_nodejs_version flag

### DIFF
--- a/src/feature_flags.ts
+++ b/src/feature_flags.ts
@@ -10,9 +10,6 @@ export const defaultFlags = {
   // Use NFT as the default bundler.
   traceWithNft: false,
 
-  // Should Lambda functions inherit the build Node.js version
-  functions_inherit_build_nodejs_version: false,
-
   // Output pure (i.e. untranspiled) ESM files when the function file has ESM
   // syntax and the parent `package.json` file has `{"type": "module"}`.
   zisi_pure_esm: false,

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -2,7 +2,6 @@ import { promises as fs } from 'fs'
 import { resolve } from 'path'
 import { arch, platform } from 'process'
 
-import type { FeatureFlags } from './feature_flags.js'
 import type { InvocationMode } from './function.js'
 import type { FunctionResult } from './utils/format_result.js'
 import type { Route } from './utils/routes.js'
@@ -33,16 +32,8 @@ export interface Manifest {
 
 const MANIFEST_VERSION = 1
 
-export const createManifest = async ({
-  featureFlags,
-  functions,
-  path,
-}: {
-  featureFlags: FeatureFlags
-  functions: FunctionResult[]
-  path: string
-}) => {
-  const formattedFunctions = functions.map((func) => formatFunctionForManifest(func, featureFlags))
+export const createManifest = async ({ functions, path }: { functions: FunctionResult[]; path: string }) => {
+  const formattedFunctions = functions.map((func) => formatFunctionForManifest(func))
   const payload: Manifest = {
     functions: formattedFunctions,
     system: { arch, platform },
@@ -53,22 +44,19 @@ export const createManifest = async ({
   await fs.writeFile(path, JSON.stringify(payload))
 }
 
-const formatFunctionForManifest = (
-  {
-    bundler,
-    displayName,
-    generator,
-    invocationMode,
-    mainFile,
-    name,
-    path,
-    routes,
-    runtime,
-    runtimeVersion,
-    schedule,
-  }: FunctionResult,
-  featureFlags: FeatureFlags,
-): ManifestFunction => {
+const formatFunctionForManifest = ({
+  bundler,
+  displayName,
+  generator,
+  invocationMode,
+  mainFile,
+  name,
+  path,
+  routes,
+  runtime,
+  runtimeVersion,
+  schedule,
+}: FunctionResult): ManifestFunction => {
   const manifestFunction: ManifestFunction = {
     bundler,
     displayName,
@@ -76,7 +64,7 @@ const formatFunctionForManifest = (
     invocationMode,
     mainFile,
     name,
-    runtimeVersion: featureFlags.functions_inherit_build_nodejs_version ? runtimeVersion : undefined,
+    runtimeVersion,
     path: resolve(path),
     runtime,
     schedule,

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -126,7 +126,7 @@ export const zipFunctions = async function (
   )
 
   if (manifest !== undefined) {
-    await createManifest({ featureFlags, functions: formattedResults, path: resolve(manifest) })
+    await createManifest({ functions: formattedResults, path: resolve(manifest) })
   }
 
   return formattedResults


### PR DESCRIPTION
The flag has been rolled out fully for a while, let's remove it.