### PR TITLE
feat: always transform V2 functions

### DIFF
--- a/src/runtimes/node/bundlers/nft/bundler.ts
+++ b/src/runtimes/node/bundlers/nft/bundler.ts
@@ -1,0 +1,149 @@
+import { dirname, extname, resolve } from 'path'
+
+import { build, BuildOptions } from 'esbuild'
+
+import type { FunctionConfig } from '../../../../config.js'
+import { FunctionBundlingUserError } from '../../../../utils/error.js'
+import { getPathWithExtension } from '../../../../utils/fs.js'
+import { RUNTIME } from '../../../runtime.js'
+import { CJS_SHIM } from '../../utils/esm_cjs_compat.js'
+import { MODULE_FORMAT, MODULE_FILE_EXTENSION, tsExtensions, ModuleFormat } from '../../utils/module_format.js'
+import { getClosestPackageJson } from '../../utils/package_json.js'
+import { getBundlerTarget } from '../esbuild/bundler_target.js'
+import { NODE_BUNDLER } from '../types.js'
+
+type TypeScriptTransformer = {
+  aliases: Map<string, string>
+  bundle?: boolean
+  bundledPaths?: string[]
+  format: ModuleFormat
+  newMainFile?: string
+  rewrites: Map<string, string>
+}
+
+/**
+ * Returns the module format that should be used for a given function file.
+ */
+const getModuleFormat = async (
+  mainFile: string,
+  runtimeAPIVersion: number,
+  repositoryRoot?: string,
+): Promise<ModuleFormat> => {
+  const extension = extname(mainFile)
+
+  // TODO: This check should go away. We should always respect the format from
+  // the extension. We'll do this at a later stage, after we roll out the V2
+  // API with no side-effects on V1 functions.
+  if (runtimeAPIVersion === 2) {
+    if (extension === MODULE_FILE_EXTENSION.MJS || extension === MODULE_FILE_EXTENSION.MTS) {
+      return MODULE_FORMAT.ESM
+    }
+
+    if (extension === MODULE_FILE_EXTENSION.CTS || extension === MODULE_FILE_EXTENSION.CTS) {
+      return MODULE_FORMAT.COMMONJS
+    }
+  }
+
+  // At this point, we need to infer the module type from the `type` field in
+  // the closest `package.json`.
+  try {
+    const packageJSON = await getClosestPackageJson(dirname(mainFile), repositoryRoot)
+
+    if (packageJSON?.contents.type === 'module') {
+      return MODULE_FORMAT.ESM
+    }
+  } catch {
+    // no-op
+  }
+
+  return MODULE_FORMAT.COMMONJS
+}
+
+export const getBundler = async (
+  runtimeAPIVersion: number,
+  mainFile: string,
+  repositoryRoot?: string,
+): Promise<TypeScriptTransformer | undefined> => {
+  const isTypeScript = tsExtensions.has(extname(mainFile))
+
+  if (runtimeAPIVersion === 1 && !isTypeScript) {
+    return
+  }
+
+  const format = await getModuleFormat(mainFile, runtimeAPIVersion, repositoryRoot)
+  const aliases = new Map<string, string>()
+  const rewrites = new Map<string, string>()
+  const transformer = {
+    aliases,
+    format,
+    rewrites,
+  }
+
+  if (runtimeAPIVersion === 2) {
+    // For V2 functions, we want to emit a main file with an unambiguous
+    // extension (i.e. `.cjs` or `.mjs`), so that the file is loaded with
+    // the correct format regardless of what is set in `package.json`.
+    const newExtension = format === MODULE_FORMAT.COMMONJS ? MODULE_FILE_EXTENSION.CJS : MODULE_FILE_EXTENSION.MJS
+    const newMainFile = getPathWithExtension(mainFile, newExtension)
+
+    return {
+      ...transformer,
+      bundle: true,
+      bundledPaths: [],
+      newMainFile,
+    }
+  }
+
+  return transformer
+}
+
+interface TranspileTSOptions {
+  bundleLocalImports?: boolean
+  config: FunctionConfig
+  format?: ModuleFormat
+  name: string
+  path: string
+}
+
+export const bundle = async ({ bundleLocalImports = false, config, format, name, path }: TranspileTSOptions) => {
+  // The version of ECMAScript to use as the build target. This will determine
+  // whether certain features are transpiled down or left untransformed.
+  const nodeTarget = getBundlerTarget(config.nodeVersion)
+  const bundleOptions: BuildOptions = {
+    bundle: false,
+  }
+
+  if (bundleLocalImports) {
+    bundleOptions.bundle = true
+    bundleOptions.packages = 'external'
+
+    if (format === MODULE_FORMAT.ESM) {
+      bundleOptions.banner = { js: CJS_SHIM }
+    }
+  }
+
+  try {
+    const transpiled = await build({
+      ...bundleOptions,
+      entryPoints: [path],
+      format,
+      logLevel: 'error',
+      metafile: true,
+      platform: 'node',
+      sourcemap: Boolean(config.nodeSourcemap),
+      target: [nodeTarget],
+      write: false,
+    })
+    const bundledPaths = bundleLocalImports
+      ? Object.keys(transpiled.metafile.inputs).map((inputPath) => resolve(inputPath))
+      : []
+
+    return { bundledPaths, transpiled: transpiled.outputFiles[0].text }
+  } catch (error) {
+    throw FunctionBundlingUserError.addCustomErrorInfo(error, {
+      functionName: name,
+      runtime: RUNTIME.JAVASCRIPT,
+      bundler: NODE_BUNDLER.NFT,
+    })
+  }
+}

--- a/src/runtimes/node/bundlers/nft/index.ts
+++ b/src/runtimes/node/bundlers/nft/index.ts
@@ -1,4 +1,4 @@
-import { basename, dirname, join, normalize, resolve, extname } from 'path'
+import { basename, dirname, join, normalize, resolve } from 'path'
 
 import { nodeFileTrace } from '@vercel/nft'
 import resolveDependency from '@vercel/nft/out/resolve-dependency.js'
@@ -10,13 +10,12 @@ import { cachedReadFile, getPathWithExtension } from '../../../../utils/fs.js'
 import { minimatch } from '../../../../utils/matching.js'
 import { getBasePath } from '../../utils/base_path.js'
 import { filterExcludedPaths, getPathsOfIncludedFiles } from '../../utils/included_files.js'
-import { MODULE_FORMAT, MODULE_FILE_EXTENSION, tsExtensions, ModuleFormat } from '../../utils/module_format.js'
+import { MODULE_FILE_EXTENSION } from '../../utils/module_format.js'
 import { getNodeSupportMatrix } from '../../utils/node_version.js'
-import { getClosestPackageJson } from '../../utils/package_json.js'
 import type { GetSrcFilesFunction, BundleFunction } from '../types.js'
 
+import { bundle as bundleWithEsbuild, getBundler } from './bundler.js'
 import { processESM } from './es_modules.js'
-import { transpileTS } from './transpile.js'
 
 const appearsToBeModuleName = (name: string) => !name.startsWith('.')
 
@@ -90,90 +89,6 @@ const getIgnoreFunction = (config: FunctionConfig) => {
   }
 }
 
-/**
- * Returns the module format that should be used when transpiling a TypeScript
- * file.
- */
-const getTSModuleFormat = async (
-  mainFile: string,
-  runtimeAPIVersion: number,
-  repositoryRoot?: string,
-): Promise<ModuleFormat> => {
-  // TODO: This check should go away. We should always respect the format from
-  // the extension. We'll do this at a later stage, after we roll out the V2
-  // API with no side-effects on V1 functions.
-  if (runtimeAPIVersion === 2) {
-    if (extname(mainFile) === MODULE_FILE_EXTENSION.MTS) {
-      return MODULE_FORMAT.ESM
-    }
-
-    if (extname(mainFile) === MODULE_FILE_EXTENSION.CTS) {
-      return MODULE_FORMAT.COMMONJS
-    }
-  }
-
-  // At this point, we need to infer the module type from the `type` field in
-  // the closest `package.json`.
-  try {
-    const packageJSON = await getClosestPackageJson(dirname(mainFile), repositoryRoot)
-
-    if (packageJSON?.contents.type === 'module') {
-      return MODULE_FORMAT.ESM
-    }
-  } catch {
-    // no-op
-  }
-
-  return MODULE_FORMAT.COMMONJS
-}
-
-type TypeScriptTransformer = {
-  aliases: Map<string, string>
-  bundle?: boolean
-  bundledPaths?: string[]
-  format: ModuleFormat
-  newMainFile?: string
-  rewrites: Map<string, string>
-}
-
-const getTypeScriptTransformer = async (
-  runtimeAPIVersion: number,
-  mainFile: string,
-  repositoryRoot?: string,
-): Promise<TypeScriptTransformer | undefined> => {
-  const isTypeScript = tsExtensions.has(extname(mainFile))
-
-  if (!isTypeScript) {
-    return
-  }
-
-  const format = await getTSModuleFormat(mainFile, runtimeAPIVersion, repositoryRoot)
-  const aliases = new Map<string, string>()
-  const rewrites = new Map<string, string>()
-  const transformer = {
-    aliases,
-    format,
-    rewrites,
-  }
-
-  if (runtimeAPIVersion === 2) {
-    // For V2 functions, we want to emit a main file with an unambiguous
-    // extension (i.e. `.cjs` or `.mjs`), so that the file is loaded with
-    // the correct format regardless of what is set in `package.json`.
-    const newExtension = format === MODULE_FORMAT.COMMONJS ? MODULE_FILE_EXTENSION.CJS : MODULE_FILE_EXTENSION.MJS
-    const newMainFile = getPathWithExtension(mainFile, newExtension)
-
-    return {
-      ...transformer,
-      bundle: true,
-      bundledPaths: [],
-      newMainFile,
-    }
-  }
-
-  return transformer
-}
-
 const traceFilesAndTranspile = async function ({
   basePath,
   cache,
@@ -195,7 +110,7 @@ const traceFilesAndTranspile = async function ({
   repositoryRoot?: string
   runtimeAPIVersion: number
 }) {
-  const tsTransformer = await getTypeScriptTransformer(runtimeAPIVersion, mainFile, repositoryRoot)
+  const bundler = await getBundler(runtimeAPIVersion, mainFile, repositoryRoot)
   const {
     fileList: dependencyPaths,
     esmFileList,
@@ -208,36 +123,33 @@ const traceFilesAndTranspile = async function ({
     ignore: getIgnoreFunction(config),
     readFile: async (path: string) => {
       try {
-        const extension = extname(path)
+        const isMainFile = path === mainFile
 
-        if (tsExtensions.has(extension)) {
-          const { bundledPaths, transpiled } = await transpileTS({
-            bundle: tsTransformer?.bundle,
+        // If there is a bundler defined and this is the main file, we bundle.
+        if (bundler && isMainFile) {
+          const { bundledPaths, transpiled } = await bundleWithEsbuild({
+            bundleLocalImports: bundler?.bundle,
             config,
             name,
-            format: tsTransformer?.format,
+            format: bundler?.format,
             path,
           })
-          const isMainFile = path === mainFile
 
           // If this is the main file, the final path of the compiled file may
           // have been set by the transformer. It's fine to do this, since the
           // only place where this file will be imported from is our entry file
           // and we'll know the right path to use.
-          const newPath =
-            isMainFile && tsTransformer?.newMainFile
-              ? tsTransformer.newMainFile
-              : getPathWithExtension(path, MODULE_FILE_EXTENSION.JS)
+          const newPath = bundler?.newMainFile ?? getPathWithExtension(path, MODULE_FILE_EXTENSION.JS)
 
           // Overriding the contents of the `.ts` file.
-          tsTransformer?.rewrites.set(path, transpiled)
+          bundler?.rewrites.set(path, transpiled)
 
           // Rewriting the `.ts` path to `.js` in the bundle.
-          tsTransformer?.aliases.set(path, newPath)
+          bundler?.aliases.set(path, newPath)
 
           // Registering the input files that were bundled into the transpiled
           // file.
-          tsTransformer?.bundledPaths?.push(...bundledPaths)
+          bundler?.bundledPaths?.push(...bundledPaths)
 
           return transpiled
         }
@@ -270,13 +182,13 @@ const traceFilesAndTranspile = async function ({
   })
   const normalizedTracedPaths = [...dependencyPaths].map((path) => (basePath ? resolve(basePath, path) : resolve(path)))
 
-  if (tsTransformer) {
+  if (bundler) {
     return {
-      aliases: tsTransformer.aliases,
-      bundledPaths: tsTransformer.bundledPaths,
-      mainFile: tsTransformer.newMainFile ?? getPathWithExtension(mainFile, MODULE_FILE_EXTENSION.JS),
-      moduleFormat: tsTransformer.format,
-      rewrites: tsTransformer.rewrites,
+      aliases: bundler.aliases,
+      bundledPaths: bundler.bundledPaths,
+      mainFile: bundler.newMainFile ?? getPathWithExtension(mainFile, MODULE_FILE_EXTENSION.JS),
+      moduleFormat: bundler.format,
+      rewrites: bundler.rewrites,
       tracedPaths: normalizedTracedPaths,
     }
   }

--- a/src/runtimes/node/bundlers/nft/index.ts
+++ b/src/runtimes/node/bundlers/nft/index.ts
@@ -130,7 +130,6 @@ const traceFilesAndTranspile = async function ({
         // between ESM and CJS works) and when we want to transpile TypeScript.
         if (transformer && isMainFile) {
           const { bundledPaths, transpiled } = await transform({
-            bundle: transformer?.bundle,
             config,
             name,
             format: transformer?.format,

--- a/src/runtimes/node/bundlers/nft/transpile.ts
+++ b/src/runtimes/node/bundlers/nft/transpile.ts
@@ -1,12 +1,9 @@
-import { resolve } from 'path'
-
-import { build, BuildOptions } from 'esbuild'
+import { build } from 'esbuild'
 
 import type { FunctionConfig } from '../../../../config.js'
 import { FunctionBundlingUserError } from '../../../../utils/error.js'
 import { RUNTIME } from '../../../runtime.js'
-import { CJS_SHIM } from '../../utils/esm_cjs_compat.js'
-import { ModuleFormat, MODULE_FORMAT } from '../../utils/module_format.js'
+import { MODULE_FORMAT } from '../../utils/module_format.js'
 import { getBundlerTarget } from '../esbuild/bundler_target.js'
 import { NODE_BUNDLER } from '../types.js'
 
@@ -34,55 +31,6 @@ export const transpileESMToCJS = async ({ config, name, path }: TranspileESMToCJ
     })
 
     return transpiled.outputFiles[0].text
-  } catch (error) {
-    throw FunctionBundlingUserError.addCustomErrorInfo(error, {
-      functionName: name,
-      runtime: RUNTIME.JAVASCRIPT,
-      bundler: NODE_BUNDLER.NFT,
-    })
-  }
-}
-
-interface TranspileTSOptions {
-  bundle?: boolean
-  config: FunctionConfig
-  format?: ModuleFormat
-  name: string
-  path: string
-}
-
-export const transpileTS = async ({ bundle = false, config, format, name, path }: TranspileTSOptions) => {
-  // The version of ECMAScript to use as the build target. This will determine
-  // whether certain features are transpiled down or left untransformed.
-  const nodeTarget = getBundlerTarget(config.nodeVersion)
-  const bundleOptions: BuildOptions = {
-    bundle: false,
-  }
-
-  if (bundle) {
-    bundleOptions.bundle = true
-    bundleOptions.packages = 'external'
-
-    if (format === MODULE_FORMAT.ESM) {
-      bundleOptions.banner = { js: CJS_SHIM }
-    }
-  }
-
-  try {
-    const transpiled = await build({
-      ...bundleOptions,
-      entryPoints: [path],
-      format,
-      logLevel: 'error',
-      metafile: true,
-      platform: 'node',
-      sourcemap: Boolean(config.nodeSourcemap),
-      target: [nodeTarget],
-      write: false,
-    })
-    const bundledPaths = bundle ? Object.keys(transpiled.metafile.inputs).map((inputPath) => resolve(inputPath)) : []
-
-    return { bundledPaths, transpiled: transpiled.outputFiles[0].text }
   } catch (error) {
     throw FunctionBundlingUserError.addCustomErrorInfo(error, {
       functionName: name,

--- a/tests/fixtures-esm/v2-api-cjs-modules/function-js.js
+++ b/tests/fixtures-esm/v2-api-cjs-modules/function-js.js
@@ -6,7 +6,7 @@ import { name as helper3 } from './lib/helper3'
 import { name as helper4 } from './lib/helper4.js'
 import { name as helper5 } from './lib/helper5.mjs'
 
-export default async (req: Request) => {
+export default async () => {
   // We're in CJS, so importing a ESM package must use a dynamic import.
   const { default: esm } = await import('esm-module')
 

--- a/tests/fixtures-esm/v2-api-cjs-modules/function-ts.ts
+++ b/tests/fixtures-esm/v2-api-cjs-modules/function-ts.ts
@@ -1,0 +1,14 @@
+import cjs from 'cjs-module'
+
+import { name as helper1 } from './lib/helper1.js'
+import { name as helper2 } from './lib/helper2.js'
+import { name as helper3 } from './lib/helper3.js'
+import { name as helper4 } from './lib/helper4.js'
+import { name as helper5 } from './lib/helper5.mjs'
+
+export default async (req: Request) => {
+  // We're in CJS, so importing a ESM package must use a dynamic import.
+  const { default: esm } = await import('esm-module')
+
+  return Response.json({ cjs, esm, helper1, helper2, helper3, helper4, helper5 })
+}

--- a/tests/fixtures-esm/v2-api-esm-mixed-modules/function-js.js
+++ b/tests/fixtures-esm/v2-api-esm-mixed-modules/function-js.js
@@ -1,0 +1,11 @@
+import cjs from 'cjs-module'
+import esm from 'esm-module'
+
+import { name as helper1 } from './lib/helper1.js'
+import { name as helper2 } from './lib/helper2.js'
+import { name as helper3 } from './lib/helper3.js'
+import { name as helper4 } from './lib/helper4.js'
+import { name as helper5 } from './lib/helper5.mjs'
+import { name as helper6 } from './lib/helper6.js'
+
+export default async () => Response.json({ cjs, esm, helper1, helper2, helper3, helper4, helper5, helper6 })

--- a/tests/fixtures-esm/v2-api-esm-mixed-modules/function-ts.ts
+++ b/tests/fixtures-esm/v2-api-esm-mixed-modules/function-ts.ts
@@ -1,9 +1,9 @@
 import cjs from 'cjs-module'
 import esm from 'esm-module'
 
-import { name as helper1 } from './lib/helper1.ts'
+import { name as helper1 } from './lib/helper1.js'
 import { name as helper2 } from './lib/helper2.js'
-import { name as helper3 } from './lib/helper3'
+import { name as helper3 } from './lib/helper3.js'
 import { name as helper4 } from './lib/helper4.js'
 import { name as helper5 } from './lib/helper5.mjs'
 import { name as helper6 } from './lib/helper6.js'

--- a/tests/v2api.test.ts
+++ b/tests/v2api.test.ts
@@ -143,127 +143,121 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
   )
 
   testMany(
-    'Handles an ESM TypeScript function that imports both CJS and ESM modules',
+    'Handles an ESM function that imports both CJS and ESM modules',
     ['bundler_default', 'bundler_esbuild', 'bundler_esbuild_zisi', 'bundler_default_nft', 'bundler_nft'],
     async (options) => {
       const fixtureName = 'v2-api-esm-mixed-modules'
       const { files, tmpDir } = await zipFixture(fixtureName, {
+        length: 2,
         fixtureDir: FIXTURES_ESM_DIR,
         opts: merge(options, {
           archiveFormat: ARCHIVE_FORMAT.NONE,
         }),
       })
 
-      expect(files.length).toBe(1)
+      for (const entry of files) {
+        expect(entry.bundler).toBe('nft')
+        expect(entry.outputModuleFormat).toBe('esm')
+        expect(entry.entryFilename).toBe('___netlify-entry-point.mjs')
+        expect(entry.runtimeAPIVersion).toBe(2)
 
-      const [entry] = files
+        const expectedInputs = [
+          'package.json',
+          entry.name === 'function-js' ? 'function-js.js' : 'function-ts.ts',
+          'node_modules/cjs-module/package.json',
+          'node_modules/cjs-module/index.js',
+          'node_modules/esm-module/package.json',
+          'node_modules/esm-module/index.js',
+          'node_modules/esm-module/foo.js',
+          'node_modules/cjs-module/foo.js',
+          'lib/helper1.ts',
+          'lib/helper2.ts',
+          'lib/helper3.ts',
+          'lib/helper4.js',
+          'lib/helper5.mjs',
+          'lib/helper6.js',
+        ]
+          .map((relativePath) => resolve(FIXTURES_ESM_DIR, fixtureName, relativePath))
+          .sort()
 
-      expect(entry.bundler).toBe('nft')
-      expect(entry.outputModuleFormat).toBe('esm')
-      expect(entry.entryFilename).toBe('___netlify-entry-point.mjs')
-      expect(entry.runtimeAPIVersion).toBe(2)
+        expect(entry.inputs?.sort()).toEqual(expectedInputs)
 
-      const expectedInputs = [
-        'package.json',
-        'function.ts',
-        'node_modules/cjs-module/package.json',
-        'node_modules/cjs-module/index.js',
-        'node_modules/esm-module/package.json',
-        'node_modules/esm-module/index.js',
-        'node_modules/esm-module/foo.js',
-        'node_modules/cjs-module/foo.js',
-        'lib/helper1.ts',
-        'lib/helper2.ts',
-        'lib/helper3.ts',
-        'lib/helper4.js',
-        'lib/helper5.mjs',
-        'lib/helper6.js',
-      ]
+        const [{ name: archive, entryFilename }] = files
 
-      for (const relativePath of expectedInputs) {
-        const absolutePath = resolve(FIXTURES_ESM_DIR, fixtureName, relativePath)
+        const func = await importFunctionFile(`${tmpDir}/${archive}/${entryFilename}`)
+        const { body: bodyStream, statusCode } = await invokeLambda(func)
+        const body = await readAsBuffer(bodyStream)
 
-        expect(entry.inputs?.includes(absolutePath)).toBeTruthy()
+        expect(JSON.parse(body)).toEqual({
+          cjs: { foo: '🌭', type: 'cjs' },
+          esm: { foo: '🌭', type: 'esm' },
+          helper1: 'helper1',
+          helper2: 'helper2',
+          helper3: 'helper3',
+          helper4: 'helper4',
+          helper5: 'helper5',
+        })
+        expect(statusCode).toBe(200)
       }
-
-      const [{ name: archive, entryFilename }] = files
-
-      const func = await importFunctionFile(`${tmpDir}/${archive}/${entryFilename}`)
-      const { body: bodyStream, statusCode } = await invokeLambda(func)
-      const body = await readAsBuffer(bodyStream)
-
-      expect(JSON.parse(body)).toEqual({
-        cjs: { foo: '🌭', type: 'cjs' },
-        esm: { foo: '🌭', type: 'esm' },
-        helper1: 'helper1',
-        helper2: 'helper2',
-        helper3: 'helper3',
-        helper4: 'helper4',
-        helper5: 'helper5',
-      })
-      expect(statusCode).toBe(200)
     },
   )
 
   testMany(
-    'Handles a CJS TypeScript function that imports CJS modules',
+    'Handles a CJS function that imports CJS and ESM modules',
     ['bundler_default', 'bundler_esbuild', 'bundler_esbuild_zisi', 'bundler_default_nft', 'bundler_nft'],
     async (options) => {
       const fixtureName = 'v2-api-cjs-modules'
       const { files, tmpDir } = await zipFixture(fixtureName, {
+        length: 2,
         fixtureDir: FIXTURES_ESM_DIR,
         opts: merge(options, {
           archiveFormat: ARCHIVE_FORMAT.NONE,
         }),
       })
 
-      expect(files.length).toBe(1)
+      for (const entry of files) {
+        expect(entry.bundler).toBe('nft')
+        expect(entry.outputModuleFormat).toBe('cjs')
+        expect(entry.entryFilename).toBe('___netlify-entry-point.mjs')
+        expect(entry.runtimeAPIVersion).toBe(2)
 
-      const [entry] = files
+        const expectedInputs = [
+          'package.json',
+          entry.name === 'function-ts' ? 'function-ts.ts' : 'function-js.js',
+          'node_modules/cjs-module/package.json',
+          'node_modules/cjs-module/index.js',
+          'node_modules/esm-module/package.json',
+          'node_modules/esm-module/index.js',
+          'node_modules/esm-module/foo.js',
+          'node_modules/cjs-module/foo.js',
+          'lib/helper1.ts',
+          'lib/helper2.ts',
+          'lib/helper3.ts',
+          'lib/helper4.js',
+          'lib/helper5.mjs',
+        ]
+          .map((relativePath) => resolve(FIXTURES_ESM_DIR, fixtureName, relativePath))
+          .sort()
 
-      expect(entry.bundler).toBe('nft')
-      expect(entry.outputModuleFormat).toBe('cjs')
-      expect(entry.entryFilename).toBe('___netlify-entry-point.mjs')
-      expect(entry.runtimeAPIVersion).toBe(2)
+        expect(entry.inputs?.sort()).toEqual(expectedInputs)
 
-      const expectedInputs = [
-        'package.json',
-        'function.ts',
-        'node_modules/cjs-module/package.json',
-        'node_modules/cjs-module/index.js',
-        'node_modules/esm-module/package.json',
-        'node_modules/esm-module/index.js',
-        'node_modules/esm-module/foo.js',
-        'node_modules/cjs-module/foo.js',
-        'lib/helper1.ts',
-        'lib/helper2.ts',
-        'lib/helper3.ts',
-        'lib/helper4.js',
-        'lib/helper5.mjs',
-      ]
+        const [{ name: archive, entryFilename }] = files
 
-      for (const relativePath of expectedInputs) {
-        const absolutePath = resolve(FIXTURES_ESM_DIR, fixtureName, relativePath)
+        const func = await importFunctionFile(`${tmpDir}/${archive}/${entryFilename}`)
+        const { body: bodyStream, statusCode } = await invokeLambda(func)
+        const body = await readAsBuffer(bodyStream)
 
-        expect(entry.inputs?.includes(absolutePath)).toBeTruthy()
+        expect(JSON.parse(body)).toEqual({
+          cjs: { foo: '🌭', type: 'cjs' },
+          esm: { foo: '🌭', type: 'esm' },
+          helper1: 'helper1',
+          helper2: 'helper2',
+          helper3: 'helper3',
+          helper4: 'helper4',
+          helper5: 'helper5',
+        })
+        expect(statusCode).toBe(200)
       }
-
-      const [{ name: archive, entryFilename }] = files
-
-      const func = await importFunctionFile(`${tmpDir}/${archive}/${entryFilename}`)
-      const { body: bodyStream, statusCode } = await invokeLambda(func)
-      const body = await readAsBuffer(bodyStream)
-
-      expect(JSON.parse(body)).toEqual({
-        cjs: { foo: '🌭', type: 'cjs' },
-        esm: { foo: '🌭', type: 'esm' },
-        helper1: 'helper1',
-        helper2: 'helper2',
-        helper3: 'helper3',
-        helper4: 'helper4',
-        helper5: 'helper5',
-      })
-      expect(statusCode).toBe(200)
     },
   )
 

--- a/tests/v2api.test.ts
+++ b/tests/v2api.test.ts
@@ -35,7 +35,7 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
 
       for (const entry of files) {
         expect(entry.bundler).toBe('nft')
-        expect(entry.outputModuleFormat).toBe('cjs')
+        expect(entry.outputModuleFormat).toBe('esm')
         expect(entry.entryFilename).toBe('___netlify-entry-point.mjs')
         expect(entry.runtimeAPIVersion).toBe(2)
       }
@@ -93,7 +93,7 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
 
       for (const entry of files) {
         expect(entry.bundler).toBe('nft')
-        expect(entry.outputModuleFormat).toBe('cjs')
+        expect(entry.outputModuleFormat).toBe('esm')
         expect(entry.entryFilename).toBe('___netlify-entry-point.mjs')
         expect(entry.runtimeAPIVersion).toBe(2)
       }


### PR DESCRIPTION
#### Summary

I realised that we were only transforming V2 functions (i.e. running them through esbuild) when the extension was a TypeScript extension. But we should also do it for JavaScript functions, since bundling local imports is essential to ensure imports between ESM and CJS work as expected.

I ended up renaming the "TS transformer" to a generic transformer, and I moved it into its own file.