### PR TITLE
fix: dont duplicate zip files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
         "@types/unixify": "1.0.0",
         "@types/yargs": "17.0.24",
         "@vitest/coverage-v8": "0.34.4",
+        "adm-zip": "^0.5.10",
         "browserslist": "4.21.11",
         "cardinal": "2.1.1",
         "cpy": "9.0.1",
@@ -2614,6 +2615,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.10.tgz",
+      "integrity": "sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0"
       }
     },
     "node_modules/agent-base": {
@@ -12841,6 +12851,12 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
       "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true
+    },
+    "adm-zip": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.10.tgz",
+      "integrity": "sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==",
       "dev": true
     },
     "agent-base": {

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "@types/unixify": "1.0.0",
     "@types/yargs": "17.0.24",
     "@vitest/coverage-v8": "0.34.4",
+    "adm-zip": "^0.5.10",
     "browserslist": "4.21.11",
     "cardinal": "2.1.1",
     "cpy": "9.0.1",

--- a/src/runtimes/node/utils/zip.ts
+++ b/src/runtimes/node/utils/zip.ts
@@ -224,7 +224,8 @@ const createZipArchive = async function ({
     }
   }
 
-  const srcFilesInfos = await Promise.all(srcFiles.map((file) => addStat(cache, file)))
+  const deduplicatedSrcFiles = [...new Set(srcFiles)]
+  const srcFilesInfos = await Promise.all(deduplicatedSrcFiles.map((file) => addStat(cache, file)))
 
   // We ensure this is not async, so that the archive's checksum is
   // deterministic. Otherwise it depends on the order the files were added.

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -2824,7 +2824,7 @@ describe('zip-it-and-ship-it', () => {
     )
   })
 
-  testMany.only('only includes files once in a zip', [...allBundleConfigs], async (options) => {
+  testMany('only includes files once in a zip', [...allBundleConfigs], async (options) => {
     const { files } = await zipFixture('local-require', {
       length: 1,
       opts: merge(options, {

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -2,6 +2,7 @@ import { mkdir, readFile, chmod, symlink, writeFile, rm } from 'fs/promises'
 import { dirname, isAbsolute, join, resolve } from 'path'
 import { arch, platform, version as nodeVersion } from 'process'
 
+import AdmZip from 'adm-zip'
 import cpy from 'cpy'
 import merge from 'deepmerge'
 import { execa, execaNode } from 'execa'
@@ -2821,5 +2822,26 @@ describe('zip-it-and-ship-it', () => {
     expect((bundlerWarnings?.[0] as any).text).toEqual(
       `"import.meta" is not available and will be empty, use __dirname instead`,
     )
+  })
+
+  testMany.only('only includes files once in a zip', [...allBundleConfigs], async (options) => {
+    const { files } = await zipFixture('local-require', {
+      length: 1,
+      opts: merge(options, {
+        basePath: join(FIXTURES_DIR, 'local-require'),
+        config: {
+          '*': {
+            includedFiles: ['function/file.js'],
+            ...options.config['*'],
+          },
+        },
+      }),
+    })
+
+    const zip = new AdmZip(files[0].path)
+
+    const fileNames: string[] = zip.getEntries().map((entry) => entry.entryName)
+    const duplicates = fileNames.filter((item, index) => fileNames.indexOf(item) !== index)
+    expect(duplicates).toHaveLength(0)
   })
 })


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Closes https://github.com/netlify/pillar-support/issues/733

If a file was identified by NFT as needing to be included, plus the same file was listet in `included_files`, we are currently calling `zipJsFile` two times for that. This means the file will be zipped twice, redudantly.

This PR adds a repro + fix for that, so we deduplicate files before including them in the zip.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/zip-it-and-ship-it/issues/new/choose) before writing your code 🧑‍💻.
      This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing
      a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
