### PR TITLE
feat: add runtime API version property

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -7,6 +7,7 @@ import type { FunctionResult } from './utils/format_result.js'
 import type { Route } from './utils/routes.js'
 
 interface ManifestFunction {
+  buildData?: Record <string, unknown>
   invocationMode?: InvocationMode
   mainFile: string
   name: string
@@ -55,6 +56,7 @@ const formatFunctionForManifest = ({
   routes,
   runtime,
   runtimeVersion,
+  runtimeAPIVersion,
   schedule,
 }: FunctionResult): ManifestFunction => {
   const manifestFunction: ManifestFunction = {
@@ -62,6 +64,7 @@ const formatFunctionForManifest = ({
     displayName,
     generator,
     invocationMode,
+    buildData: { runtimeAPIVersion },
     mainFile,
     name,
     runtimeVersion,

--- a/tests/v2api.test.ts
+++ b/tests/v2api.test.ts
@@ -205,7 +205,7 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
     expect(systemLog).not.toHaveBeenCalled()
   })
 
-  test('Extracts routes from the `path` in-source configuration property', async () => {
+  test.only('Extracts routes from the `path` in-source configuration property', async () => {
     const { path: tmpDir } = await getTmpDir({ prefix: 'zip-it-test' })
     const manifestPath = join(tmpDir, 'manifest.json')
 
@@ -217,7 +217,7 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
       },
     })
 
-    expect.assertions(files.length + 1)
+    expect.assertions(files.length + 2)
 
     for (const file of files) {
       switch (file.name) {
@@ -256,6 +256,7 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
     const manifestString = await readFile(manifestPath, { encoding: 'utf8' })
     const manifest = JSON.parse(manifestString)
     expect(manifest.functions[0].routes[0].methods).toEqual(['GET', 'POST'])
+    expect(manifest.functions[0].buildData.runtimeAPIVersion).toEqual(2)
   })
 
   test('Flags invalid values of the `path` in-source configuration property as user errors', async () => {


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉
Adds a property to surface the runtime API version for the function in build data. Part of issue https://linear.app/netlify/issue/COM-6/expose-the-ability-to-query-for-functions-using-the-v2-api

#### Summary

Fixes #<replace_with_issue_number>

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/zip-it-and-ship-it/issues/new/choose) before writing your code 🧑‍💻.
      This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing
      a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
