### PR TITLE
fix: integration test needs to use run.js instead of run.mjs

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -58,7 +58,7 @@ jobs:
         working-directory: zip-it-and-ship-it
       - name: Building and deploying site
         run:
-          $GITHUB_WORKSPACE/netlify-cli/bin/run.mjs deploy --build --json --site ${{ secrets.NETLIFY_SITE_ID }} --auth
+          $GITHUB_WORKSPACE/netlify-cli/bin/run.js deploy --build --json --site ${{ secrets.NETLIFY_SITE_ID }} --auth
           ${{ secrets.NETLIFY_TOKEN }} --cwd demos/default --functions .netlify/functions > .netlify-deploy-log.json
         working-directory: test-site
       - name: Parsing deploy result


### PR DESCRIPTION
With https://github.com/netlify/cli/commit/5eb2133a277191c68e6d2129f0ebe6d5d85a9402, the CLI changed the file format of `run.mjs` to `run.js`. Gotta move our test along!