### PR TITLE
chore: add Deno to integration CI

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -34,6 +34,8 @@ jobs:
             zip-it-and-ship-it/package-lock.json
             test-site/package-lock.json
             netlify-cli/package-lock.json
+      - name: Setup Deno
+        uses: denoland/setup-deno@v1
       - name: Installing netlify-cli
         run: npm ci
         working-directory: netlify-cli


### PR DESCRIPTION
#### Summary

The Next runtime now uses Deno as part of its build process, so we need it in our integration tests.