### PR TITLE
chore: add script to parse deploy result

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -62,9 +62,7 @@ jobs:
           ${{ secrets.NETLIFY_TOKEN }} --cwd demos/default --functions .netlify/functions > .netlify-deploy-log.json
         working-directory: test-site
       - name: Parsing deploy result
-        run: |
-          node -e "console.log('deploy_log_url=' + require('./.netlify-deploy-log.json').logs)" >> $GITHUB_ENV
-          node -e "console.log('deploy_url=' + require('./.netlify-deploy-log.json').deploy_url)" >> $GITHUB_ENV
+        run: node scripts/parse_deploy_result.mjs ./.netlify-deploy-log.json >> $GITHUB_ENV
         working-directory: test-site
       - name: Cypress run
         uses: cypress-io/github-action@v5

--- a/scripts/parse_deploy_result.mjs
+++ b/scripts/parse_deploy_result.mjs
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs'
+import { argv } from 'node:process'
+
+let data
+
+try {
+  data = readFileSync(argv[2])
+} catch (error) {
+  console.error('Could not read deploy result:')
+
+  throw error
+}
+
+try {
+  const { deploy_url: deployURL, logs } = JSON.parse(data)
+
+  console.log(`deploy_log_url=${logs}`)
+  console.log(`deploy_url=${deployURL}`)
+} catch (error) {
+  console.log(data)
+
+  throw error
+}


### PR DESCRIPTION
#### Summary

Moves the parsing of integration test deploy results to a separate file. This adds some debugging data, which is helpful when tests are failing (like they are right now).