### PR TITLE
feat: add `priority` field to manifest

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -19,6 +19,7 @@ interface ManifestFunction {
   displayName?: string
   bundler?: string
   generator?: string
+  priority?: number
 }
 
 export interface Manifest {
@@ -53,6 +54,7 @@ const formatFunctionForManifest = ({
   mainFile,
   name,
   path,
+  priority,
   routes,
   runtime,
   runtimeVersion,
@@ -67,6 +69,7 @@ const formatFunctionForManifest = ({
     buildData: { runtimeAPIVersion },
     mainFile,
     name,
+    priority,
     runtimeVersion,
     path: resolve(path),
     runtime,

--- a/src/priority.ts
+++ b/src/priority.ts
@@ -1,0 +1,4 @@
+export enum Priority {
+  GeneratedFunction = 0,
+  UserFunction = 10,
+}

--- a/src/runtimes/node/index.ts
+++ b/src/runtimes/node/index.ts
@@ -3,6 +3,7 @@ import { extname, join } from 'path'
 import { copyFile } from 'cp-file'
 
 import { INVOCATION_MODE } from '../../function.js'
+import { Priority } from '../../priority.js'
 import getInternalValue from '../../utils/get_internal_value.js'
 import { GetSrcFilesFunction, Runtime, RUNTIME, ZipFunction } from '../runtime.js'
 
@@ -142,6 +143,7 @@ const zipFunction: ZipFunction = async function ({
 
   const outputModuleFormat =
     extname(finalMainFile) === MODULE_FILE_EXTENSION.MJS ? MODULE_FORMAT.ESM : MODULE_FORMAT.COMMONJS
+  const priority = isInternal ? Priority.GeneratedFunction : Priority.UserFunction
 
   return {
     bundler: bundlerName,
@@ -157,6 +159,7 @@ const zipFunction: ZipFunction = async function ({
     outputModuleFormat,
     nativeNodeModules,
     path: zipPath.path,
+    priority,
     runtimeVersion:
       runtimeAPIVersion === 2 ? getNodeRuntimeForV2(config.nodeVersion) : getNodeRuntime(config.nodeVersion),
   }

--- a/src/runtimes/runtime.ts
+++ b/src/runtimes/runtime.ts
@@ -53,6 +53,7 @@ export interface ZipFunctionResult {
   outputModuleFormat?: ModuleFormat
   nativeNodeModules?: object
   path: string
+  priority?: number
   runtimeVersion?: string
   staticAnalysisResult?: StaticAnalysisResult
   entryFilename: string

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -2889,12 +2889,12 @@ test('Adds a `priority` field to the generated manifest file', async () => {
   expect(manifest.system.platform).toBe(platform)
   expect(manifest.timestamp).toBeTypeOf('number')
 
-  const userFunction1 = manifest.function.find((fn) => fn.name === 'function_user')
+  const userFunction1 = manifest.functions.find((fn) => fn.name === 'function_user')
   expect(userFunction1.priority).toBe(10)
 
-  const userFunction2 = manifest.function.find((fn) => fn.name === 'function')
+  const userFunction2 = manifest.functions.find((fn) => fn.name === 'function')
   expect(userFunction2.priority).toBe(10)
 
-  const generatedFunction1 = manifest.function.find((fn) => fn.name === 'function_internal')
+  const generatedFunction1 = manifest.functions.find((fn) => fn.name === 'function_internal')
   expect(generatedFunction1.priority).toBe(0)
 })

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -2864,3 +2864,37 @@ describe('zip-it-and-ship-it', () => {
     expect(duplicates).toHaveLength(0)
   })
 })
+
+test('Adds a `priority` field to the generated manifest file', async () => {
+  const { path: tmpDir } = await getTmpDir({ prefix: 'zip-it-test' })
+  const fixtureName = 'multiple-src-directories'
+  const manifestPath = join(tmpDir, 'manifest.json')
+  const paths = {
+    generated: `${fixtureName}/.netlify/internal-functions`,
+    user: `${fixtureName}/netlify/functions`,
+  }
+
+  await zipNode([paths.generated, paths.user], {
+    length: 3,
+    opts: {
+      internalSrcFolder: join(FIXTURES_DIR, paths.generated),
+      manifest: manifestPath,
+    },
+  })
+
+  const manifest = JSON.parse(await readFile(manifestPath, 'utf-8'))
+
+  expect(manifest.version).toBe(1)
+  expect(manifest.system.arch).toBe(arch)
+  expect(manifest.system.platform).toBe(platform)
+  expect(manifest.timestamp).toBeTypeOf('number')
+
+  const userFunction1 = manifest.function.find((fn) => fn.name === 'function_user')
+  expect(userFunction1.priority).toBe(10)
+
+  const userFunction2 = manifest.function.find((fn) => fn.name === 'function')
+  expect(userFunction2.priority).toBe(10)
+
+  const generatedFunction1 = manifest.function.find((fn) => fn.name === 'function_internal')
+  expect(generatedFunction1.priority).toBe(0)
+})


### PR DESCRIPTION
#### Summary

Adds a `priority` field to the functions manifest file based on whether it was generated by an integration or authored by a user.

Part of COM-327.