### PR TITLE
fix: make empty-import-meta warning more actionable

### DIFF
--- a/src/runtimes/node/bundlers/esbuild/bundler.ts
+++ b/src/runtimes/node/bundlers/esbuild/bundler.ts
@@ -207,6 +207,17 @@ var __glob = (map) => (path) => {
     const cleanTempFiles = getCleanupFunction([...bundlePaths.keys()])
     const additionalPaths = includedFilesFromModuleDetection
 
+    const updatedWarnings = warnings.map((warning) => {
+      if (warning.id === 'empty-import-meta') {
+        return {
+          ...warning,
+          text: `"import.meta" is not available and will be empty, use __dirname instead`,
+        }
+      }
+
+      return warning
+    })
+
     return {
       additionalPaths,
       bundlePaths,
@@ -215,7 +226,7 @@ var __glob = (map) => (path) => {
       moduleFormat,
       nativeNodeModules,
       outputExtension,
-      warnings,
+      warnings: updatedWarnings,
     }
   } catch (error) {
     throw FunctionBundlingUserError.addCustomErrorInfo(error, {

--- a/tests/fixtures/import-meta-warning/function.ts
+++ b/tests/fixtures/import-meta-warning/function.ts
@@ -1,0 +1,10 @@
+export const handler = async () => ({
+  statusCode: 200,
+  body: JSON.stringify({
+    msg: "Hello from .ts",
+    v: 2,
+    // @ts-ignore Error expected
+    importMetaURL: import.meta.url,
+    dirname: typeof __dirname === "undefined" ? undefined : __dirname,
+  }),
+});

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -2750,4 +2750,17 @@ describe('zip-it-and-ship-it', () => {
       expect(handler()).toBe(true)
     }
   })
+
+  testMany('esbuild hides unactionable import.meta warning', ['bundler_esbuild'], async (options) => {
+    const {
+      files: [{ bundlerWarnings }],
+    } = await zipFixture('import-meta-warning', {
+      length: 1,
+      opts: options,
+    })
+    expect(bundlerWarnings).toHaveLength(1)
+    expect((bundlerWarnings?.[0] as any).text).toEqual(
+      `"import.meta" is not available and will be empty, use __dirname instead`,
+    )
+  })
 })


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Replaces a warning text emitted by esbuild with something more actionable.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/zip-it-and-ship-it/issues/new/choose) before writing your code 🧑‍💻.
      This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing
      a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
