### PR TITLE
fix: output `provided.al2` also when zipGo is disabled

### DIFF
--- a/src/runtimes/go/index.ts
+++ b/src/runtimes/go/index.ts
@@ -134,6 +134,8 @@ const zipFunction: ZipFunction = async function ({
     }
   }
 
+  const runtimeVersion = featureFlags.zisi_golang_use_al2 ? 'provided.al2' : undefined;
+
   // If `zipGo` is enabled, we create a zip archive with the Go binary and the
   // toolchain file.
   if (config.zipGo) {
@@ -150,7 +152,7 @@ const zipFunction: ZipFunction = async function ({
       config,
       path: zipPath,
       entryFilename: zipOptions.filename,
-      runtimeVersion: featureFlags.zisi_golang_use_al2 ? 'provided.al2' : undefined,
+      runtimeVersion,
     }
   }
 
@@ -167,6 +169,7 @@ const zipFunction: ZipFunction = async function ({
     entryFilename: '',
     displayName: config?.name,
     generator: config?.generator || getInternalValue(isInternal),
+    runtimeVersion,
   }
 }
 

--- a/src/runtimes/go/index.ts
+++ b/src/runtimes/go/index.ts
@@ -134,7 +134,12 @@ const zipFunction: ZipFunction = async function ({
     }
   }
 
-  const runtimeVersion = featureFlags.zisi_golang_use_al2 ? 'provided.al2' : undefined;
+  const result = {
+    config,
+    displayName: config?.name,
+    generator: config?.generator || getInternalValue(isInternal),
+    runtimeVersion: featureFlags.zisi_golang_use_al2 ? 'provided.al2' : undefined,
+  }
 
   // If `zipGo` is enabled, we create a zip archive with the Go binary and the
   // toolchain file.
@@ -149,10 +154,9 @@ const zipFunction: ZipFunction = async function ({
     await zipBinary({ ...zipOptions, srcPath: binary.path, stat: binary.stat })
 
     return {
-      config,
+      ...result,
       path: zipPath,
       entryFilename: zipOptions.filename,
-      runtimeVersion,
     }
   }
 
@@ -164,12 +168,9 @@ const zipFunction: ZipFunction = async function ({
   }
 
   return {
-    config,
+    ...result,
     path: destPath,
     entryFilename: '',
-    displayName: config?.name,
-    generator: config?.generator || getInternalValue(isInternal),
-    runtimeVersion,
   }
 }
 


### PR DESCRIPTION
We were only emitting `runtimeVersion: "provided.al2"` when `zipGo` is enabled. In Buildbot deploys, this is disabled, so we weren't emitting `provided.al2` properly! This PR fixes that.

I also noticed we weren't emitting `generator` and `runtimeVersion` when `zipGo` is enabled. I don't think that's intended, so I changed it as well.