### PR TITLE
fix(exports parser): handle `as default` export

### DIFF
--- a/src/runtimes/node/parser/exports.ts
+++ b/src/runtimes/node/parser/exports.ts
@@ -45,6 +45,15 @@ export const traverseNodes = (nodes: Statement[], getAllBindings: BindingMethod)
       configExport = esmConfigExports[0].object
     }
 
+    if (node.type === 'ExportNamedDeclaration') {
+        for (const exportSpecifier of node.specifiers) {
+            if (exportSpecifier.exported.name === 'default') {
+                hasDefaultExport = true;
+                return;
+            }
+        }    
+    }
+
     if (esmHandlerExports.length !== 0) {
       if (esmHandlerExports.some(({ type }) => type === 'default')) {
         hasDefaultExport = true


### PR DESCRIPTION
#### Summary

- Unblocks https://github.com/withastro/adapters/pull/31
- The parser failed to detect the following as a default export.
<img width="400" alt="image" src="https://github.com/netlify/zip-it-and-ship-it/assets/69170106/c2b9e65d-913b-429e-8c37-568caf41bf3c">

- This resulted in `runtimeAPIVersion` failing to be correctly detected as v2 [here](https://github.com/netlify/zip-it-and-ship-it/blob/b8a39b643d2c6101a20683e1a6823e1da188bf5a/src/runtimes/node/index.ts#L65)
- And an incorrect version being picked by the builder [here](https://github.com/netlify/cli/blob/main/src/lib/functions/runtimes/js/builders/zisi.mts#L74)
- The CLI then goes on to deploy critically misbehaving functions, like in [this case](https://655979f55ad363609619075c--bespoke-gumdrop-44a21e.netlify.app/)
<img width="400" alt="image" src="https://github.com/netlify/zip-it-and-ship-it/assets/69170106/c7c405d5-fe86-4e21-8baf-ee0674d475db">

The implementation may be done better, I don't have the full context of the codebase. Feel free to improve upon it.