### PR TITLE
feat: support multiple paths in V2 functions

### DIFF
--- a/src/runtimes/node/in_source_config/index.ts
+++ b/src/runtimes/node/in_source_config/index.ts
@@ -4,7 +4,7 @@ import { InvocationMode, INVOCATION_MODE } from '../../../function.js'
 import { FunctionBundlingUserError } from '../../../utils/error.js'
 import { Logger } from '../../../utils/logger.js'
 import { nonNullable } from '../../../utils/non_nullable.js'
-import { getRoutesFromPath, Route } from '../../../utils/routes.js'
+import { getRoutes, Route } from '../../../utils/routes.js'
 import { RUNTIME } from '../../runtime.js'
 import { NODE_BUNDLER } from '../bundlers/types.js'
 import { createBindingsMethod } from '../parser/bindings.js'
@@ -119,7 +119,7 @@ export const findISCDeclarations = (
       config.methods = normalizeMethods(configExport.method, functionName)
     }
 
-    config.routes = getRoutesFromPath(configExport.path, functionName, config.methods ?? [])
+    config.routes = getRoutes(configExport.path, functionName, config.methods ?? [])
 
     return config
   }

--- a/src/runtimes/node/parser/exports.ts
+++ b/src/runtimes/node/parser/exports.ts
@@ -13,7 +13,7 @@ import type { ISCExport } from '../in_source_config/index.js'
 import type { BindingMethod } from './bindings.js'
 import { isModuleExports } from './helpers.js'
 
-type PrimitiveResult = string | number | boolean | Record<string, unknown> | undefined | PrimitiveResult[]
+type PrimitiveResult = string | number | boolean | Record<string, unknown> | undefined | null | PrimitiveResult[]
 
 // Finds and returns the following types of exports in an AST:
 // 1. Named `handler` function exports
@@ -161,6 +161,7 @@ const parseObject = (node: ObjectExpression) =>
  * - object
  * - string
  * - array
+ * - null
  */
 const parsePrimitive = (exp: Expression | PatternLike): PrimitiveResult => {
   if (exp.type === 'BooleanLiteral' || exp.type === 'NumericLiteral' || exp.type === 'StringLiteral') {
@@ -179,6 +180,10 @@ const parsePrimitive = (exp: Expression | PatternLike): PrimitiveResult => {
 
   if (exp.type === 'ObjectExpression') {
     return parseObject(exp)
+  }
+
+  if (exp.type === 'NullLiteral') {
+    return null
   }
 }
 

--- a/src/runtimes/node/parser/exports.ts
+++ b/src/runtimes/node/parser/exports.ts
@@ -4,6 +4,7 @@ import type {
   ExportSpecifier,
   Expression,
   ObjectExpression,
+  PatternLike,
   Statement,
 } from '@babel/types'
 
@@ -11,6 +12,8 @@ import type { ISCExport } from '../in_source_config/index.js'
 
 import type { BindingMethod } from './bindings.js'
 import { isModuleExports } from './helpers.js'
+
+type PrimitiveResult = string | number | boolean | Record<string, unknown> | undefined | PrimitiveResult[]
 
 // Finds and returns the following types of exports in an AST:
 // 1. Named `handler` function exports
@@ -131,50 +134,53 @@ const parseConfigExport = (node: Statement) => {
   }
 }
 
-// Takes an object expression node and returns the object resulting from the
-// subtree. The following types are accepted as values, and any others will
-// be ignored and excluded from the resulting object:
-//
-// - boolean
-// - number
-// - object
-// - string
-// - array of strings
+/**
+ * Takes an object expression node and returns the object resulting from the
+ * subtree. Only values supported by the `parsePrimitive` method are returned,
+ * and any others will be ignored and excluded from the resulting object.
+ */
 const parseObject = (node: ObjectExpression) =>
   node.properties.reduce((acc, property): Record<string, unknown> => {
     if (property.type !== 'ObjectProperty' || property.key.type !== 'Identifier') {
       return acc
     }
 
-    if (
-      property.value.type === 'BooleanLiteral' ||
-      property.value.type === 'NumericLiteral' ||
-      property.value.type === 'StringLiteral'
-    ) {
-      return {
-        ...acc,
-        [property.key.name]: property.value.value,
-      }
+    return {
+      ...acc,
+      [property.key.name]: parsePrimitive(property.value),
     }
-
-    if (property.value.type === 'ArrayExpression') {
-      return {
-        ...acc,
-        [property.key.name]: property.value.elements.flatMap((element) =>
-          element?.type === 'StringLiteral' ? [element.value] : [],
-        ),
-      }
-    }
-
-    if (property.value.type === 'ObjectExpression') {
-      return {
-        ...acc,
-        [property.key.name]: parseObject(property.value),
-      }
-    }
-
-    return acc
   }, {} as Record<string, unknown>)
+
+/**
+ * Takes an expression and, if it matches a JavaScript primitive type, returns
+ * the corresponding value. If not, `undefined` is returned.
+ * Currently, the following primitive types are supported:
+ *
+ * - boolean
+ * - number
+ * - object
+ * - string
+ * - array
+ */
+const parsePrimitive = (exp: Expression | PatternLike): PrimitiveResult => {
+  if (exp.type === 'BooleanLiteral' || exp.type === 'NumericLiteral' || exp.type === 'StringLiteral') {
+    return exp.value
+  }
+
+  if (exp.type === 'ArrayExpression') {
+    return exp.elements.map((element) => {
+      if (element === null || element.type === 'SpreadElement') {
+        return
+      }
+
+      return parsePrimitive(element)
+    })
+  }
+
+  if (exp.type === 'ObjectExpression') {
+    return parseObject(exp)
+  }
+}
 
 // Tries to resolve the export from a binding (variable)
 // for example `let handler; handler = () => {}; export { handler }` would

--- a/src/utils/routes.ts
+++ b/src/utils/routes.ts
@@ -19,10 +19,6 @@ const isPathLiteral = (path: string) => {
 }
 
 const getRoute = (path: unknown, functionName: string, methods: string[]): Route | undefined => {
-  if (!path) {
-    return
-  }
-
   if (typeof path !== 'string') {
     throw new FunctionBundlingUserError(`'path' property must be a string, found '${typeof path}'`, {
       functionName,

--- a/src/utils/routes.ts
+++ b/src/utils/routes.ts
@@ -24,7 +24,7 @@ const isPathLiteral = (path: string) => {
  */
 const getRoute = (path: unknown, functionName: string, methods: string[]): Route | undefined => {
   if (typeof path !== 'string') {
-    throw new FunctionBundlingUserError(`'path' property must be a string, found '${typeof path}'`, {
+    throw new FunctionBundlingUserError(`'path' property must be a string, found '${JSON.stringify(path)}'`, {
       functionName,
       runtime: RUNTIME.JAVASCRIPT,
     })

--- a/src/utils/routes.ts
+++ b/src/utils/routes.ts
@@ -18,6 +18,10 @@ const isPathLiteral = (path: string) => {
   return parts.every((part) => !isExpression(part))
 }
 
+/**
+ * Takes an element from a `path` declaration and returns a Route element that
+ * represents it.
+ */
 const getRoute = (path: unknown, functionName: string, methods: string[]): Route | undefined => {
   if (typeof path !== 'string') {
     throw new FunctionBundlingUserError(`'path' property must be a string, found '${typeof path}'`, {
@@ -58,12 +62,16 @@ const getRoute = (path: unknown, functionName: string, methods: string[]): Route
   }
 }
 
+/**
+ * Takes a `path` declaration, normalizes it into an array, and processes the
+ * individual elements to obtain an array of `Route` expressions.
+ */
 export const getRoutes = (input: unknown, functionName: string, methods: string[]): Route[] => {
   if (!input) {
     return []
   }
 
-  const paths = Array.isArray(input) ? input : [input]
+  const paths = [...new Set(Array.isArray(input) ? input : [input])]
   const routes = paths.map((path) => getRoute(path, functionName, methods ?? [])).filter(nonNullable)
 
   return routes

--- a/tests/unit/runtimes/node/in_source_config.test.ts
+++ b/tests/unit/runtimes/node/in_source_config.test.ts
@@ -303,7 +303,7 @@ describe('V2 API', () => {
         } catch (error) {
           const { customErrorInfo, message } = error
 
-          expect(message).toBe(`'path' property must be a string, found 'object'`)
+          expect(message).toBe(`'path' property must be a string, found '{"url":"/products"}'`)
           expect(customErrorInfo.type).toBe('functionsBundling')
           expect(customErrorInfo.location.functionName).toBe('func1')
           expect(customErrorInfo.location.runtime).toBe('js')
@@ -349,7 +349,53 @@ describe('V2 API', () => {
         } catch (error) {
           const { customErrorInfo, message } = error
 
-          expect(message).toBe(`'path' property must be a string, found 'number'`)
+          expect(message).toBe(`'path' property must be a string, found '42'`)
+          expect(customErrorInfo.type).toBe('functionsBundling')
+          expect(customErrorInfo.location.functionName).toBe('func1')
+          expect(customErrorInfo.location.runtime).toBe('js')
+        }
+      })
+
+      test('A `null` value in a group', () => {
+        expect.assertions(4)
+
+        try {
+          const source = `export default async () => {
+            return new Response("Hello!")
+          }
+      
+          export const config = {
+            path: ["/store", null]
+          }`
+
+          findISCDeclarations(source, options)
+        } catch (error) {
+          const { customErrorInfo, message } = error
+
+          expect(message).toBe(`'path' property must be a string, found 'null'`)
+          expect(customErrorInfo.type).toBe('functionsBundling')
+          expect(customErrorInfo.location.functionName).toBe('func1')
+          expect(customErrorInfo.location.runtime).toBe('js')
+        }
+      })
+
+      test('An `undefined` value in a group', () => {
+        expect.assertions(4)
+
+        try {
+          const source = `export default async () => {
+            return new Response("Hello!")
+          }
+      
+          export const config = {
+            path: ["/store", undefined]
+          }`
+
+          findISCDeclarations(source, options)
+        } catch (error) {
+          const { customErrorInfo, message } = error
+
+          expect(message).toBe(`'path' property must be a string, found 'undefined'`)
           expect(customErrorInfo.type).toBe('functionsBundling')
           expect(customErrorInfo.location.functionName).toBe('func1')
           expect(customErrorInfo.location.runtime).toBe('js')

--- a/tests/unit/runtimes/node/in_source_config.test.ts
+++ b/tests/unit/runtimes/node/in_source_config.test.ts
@@ -261,46 +261,100 @@ describe('V2 API', () => {
       }
     })
 
-    test('With an invalid pattern', () => {
-      expect.assertions(8)
+    describe('Thows an error when invalid values are supplied', () => {
+      test('An invalid pattern', () => {
+        expect.assertions(4)
 
-      try {
-        const source = `export default async () => {
-          return new Response("Hello!")
+        try {
+          const source = `export default async () => {
+            return new Response("Hello!")
+          }
+      
+          export const config = {
+            path: "/products("
+          }`
+
+          findISCDeclarations(source, options)
+        } catch (error) {
+          const { customErrorInfo, message } = error
+
+          expect(message).toBe(`'/products(' is not a valid path according to the URLPattern specification`)
+          expect(customErrorInfo.type).toBe('functionsBundling')
+          expect(customErrorInfo.location.functionName).toBe('func1')
+          expect(customErrorInfo.location.runtime).toBe('js')
         }
-    
-        export const config = {
-          path: "/products("
-        }`
+      })
 
-        findISCDeclarations(source, options)
-      } catch (error) {
-        const { customErrorInfo, message } = error
+      test('A non-string value', () => {
+        expect.assertions(4)
 
-        expect(message).toBe(`'/products(' is not a valid path according to the URLPattern specification`)
-        expect(customErrorInfo.type).toBe('functionsBundling')
-        expect(customErrorInfo.location.functionName).toBe('func1')
-        expect(customErrorInfo.location.runtime).toBe('js')
-      }
+        try {
+          const source = `export default async () => {
+            return new Response("Hello!")
+          }
+      
+          export const config = {
+            path: {
+              url: "/products"
+            }
+          }`
 
-      try {
-        const source = `export default async () => {
-          return new Response("Hello!")
+          findISCDeclarations(source, options)
+        } catch (error) {
+          const { customErrorInfo, message } = error
+
+          expect(message).toBe(`'path' property must be a string, found 'object'`)
+          expect(customErrorInfo.type).toBe('functionsBundling')
+          expect(customErrorInfo.location.functionName).toBe('func1')
+          expect(customErrorInfo.location.runtime).toBe('js')
         }
-    
-        export const config = {
-          path: ["/store", "/products("]
-        }`
+      })
 
-        findISCDeclarations(source, options)
-      } catch (error) {
-        const { customErrorInfo, message } = error
+      test('An invalid pattern in a group', () => {
+        expect.assertions(4)
 
-        expect(message).toBe(`'/products(' is not a valid path according to the URLPattern specification`)
-        expect(customErrorInfo.type).toBe('functionsBundling')
-        expect(customErrorInfo.location.functionName).toBe('func1')
-        expect(customErrorInfo.location.runtime).toBe('js')
-      }
+        try {
+          const source = `export default async () => {
+            return new Response("Hello!")
+          }
+      
+          export const config = {
+            path: ["/store", "/products("]
+          }`
+
+          findISCDeclarations(source, options)
+        } catch (error) {
+          const { customErrorInfo, message } = error
+
+          expect(message).toBe(`'/products(' is not a valid path according to the URLPattern specification`)
+          expect(customErrorInfo.type).toBe('functionsBundling')
+          expect(customErrorInfo.location.functionName).toBe('func1')
+          expect(customErrorInfo.location.runtime).toBe('js')
+        }
+      })
+
+      test('A non-string value in a group', () => {
+        expect.assertions(4)
+
+        try {
+          const source = `export default async () => {
+            return new Response("Hello!")
+          }
+      
+          export const config = {
+            path: ["/store", 42]
+          }`
+
+          findISCDeclarations(source, options)
+        } catch (error) {
+          const { customErrorInfo, message } = error
+
+          expect(message).toBe(`'path' property must be a string, found 'number'`)
+          expect(customErrorInfo.type).toBe('functionsBundling')
+          expect(customErrorInfo.location.functionName).toBe('func1')
+          expect(customErrorInfo.location.runtime).toBe('js')
+        }
+      })
     })
 
     test('Using a literal pattern', () => {

--- a/tests/unit/runtimes/node/in_source_config.test.ts
+++ b/tests/unit/runtimes/node/in_source_config.test.ts
@@ -238,30 +238,30 @@ describe('V2 API', () => {
   })
 
   describe('`path` property', () => {
-    test('Missing a leading slash', () => {
-      expect.assertions(4)
-
-      try {
-        const source = `export default async () => {
-          return new Response("Hello!")
-        }
-    
-        export const config = {
-          path: "missing-slash"
-        }`
-
-        findISCDeclarations(source, options)
-      } catch (error) {
-        const { customErrorInfo, message } = error
-
-        expect(message).toBe(`'path' property must start with a '/'`)
-        expect(customErrorInfo.type).toBe('functionsBundling')
-        expect(customErrorInfo.location.functionName).toBe('func1')
-        expect(customErrorInfo.location.runtime).toBe('js')
-      }
-    })
-
     describe('Thows an error when invalid values are supplied', () => {
+      test('Missing a leading slash', () => {
+        expect.assertions(4)
+
+        try {
+          const source = `export default async () => {
+            return new Response("Hello!")
+          }
+      
+          export const config = {
+            path: "missing-slash"
+          }`
+
+          findISCDeclarations(source, options)
+        } catch (error) {
+          const { customErrorInfo, message } = error
+
+          expect(message).toBe(`'path' property must start with a '/'`)
+          expect(customErrorInfo.type).toBe('functionsBundling')
+          expect(customErrorInfo.location.functionName).toBe('func1')
+          expect(customErrorInfo.location.runtime).toBe('js')
+        }
+      })
+
       test('An invalid pattern', () => {
         expect.assertions(4)
 
@@ -397,7 +397,11 @@ describe('V2 API', () => {
       }
   
       export const config = {
-        path: ["/store/:category/products/:product-id", "/super-awesome-campaign"]
+        path: [
+          "/store/:category/products/:product-id",
+          "/product/:product-id",
+          "/super-awesome-campaign"
+        ]
       }`
 
       const { routes } = findISCDeclarations(source, options)
@@ -408,8 +412,27 @@ describe('V2 API', () => {
           expression: '^\\/store(?:\\/([^\\/]+?))\\/products(?:\\/([^\\/]+?))-id\\/?$',
           methods: [],
         },
+        {
+          pattern: '/product/:product-id',
+          expression: '^\\/product(?:\\/([^\\/]+?))-id\\/?$',
+          methods: [],
+        },
         { pattern: '/super-awesome-campaign', literal: '/super-awesome-campaign', methods: [] },
       ])
+    })
+
+    test('De-duplicates paths', () => {
+      const source = `export default async () => {
+        return new Response("Hello!")
+      }
+  
+      export const config = {
+        path: ["/products", "/products"]
+      }`
+
+      const { routes } = findISCDeclarations(source, options)
+
+      expect(routes).toEqual([{ pattern: '/products', literal: '/products', methods: [] }])
     })
   })
 })


### PR DESCRIPTION
#### Summary

Allow an array of strings in the `path` in-source configuration property of V2 functions.

The types [already allow this](https://github.com/netlify/functions/blob/3270f5f7823aef8f27e62ab39322514481b7b171/src/function/v2.ts#L10), as well as the rest of the infrastructure.