### PR TITLE
fix: drop runtimeVersion override for go functions

### DIFF
--- a/src/feature_flags.ts
+++ b/src/feature_flags.ts
@@ -26,6 +26,9 @@ export const defaultFlags = {
 
   // If multiple glob stars are in includedFiles, fail the build instead of warning.
   zisi_esbuild_fail_double_glob: false,
+
+  // drops the "runtimeVersion" override field
+  zisi_go_drop_runtime_override: false,
 } as const
 
 export type FeatureFlags = Partial<Record<keyof typeof defaultFlags, boolean>>

--- a/src/runtimes/go/index.ts
+++ b/src/runtimes/go/index.ts
@@ -113,6 +113,7 @@ const zipFunction: ZipFunction = async function ({
   srcPath,
   stat,
   isInternal,
+  featureFlags,
 }) {
   const destPath = join(destFolder, filename)
   const isSource = extname(mainFile) === '.go'
@@ -137,7 +138,7 @@ const zipFunction: ZipFunction = async function ({
     config,
     displayName: config?.name,
     generator: config?.generator || getInternalValue(isInternal),
-    runtimeVersion: 'provided.al2',
+    runtimeVersion: featureFlags.zisi_go_drop_runtime_override ? undefined : 'provided.al2',
   }
 
   // If `zipGo` is enabled, we create a zip archive with the Go binary and the

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -1791,6 +1791,9 @@ describe('zip-it-and-ship-it', () => {
             zipGo: true,
           },
         },
+        featureFlags: {
+          zisi_go_drop_runtime_override: true,
+        },
       },
     })
     const binaryPath = join(FIXTURES_DIR, fixtureName, 'test')
@@ -1803,7 +1806,7 @@ describe('zip-it-and-ship-it', () => {
 
     const manifest = JSON.parse(await readFile(manifestPath, 'utf-8'))
 
-    expect(manifest.functions[0].runtimeVersion).toEqual('provided.al2')
+    expect(manifest.functions[0].runtimeVersion).toBeUndefined()
 
     const unzippedFunctions = await unzipFiles([func])
     const unzippedBinaryPath = join(unzippedFunctions[0].unzipPath, 'bootstrap')


### PR DESCRIPTION
Part of https://github.com/netlify/pod-dev-foundations/issues/581. `provided.al2` is the default runtime for Go functions now, so we don't need the override here anymore. Put the change behind a flag, so we can rollout gradually.