### PR TITLE
fix: fixes an issue where createDirectory created a different structure than createZip

### DIFF
--- a/src/runtimes/node/utils/zip.ts
+++ b/src/runtimes/node/utils/zip.ts
@@ -78,13 +78,29 @@ const createDirectory = async function ({
   runtimeAPIVersion,
   srcFiles,
 }: ZipNodeParameters) {
+  // There is a naming conflict with the entry file if one of the supporting
+  // files (i.e. not the main file) has the path that the entry file needs to
+  // take.
+  const hasEntryFileConflict = conflictsWithEntryFile(srcFiles, {
+    basePath,
+    extension,
+    featureFlags,
+    filename,
+    mainFile,
+    runtimeAPIVersion,
+  })
+
+  // If there is a naming conflict, we move all user files (everything other
+  // than the entry file) to its own sub-directory.
+  const userNamespace = hasEntryFileConflict ? DEFAULT_USER_SUBDIRECTORY : ''
+
   const { contents: entryContents, filename: entryFilename } = getEntryFile({
     commonPrefix: basePath,
     featureFlags,
     filename,
     mainFile,
     moduleFormat,
-    userNamespace: DEFAULT_USER_SUBDIRECTORY,
+    userNamespace,
     runtimeAPIVersion,
   })
   const functionFolder = join(destFolder, basename(filename, extension))
@@ -108,7 +124,7 @@ const createDirectory = async function ({
       const normalizedDestPath = normalizeFilePath({
         commonPrefix: basePath,
         path: destPath,
-        userNamespace: DEFAULT_USER_SUBDIRECTORY,
+        userNamespace,
       })
       const absoluteDestPath = join(functionFolder, normalizedDestPath)
 

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -2302,8 +2302,7 @@ describe('zip-it-and-ship-it', () => {
 
       expect.fail()
     } catch (error) {
-      const filePath = join('src', 'tests', 'fixtures', fixtureName, 'function.js')
-
+      const filePath = join('tests', 'fixtures', fixtureName, 'function.js')
       // Asserts that the line/column of the error match the position of the
       // original source file, not the transpiled one.
       expect(error.stack).toMatch(`${filePath}:2:9`)


### PR DESCRIPTION

🎉 Thanks for submitting a pull request! 🎉

#### Summary

Fixes an issue where on directory mode there was always a `src` folder (which breaks nextjs) and in zip mode there was no `src` folder. Now it uses the same deterministic for creating a src folder in both implementations. Just copied it over for now :)

Currently blocking the next runtime tests

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/zip-it-and-ship-it/issues/new/choose) before writing your code 🧑‍💻.
      This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing
      a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
