### PR TITLE
fix: parse minified boolean

### DIFF
--- a/src/runtimes/node/parser/exports.ts
+++ b/src/runtimes/node/parser/exports.ts
@@ -245,6 +245,12 @@ const parsePrimitive = (exp: Expression | PatternLike): PrimitiveResult => {
   if (exp.type === 'NullLiteral') {
     return null
   }
+
+  // special case: minifiers like to transform `true` to `!0` and `false` to `!1`.
+  // because this can be hard to turn off for some frameworks, we have a special case.
+  if (exp.type === 'UnaryExpression' && exp.operator === '!' && exp.argument.type === 'NumericLiteral') {
+    return !exp.argument.value
+  }
 }
 
 /**

--- a/tests/unit/runtimes/node/in_source_config.test.ts
+++ b/tests/unit/runtimes/node/in_source_config.test.ts
@@ -692,5 +692,20 @@ describe('V2 API', () => {
 
       expect(routes).toEqual([{ pattern: '/products', literal: '/products', methods: [] }])
     })
+
+    test('Understands minfied true', () => {
+      const source = `export default async () => {
+        return new Response("Hello!")
+      }
+  
+      export const config = {
+        path: "/products",
+        preferStatic: !0
+      }`
+
+      const { routes } = parseSource(source, options)
+
+      expect(routes).toEqual([{ pattern: '/products', literal: '/products', methods: [], prefer_static: true }])
+    })
   })
 })


### PR DESCRIPTION
Some Frameworks, like Remix, use ESBuild under the hood and don't allow changing its settings. In the case of Remix, it performs some sort of minification on the server code that transforms boolean literals into `!0` and `!1`. This PR teaches ZISI how to interpret those.