### PR TITLE
feat: add `preferStatic` to ISC

### DIFF
--- a/src/runtimes/node/in_source_config/index.ts
+++ b/src/runtimes/node/in_source_config/index.ts
@@ -131,7 +131,12 @@ export const parseSource = (
       result.methods = normalizeMethods(configExport.method, functionName)
     }
 
-    result.routes = getRoutes(configExport.path, functionName, result.methods ?? [])
+    result.routes = getRoutes({
+      functionName,
+      methods: result.methods ?? [],
+      path: configExport.path,
+      preferStatic: configExport.preferStatic === true,
+    })
 
     return result
   }

--- a/tests/unit/runtimes/node/in_source_config.test.ts
+++ b/tests/unit/runtimes/node/in_source_config.test.ts
@@ -593,4 +593,68 @@ describe('V2 API', () => {
       expect(routes).toEqual([{ pattern: '/products', literal: '/products', methods: [] }])
     })
   })
+
+  describe('`preferStatic` property', () => {
+    test('Sets a `prefer_static` property on a single route', () => {
+      const source = `export default async () => {
+        return new Response("Hello!")
+      }
+  
+      export const config = {
+        path: "/products",
+        preferStatic: true
+      }`
+
+      const { routes } = parseSource(source, options)
+
+      expect(routes).toEqual([{ pattern: '/products', literal: '/products', methods: [], prefer_static: true }])
+    })
+
+    test('Sets a `prefer_static` property on all routes', () => {
+      const source = `export default async () => {
+        return new Response("Hello!")
+      }
+  
+      export const config = {
+        path: ["/items", "/products"],
+        preferStatic: true
+      }`
+
+      const { routes } = parseSource(source, options)
+
+      expect(routes).toEqual([
+        { pattern: '/items', literal: '/items', methods: [], prefer_static: true },
+        { pattern: '/products', literal: '/products', methods: [], prefer_static: true },
+      ])
+    })
+
+    test('Does not set a `prefer_static` property if `preferStatic` is not a boolean', () => {
+      const source = `export default async () => {
+        return new Response("Hello!")
+      }
+  
+      export const config = {
+        path: "/products",
+        preferStatic: "yep"
+      }`
+
+      const { routes } = parseSource(source, options)
+
+      expect(routes).toEqual([{ pattern: '/products', literal: '/products', methods: [] }])
+    })
+
+    test('Does not set a `prefer_static` property if `preferStatic` is not set', () => {
+      const source = `export default async () => {
+        return new Response("Hello!")
+      }
+  
+      export const config = {
+        path: "/products"
+      }`
+
+      const { routes } = parseSource(source, options)
+
+      expect(routes).toEqual([{ pattern: '/products', literal: '/products', methods: [] }])
+    })
+  })
 })


### PR DESCRIPTION
#### Summary

Adds a `preferStatic` property to the in-source configuration that lets developers configure the file shadowing behaviour on a per-function basis.

Part of https://linear.app/netlify/issue/COM-32/functions-v2-inline-config-does-not-respect-cdn-shadowing.