### PR TITLE
feat: improvements to V2 functions

### DIFF
--- a/src/runtimes/node/bundlers/index.ts
+++ b/src/runtimes/node/bundlers/index.ts
@@ -44,11 +44,17 @@ export const getBundlerName = async ({
   mainFile: string
   runtimeAPIVersion: number
 }): Promise<NodeBundlerName> => {
+  // For V2 functions, we force the bundler to NFT. The only exception is when
+  // a `none` override was provided.
+  if (runtimeAPIVersion === 2) {
+    return nodeBundler === NODE_BUNDLER.NONE ? NODE_BUNDLER.NONE : NODE_BUNDLER.NFT
+  }
+
   if (nodeBundler) {
     return nodeBundler
   }
 
-  return await getDefaultBundler({ extension, featureFlags, mainFile, runtimeAPIVersion })
+  return await getDefaultBundler({ extension, featureFlags, mainFile })
 }
 
 const ESBUILD_EXTENSIONS = new Set(['.mjs', '.ts', '.tsx', '.cts', '.mts'])
@@ -59,17 +65,11 @@ const getDefaultBundler = async ({
   extension,
   featureFlags,
   mainFile,
-  runtimeAPIVersion,
 }: {
   extension: string
   mainFile: string
   featureFlags: FeatureFlags
-  runtimeAPIVersion: number
 }): Promise<NodeBundlerName> => {
-  if (runtimeAPIVersion === 2) {
-    return NODE_BUNDLER.NFT
-  }
-
   if (extension === MODULE_FILE_EXTENSION.MJS && featureFlags.zisi_pure_esm_mjs) {
     return NODE_BUNDLER.NFT
   }

--- a/src/runtimes/node/bundlers/nft/transpile.ts
+++ b/src/runtimes/node/bundlers/nft/transpile.ts
@@ -5,6 +5,7 @@ import { build, BuildOptions } from 'esbuild'
 import type { FunctionConfig } from '../../../../config.js'
 import { FunctionBundlingUserError } from '../../../../utils/error.js'
 import { RUNTIME } from '../../../runtime.js'
+import { CJS_SHIM } from '../../utils/esm_cjs_compat.js'
 import { ModuleFormat, MODULE_FORMAT } from '../../utils/module_format.js'
 import { getBundlerTarget } from '../esbuild/bundler_target.js'
 import { NODE_BUNDLER } from '../types.js'
@@ -54,8 +55,18 @@ export const transpileTS = async ({ bundle = false, config, format, name, path }
   // The version of ECMAScript to use as the build target. This will determine
   // whether certain features are transpiled down or left untransformed.
   const nodeTarget = getBundlerTarget(config.nodeVersion)
+  const bundleOptions: BuildOptions = {
+    bundle: false,
+  }
 
-  const bundleOptions: BuildOptions = bundle ? { bundle: true, packages: 'external' } : { bundle: false }
+  if (bundle) {
+    bundleOptions.bundle = true
+    bundleOptions.packages = 'external'
+
+    if (format === MODULE_FORMAT.ESM) {
+      bundleOptions.banner = { js: CJS_SHIM }
+    }
+  }
 
   try {
     const transpiled = await build({

--- a/src/runtimes/node/bundlers/nft/transpile.ts
+++ b/src/runtimes/node/bundlers/nft/transpile.ts
@@ -1,3 +1,5 @@
+import { resolve } from 'path'
+
 import { build, BuildOptions } from 'esbuild'
 
 import type { FunctionConfig } from '../../../../config.js'
@@ -61,13 +63,15 @@ export const transpileTS = async ({ bundle = false, config, format, name, path }
       entryPoints: [path],
       format,
       logLevel: 'error',
+      metafile: true,
       platform: 'node',
       sourcemap: Boolean(config.nodeSourcemap),
       target: [nodeTarget],
       write: false,
     })
+    const bundledPaths = bundle ? Object.keys(transpiled.metafile.inputs).map((inputPath) => resolve(inputPath)) : []
 
-    return transpiled.outputFiles[0].text
+    return { bundledPaths, transpiled: transpiled.outputFiles[0].text }
   } catch (error) {
     throw FunctionBundlingUserError.addCustomErrorInfo(error, {
       functionName: name,

--- a/src/runtimes/node/index.ts
+++ b/src/runtimes/node/index.ts
@@ -140,7 +140,7 @@ const zipFunction: ZipFunction = async function ({
     invocationMode = INVOCATION_MODE.Background
   }
 
-  const jsModuleFormat =
+  const outputModuleFormat =
     extname(finalMainFile) === MODULE_FILE_EXTENSION.MJS ? MODULE_FORMAT.ESM : MODULE_FORMAT.COMMONJS
 
   return {
@@ -154,7 +154,7 @@ const zipFunction: ZipFunction = async function ({
     includedFiles,
     inSourceConfig,
     invocationMode,
-    jsModuleFormat,
+    outputModuleFormat,
     nativeNodeModules,
     path: zipPath.path,
     runtimeVersion:

--- a/src/runtimes/node/index.ts
+++ b/src/runtimes/node/index.ts
@@ -1,4 +1,4 @@
-import { join } from 'path'
+import { extname, join } from 'path'
 
 import { copyFile } from 'cp-file'
 
@@ -10,6 +10,7 @@ import { getBundler, getBundlerName } from './bundlers/index.js'
 import { NODE_BUNDLER } from './bundlers/types.js'
 import { findFunctionsInPaths, findFunctionInPath } from './finder.js'
 import { findISCDeclarationsInPath } from './in_source_config/index.js'
+import { MODULE_FORMAT, MODULE_FILE_EXTENSION } from './utils/module_format.js'
 import { getNodeRuntime, getNodeRuntimeForV2 } from './utils/node_runtime.js'
 import { createAliases as createPluginsModulesPathAliases, getPluginsModulesPath } from './utils/plugin_modules_path.js'
 import { zipNodeJs } from './utils/zip.js'
@@ -139,6 +140,9 @@ const zipFunction: ZipFunction = async function ({
     invocationMode = INVOCATION_MODE.Background
   }
 
+  const jsModuleFormat =
+    extname(finalMainFile) === MODULE_FILE_EXTENSION.MJS ? MODULE_FORMAT.ESM : MODULE_FORMAT.COMMONJS
+
   return {
     bundler: bundlerName,
     bundlerWarnings,
@@ -150,6 +154,7 @@ const zipFunction: ZipFunction = async function ({
     includedFiles,
     inSourceConfig,
     invocationMode,
+    jsModuleFormat,
     nativeNodeModules,
     path: zipPath.path,
     runtimeVersion:

--- a/src/runtimes/node/utils/esm_cjs_compat.ts
+++ b/src/runtimes/node/utils/esm_cjs_compat.ts
@@ -1,0 +1,14 @@
+/**
+ * This shim makes calls to `require`, `__filename` and `__dirname` work when
+ * bundling to ESM with esbuild.
+ *
+ * https://github.com/evanw/esbuild/pull/2067
+ */
+export const CJS_SHIM = `
+import {createRequire as ___nfyCreateRequire} from "module";
+import {fileURLToPath as ___nfyFileURLToPath} from "url";
+import {dirname as ___nfyPathDirname} from "path";
+let __filename=___nfyFileURLToPath(import.meta.url);
+let __dirname=___nfyPathDirname(___nfyFileURLToPath(import.meta.url));
+let require=___nfyCreateRequire(import.meta.url);
+`

--- a/src/runtimes/runtime.ts
+++ b/src/runtimes/runtime.ts
@@ -51,7 +51,7 @@ export interface ZipFunctionResult {
   includedFiles?: string[]
   inSourceConfig?: ISCValues
   invocationMode?: InvocationMode
-  jsModuleFormat?: ModuleFormat
+  outputModuleFormat?: ModuleFormat
   nativeNodeModules?: object
   path: string
   runtimeVersion?: string

--- a/src/runtimes/runtime.ts
+++ b/src/runtimes/runtime.ts
@@ -2,6 +2,7 @@ import type { ArchiveFormat } from '../archive.js'
 import type { FunctionConfig } from '../config.js'
 import type { FeatureFlags } from '../feature_flags.js'
 import type { FunctionSource, InvocationMode, SourceFile } from '../function.js'
+import type { ModuleFormat } from '../main.js'
 import { ObjectValues } from '../types/utils.js'
 import type { RuntimeCache } from '../utils/cache.js'
 import { Logger } from '../utils/logger.js'
@@ -50,6 +51,7 @@ export interface ZipFunctionResult {
   includedFiles?: string[]
   inSourceConfig?: ISCValues
   invocationMode?: InvocationMode
+  jsModuleFormat?: ModuleFormat
   nativeNodeModules?: object
   path: string
   runtimeVersion?: string

--- a/tests/fixtures-esm/v2-api-esm-mixed-modules/function.ts
+++ b/tests/fixtures-esm/v2-api-esm-mixed-modules/function.ts
@@ -6,5 +6,6 @@ import { name as helper2 } from './lib/helper2.js'
 import { name as helper3 } from './lib/helper3'
 import { name as helper4 } from './lib/helper4.js'
 import { name as helper5 } from './lib/helper5.mjs'
+import { name as helper6 } from './lib/helper6.js'
 
-export default async (req: Request) => Response.json({ cjs, esm, helper1, helper2, helper3, helper4, helper5 })
+export default async (req: Request) => Response.json({ cjs, esm, helper1, helper2, helper3, helper4, helper5, helper6 })

--- a/tests/fixtures-esm/v2-api-esm-mixed-modules/lib/helper6.js
+++ b/tests/fixtures-esm/v2-api-esm-mixed-modules/lib/helper6.js
@@ -1,0 +1,3 @@
+const { os } = require('process')
+
+exports.name = typeof os === 'string' ? 'helper6' : new Error('Something went wrong')

--- a/tests/v2api.test.ts
+++ b/tests/v2api.test.ts
@@ -1,5 +1,5 @@
 import { readFile } from 'fs/promises'
-import { join } from 'path'
+import { join, resolve } from 'path'
 import { version as nodeVersion } from 'process'
 import { promisify } from 'util'
 
@@ -34,6 +34,8 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
       })
 
       for (const entry of files) {
+        expect(entry.bundler).toBe('nft')
+        expect(entry.jsModuleFormat).toBe('cjs')
         expect(entry.entryFilename).toBe('___netlify-entry-point.mjs')
         expect(entry.runtimeAPIVersion).toBe(2)
       }
@@ -60,6 +62,8 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
       })
 
       for (const entry of files) {
+        expect(entry.bundler).toBe('nft')
+        expect(entry.jsModuleFormat).toBe('esm')
         expect(entry.entryFilename).toBe('___netlify-entry-point.mjs')
         expect(entry.runtimeAPIVersion).toBe(2)
       }
@@ -88,6 +92,8 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
       })
 
       for (const entry of files) {
+        expect(entry.bundler).toBe('nft')
+        expect(entry.jsModuleFormat).toBe('cjs')
         expect(entry.entryFilename).toBe('___netlify-entry-point.mjs')
         expect(entry.runtimeAPIVersion).toBe(2)
       }
@@ -115,6 +121,8 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
       })
 
       for (const entry of files) {
+        expect(entry.bundler).toBe('nft')
+        expect(entry.jsModuleFormat).toBe('cjs')
         expect(entry.entryFilename).toBe('___netlify-entry-point.mjs')
         expect(entry.runtimeAPIVersion).toBe(2)
       }
@@ -138,16 +146,43 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
     'Handles an ESM TypeScript function that imports both CJS and ESM modules',
     ['bundler_default', 'bundler_esbuild', 'bundler_esbuild_zisi', 'bundler_default_nft', 'bundler_nft'],
     async (options) => {
-      const { files, tmpDir } = await zipFixture('v2-api-esm-mixed-modules', {
+      const fixtureName = 'v2-api-esm-mixed-modules'
+      const { files, tmpDir } = await zipFixture(fixtureName, {
         fixtureDir: FIXTURES_ESM_DIR,
         opts: merge(options, {
           archiveFormat: ARCHIVE_FORMAT.NONE,
         }),
       })
 
-      for (const entry of files) {
-        expect(entry.entryFilename).toBe('___netlify-entry-point.mjs')
-        expect(entry.runtimeAPIVersion).toBe(2)
+      expect(files.length).toBe(1)
+
+      const [entry] = files
+
+      expect(entry.bundler).toBe('nft')
+      expect(entry.jsModuleFormat).toBe('esm')
+      expect(entry.entryFilename).toBe('___netlify-entry-point.mjs')
+      expect(entry.runtimeAPIVersion).toBe(2)
+
+      const expectedInputs = [
+        'package.json',
+        'function.ts',
+        'node_modules/cjs-module/package.json',
+        'node_modules/cjs-module/index.js',
+        'node_modules/esm-module/package.json',
+        'node_modules/esm-module/index.js',
+        'node_modules/esm-module/foo.js',
+        'node_modules/cjs-module/foo.js',
+        'lib/helper1.ts',
+        'lib/helper2.ts',
+        'lib/helper3.ts',
+        'lib/helper4.js',
+        'lib/helper5.mjs',
+      ]
+
+      for (const relativePath of expectedInputs) {
+        const absolutePath = resolve(FIXTURES_ESM_DIR, fixtureName, relativePath)
+
+        expect(entry.inputs?.includes(absolutePath)).toBeTruthy()
       }
 
       const [{ name: archive, entryFilename }] = files
@@ -173,16 +208,43 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
     'Handles a CJS TypeScript function that imports CJS modules',
     ['bundler_default', 'bundler_esbuild', 'bundler_esbuild_zisi', 'bundler_default_nft', 'bundler_nft'],
     async (options) => {
-      const { files, tmpDir } = await zipFixture('v2-api-cjs-modules', {
+      const fixtureName = 'v2-api-cjs-modules'
+      const { files, tmpDir } = await zipFixture(fixtureName, {
         fixtureDir: FIXTURES_ESM_DIR,
         opts: merge(options, {
           archiveFormat: ARCHIVE_FORMAT.NONE,
         }),
       })
 
-      for (const entry of files) {
-        expect(entry.entryFilename).toBe('___netlify-entry-point.mjs')
-        expect(entry.runtimeAPIVersion).toBe(2)
+      expect(files.length).toBe(1)
+
+      const [entry] = files
+
+      expect(entry.bundler).toBe('nft')
+      expect(entry.jsModuleFormat).toBe('cjs')
+      expect(entry.entryFilename).toBe('___netlify-entry-point.mjs')
+      expect(entry.runtimeAPIVersion).toBe(2)
+
+      const expectedInputs = [
+        'package.json',
+        'function.ts',
+        'node_modules/cjs-module/package.json',
+        'node_modules/cjs-module/index.js',
+        'node_modules/esm-module/package.json',
+        'node_modules/esm-module/index.js',
+        'node_modules/esm-module/foo.js',
+        'node_modules/cjs-module/foo.js',
+        'lib/helper1.ts',
+        'lib/helper2.ts',
+        'lib/helper3.ts',
+        'lib/helper4.js',
+        'lib/helper5.mjs',
+      ]
+
+      for (const relativePath of expectedInputs) {
+        const absolutePath = resolve(FIXTURES_ESM_DIR, fixtureName, relativePath)
+
+        expect(entry.inputs?.includes(absolutePath)).toBeTruthy()
       }
 
       const [{ name: archive, entryFilename }] = files
@@ -213,6 +275,8 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
     })
 
     for (const entry of files) {
+      expect(entry.bundler).toBe('nft')
+      expect(entry.jsModuleFormat).toBe('cjs')
       expect(entry.entryFilename).toBe('___netlify-entry-point.mjs')
       expect(entry.runtimeAPIVersion).toBe(2)
     }
@@ -244,6 +308,8 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
     })
 
     for (const entry of files) {
+      expect(entry.bundler).toBe('nft')
+      expect(entry.jsModuleFormat).toBe('esm')
       expect(entry.entryFilename).toBe('___netlify-entry-point.mjs')
       expect(entry.runtimeAPIVersion).toBe(2)
     }

--- a/tests/v2api.test.ts
+++ b/tests/v2api.test.ts
@@ -35,7 +35,7 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
 
       for (const entry of files) {
         expect(entry.bundler).toBe('nft')
-        expect(entry.jsModuleFormat).toBe('cjs')
+        expect(entry.outputModuleFormat).toBe('cjs')
         expect(entry.entryFilename).toBe('___netlify-entry-point.mjs')
         expect(entry.runtimeAPIVersion).toBe(2)
       }
@@ -63,7 +63,7 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
 
       for (const entry of files) {
         expect(entry.bundler).toBe('nft')
-        expect(entry.jsModuleFormat).toBe('esm')
+        expect(entry.outputModuleFormat).toBe('esm')
         expect(entry.entryFilename).toBe('___netlify-entry-point.mjs')
         expect(entry.runtimeAPIVersion).toBe(2)
       }
@@ -93,7 +93,7 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
 
       for (const entry of files) {
         expect(entry.bundler).toBe('nft')
-        expect(entry.jsModuleFormat).toBe('cjs')
+        expect(entry.outputModuleFormat).toBe('cjs')
         expect(entry.entryFilename).toBe('___netlify-entry-point.mjs')
         expect(entry.runtimeAPIVersion).toBe(2)
       }
@@ -122,7 +122,7 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
 
       for (const entry of files) {
         expect(entry.bundler).toBe('nft')
-        expect(entry.jsModuleFormat).toBe('cjs')
+        expect(entry.outputModuleFormat).toBe('cjs')
         expect(entry.entryFilename).toBe('___netlify-entry-point.mjs')
         expect(entry.runtimeAPIVersion).toBe(2)
       }
@@ -159,7 +159,7 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
       const [entry] = files
 
       expect(entry.bundler).toBe('nft')
-      expect(entry.jsModuleFormat).toBe('esm')
+      expect(entry.outputModuleFormat).toBe('esm')
       expect(entry.entryFilename).toBe('___netlify-entry-point.mjs')
       expect(entry.runtimeAPIVersion).toBe(2)
 
@@ -221,7 +221,7 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
       const [entry] = files
 
       expect(entry.bundler).toBe('nft')
-      expect(entry.jsModuleFormat).toBe('cjs')
+      expect(entry.outputModuleFormat).toBe('cjs')
       expect(entry.entryFilename).toBe('___netlify-entry-point.mjs')
       expect(entry.runtimeAPIVersion).toBe(2)
 
@@ -276,7 +276,7 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
 
     for (const entry of files) {
       expect(entry.bundler).toBe('nft')
-      expect(entry.jsModuleFormat).toBe('cjs')
+      expect(entry.outputModuleFormat).toBe('cjs')
       expect(entry.entryFilename).toBe('___netlify-entry-point.mjs')
       expect(entry.runtimeAPIVersion).toBe(2)
     }
@@ -309,7 +309,7 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
 
     for (const entry of files) {
       expect(entry.bundler).toBe('nft')
-      expect(entry.jsModuleFormat).toBe('esm')
+      expect(entry.outputModuleFormat).toBe('esm')
       expect(entry.entryFilename).toBe('___netlify-entry-point.mjs')
       expect(entry.runtimeAPIVersion).toBe(2)
     }

--- a/tests/v2api.test.ts
+++ b/tests/v2api.test.ts
@@ -177,6 +177,7 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
         'lib/helper3.ts',
         'lib/helper4.js',
         'lib/helper5.mjs',
+        'lib/helper6.js',
       ]
 
       for (const relativePath of expectedInputs) {

--- a/tests/zip_function.test.ts
+++ b/tests/zip_function.test.ts
@@ -175,13 +175,13 @@ describe('zipFunction', () => {
 
       expect(result).not.toBeUndefined()
 
-      const bundlerUsed = variation === 'bundler_default' ? NODE_BUNDLER.NFT : getNodeBundlerString(variation)
+      const expectedBundle = variation === 'bundler_none' ? NODE_BUNDLER.NONE : NODE_BUNDLER.NFT
       const expectedConfig = options.config['*']
-      expectedConfig.nodeBundler = bundlerUsed
+      expectedConfig.nodeBundler = variation === 'bundler_default' ? NODE_BUNDLER.NFT : getNodeBundlerString(variation)
 
       expect(result.name).toBe('function')
       expect(result.runtime).toBe('js')
-      expect(result.bundler).toBe(bundlerUsed)
+      expect(result.bundler).toBe(expectedBundle)
       expect(result.mainFile).toBe(mainFile)
       expect(result.config).toEqual(bundler === undefined ? {} : expectedConfig)
       expect(result.runtimeAPIVersion).toEqual(2)


### PR DESCRIPTION
#### Summary

This PR has 3 small changes made separately in the following commits:

- https://github.com/netlify/zip-it-and-ship-it/commit/c52807a4a04e329313bbd83f3bb9971fc29d3274 + https://github.com/netlify/zip-it-and-ship-it/pull/1589/commits/802e351c15756436af42a4fc67a4d62f797a68c1: A new `outputModuleFormat` is added to the function objects returned by zip-it-and-ship-it, containing the module format that the function must run as (`cjs` or `esm`)

- https://github.com/netlify/zip-it-and-ship-it/commit/d1b747c3678245a86e0f4855254faef32fb31e24: The `inputs` array in the returned function objects contains the list of paths that acted as inputs to the output function. This is used by the CLI to know which files it needs to watch and associate with each function. Since https://github.com/netlify/zip-it-and-ship-it/pull/1584, we're bundling some of the files together, but the originating files still need to be part of `inputs`.

- https://github.com/netlify/zip-it-and-ship-it/commit/c0be11ca9c7dbf6c3fce5032d10b49926831469d: We're forcing the bundler to NFT in V2 functions, since that's the only bundler that is optimised for this flow, and we don't want people manually configuring bundlers anymore. We still allow the `none` bundler, in case users (or integrations) want to take over the bundling process.

- https://github.com/netlify/zip-it-and-ship-it/pull/1589/commits/4d6cae358ebfac14ed726b44c05fcc73a4467f11: Adds a shim that makes `require`, `__dirname`, and `__filename` available when bundling local imports to ESM.