### PR TITLE
feat: set `invocationMode` in background functions

### DIFF
--- a/src/function.ts
+++ b/src/function.ts
@@ -5,6 +5,7 @@ import type { Runtime, ZipFunctionResult } from './runtimes/runtime.js'
 import { ObjectValues } from './types/utils.js'
 
 export const INVOCATION_MODE = {
+  Background: 'background',
   Buffer: 'buffer',
   Stream: 'stream',
 } as const

--- a/src/runtimes/node/index.ts
+++ b/src/runtimes/node/index.ts
@@ -134,6 +134,11 @@ const zipFunction: ZipFunction = async function ({
     invocationMode = INVOCATION_MODE.Stream
   }
 
+  // If this is a background function, set the right `invocationMode` value.
+  if (name.endsWith('-background')) {
+    invocationMode = INVOCATION_MODE.Background
+  }
+
   return {
     bundler: bundlerName,
     bundlerWarnings,

--- a/tests/fixtures/background/func1-background.js
+++ b/tests/fixtures/background/func1-background.js
@@ -1,0 +1,3 @@
+module.exports.handler = async () => ({
+  statusCode: 202
+})

--- a/tests/fixtures/background/func2-background/func2-background.js
+++ b/tests/fixtures/background/func2-background/func2-background.js
@@ -1,0 +1,3 @@
+module.exports.handler = async () => ({
+  statusCode: 202
+})

--- a/tests/fixtures/background/func3-background/index.js
+++ b/tests/fixtures/background/func3-background/index.js
@@ -1,0 +1,3 @@
+module.exports.handler = async () => ({
+  statusCode: 202
+})

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -2280,6 +2280,21 @@ describe('zip-it-and-ship-it', () => {
   )
 
   testMany(
+    'Sets `invocationMode: "background"` on functions with a `-background` suffix in the filename',
+    [...allBundleConfigs, 'bundler_none'],
+    async (options) => {
+      const { files } = await zipFixture('background', {
+        opts: options,
+        length: 3,
+      })
+
+      files.forEach((result) => {
+        expect(result.invocationMode).toBe('background')
+      })
+    },
+  )
+
+  testMany(
     'Throws error when `schedule` helper is used but cron expression not found',
     [...allBundleConfigs, 'bundler_none'],
     async (options) => {


### PR DESCRIPTION
#### Summary

To support background functions with custom paths, we need to explicitly set `invocationMode: "background"` in the manifest.

Part of https://github.com/netlify/pod-dev-foundations/issues/578.