### PR TITLE
fix: create symlink parent directory before creating symlink itself

### DIFF
--- a/tests/fixtures-esm/symlinked-bin/function.ts
+++ b/tests/fixtures-esm/symlinked-bin/function.ts
@@ -1,0 +1,1 @@
+export default () => console.log('hello world')

--- a/tests/fixtures-esm/symlinked-bin/subproject/node_modules/.bin/cli.js
+++ b/tests/fixtures-esm/symlinked-bin/subproject/node_modules/.bin/cli.js
@@ -1,0 +1,1 @@
+../tool/cli.js

--- a/tests/fixtures-esm/symlinked-bin/subproject/node_modules/tool/cli.js
+++ b/tests/fixtures-esm/symlinked-bin/subproject/node_modules/tool/cli.js
@@ -1,0 +1,1 @@
+console.log("hello world, this is a useful tool speaking")

--- a/tests/symlinked_included_files.test.ts
+++ b/tests/symlinked_included_files.test.ts
@@ -17,7 +17,7 @@ const readDirWithType = async (dir: string, readFiles?: Record<string, boolean>,
 
   for (const dirent of dirents) {
     if (dirent.isDirectory()) {
-      await readDirWithType(join(dir, dirent.name), files, dirent.name)
+      await readDirWithType(join(dir, dirent.name), files, join(parent, dirent.name))
     } else {
       files[join(parent, dirent.name)] = dirent.isSymbolicLink()
     }
@@ -34,7 +34,7 @@ test.skipIf(platform() === 'win32')('Symlinked directories from `includedFiles` 
   // assert on the source files
   expect(await readDirWithType(basePath)).toEqual({
     'function.mjs': false,
-    [join('crazy-dep/package.json')]: false,
+    [join('node_modules/.pnpm/crazy-dep/package.json')]: false,
     [join('node_modules/crazy-dep')]: true,
   })
 
@@ -63,7 +63,7 @@ test.skipIf(platform() === 'win32')('Symlinked directories from `includedFiles` 
     '___netlify-bootstrap.mjs': false,
     '___netlify-entry-point.mjs': false,
     'function.mjs': false,
-    [join('crazy-dep/package.json')]: false,
+    [join('node_modules/.pnpm/crazy-dep/package.json')]: false,
     [join('node_modules/crazy-dep')]: true,
   })
 })


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Fixes https://github.com/netlify/cli/issues/6106, https://linear.app/netlify/issue/COM-351/esm-dependencies-in-v2-functions-in-pnpm-repo-cause-crash-in-dev.

For `includedFiles`, we're recreating symlinks, sometimes in nested paths. Sometimes this breaks because the target directory doesn't exist. This PR fixes that by ensuring that a symlinks containing directory is created before the symlink itself is created.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/zip-it-and-ship-it/issues/new/choose) before writing your code 🧑‍💻.
      This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing
      a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
