### PR TITLE
feat: stop logging V2 function detection

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,6 @@ import { ModuleFormat } from './runtimes/node/utils/module_format.js'
 import { GetSrcFilesFunction, RuntimeName, RUNTIME } from './runtimes/runtime.js'
 import { RuntimeCache } from './utils/cache.js'
 import { listFunctionsDirectories, resolveFunctionsDirectories } from './utils/fs.js'
-import { getLogger } from './utils/logger.js'
 
 export { Config, FunctionConfig } from './config.js'
 export { zipFunction, zipFunctions, ZipFunctionOptions, ZipFunctionsOptions } from './zip.js'
@@ -54,7 +53,6 @@ const augmentWithStaticAnalysis = async (func: FunctionSource): Promise<Augmente
 
   const staticAnalysisResult = await parseFile(func.mainFile, {
     functionName: func.name,
-    logger: getLogger(),
   })
 
   return { ...func, staticAnalysisResult }

--- a/src/runtimes/node/in_source_config/index.ts
+++ b/src/runtimes/node/in_source_config/index.ts
@@ -2,7 +2,6 @@ import type { ArgumentPlaceholder, Expression, SpreadElement, JSXNamespacedName 
 
 import { InvocationMode, INVOCATION_MODE } from '../../../function.js'
 import { FunctionBundlingUserError } from '../../../utils/error.js'
-import { Logger } from '../../../utils/logger.js'
 import { nonNullable } from '../../../utils/non_nullable.js'
 import { getRoutes, Route } from '../../../utils/routes.js'
 import { RUNTIME } from '../../runtime.js'
@@ -31,7 +30,6 @@ export interface StaticAnalysisResult extends ISCValues {
 
 interface FindISCDeclarationsOptions {
   functionName: string
-  logger: Logger
 }
 
 const validateScheduleFunction = (functionFound: boolean, scheduleFound: boolean, functionName: string): void => {
@@ -79,7 +77,7 @@ const normalizeMethods = (input: unknown, name: string): string[] | undefined =>
  */
 export const parseFile = async (
   sourcePath: string,
-  { functionName, logger }: FindISCDeclarationsOptions,
+  { functionName }: FindISCDeclarationsOptions,
 ): Promise<StaticAnalysisResult> => {
   const source = await safelyReadSource(sourcePath)
 
@@ -87,7 +85,7 @@ export const parseFile = async (
     return {}
   }
 
-  return parseSource(source, { functionName, logger })
+  return parseSource(source, { functionName })
 }
 
 /**
@@ -95,10 +93,7 @@ export const parseFile = async (
  * series of data points, such as in-source configuration properties and
  * other metadata.
  */
-export const parseSource = (
-  source: string,
-  { functionName, logger }: FindISCDeclarationsOptions,
-): StaticAnalysisResult => {
+export const parseSource = (source: string, { functionName }: FindISCDeclarationsOptions): StaticAnalysisResult => {
   const ast = safelyParseSource(source)
 
   if (ast === null) {
@@ -120,8 +115,6 @@ export const parseSource = (
       inputModuleFormat,
       runtimeAPIVersion: 2,
     }
-
-    logger.system('detected v2 function')
 
     if (typeof configExport.schedule === 'string') {
       result.schedule = configExport.schedule

--- a/src/runtimes/node/index.ts
+++ b/src/runtimes/node/index.ts
@@ -62,7 +62,7 @@ const zipFunction: ZipFunction = async function ({
     return { config, path: destPath, entryFilename: '' }
   }
 
-  const staticAnalysisResult = await parseFile(mainFile, { functionName: name, logger })
+  const staticAnalysisResult = await parseFile(mainFile, { functionName: name })
   const runtimeAPIVersion = staticAnalysisResult.runtimeAPIVersion === 2 ? 2 : 1
 
   const pluginsModulesPath = await getPluginsModulesPath(srcDir)

--- a/tests/unit/runtimes/node/in_source_config.test.ts
+++ b/tests/unit/runtimes/node/in_source_config.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from 'vitest'
+import { describe, expect, test } from 'vitest'
 
 import { parseSource } from '../../../../src/runtimes/node/in_source_config/index.js'
 import { getLogger } from '../../../../src/utils/logger.js'
@@ -126,13 +126,8 @@ describe('V2 API', () => {
       const source = `export default async () => {
         return new Response("Hello!")
       }`
+      const isc = parseSource(source, { ...options })
 
-      const systemLog = vi.fn()
-
-      const isc = parseSource(source, { ...options, logger: getLogger(systemLog) })
-
-      expect(systemLog).toHaveBeenCalledOnce()
-      expect(systemLog).toHaveBeenCalledWith('detected v2 function')
       expect(isc).toEqual({ inputModuleFormat: 'esm', routes: [], runtimeAPIVersion: 2 })
     })
 

--- a/tests/v2api.test.ts
+++ b/tests/v2api.test.ts
@@ -372,20 +372,6 @@ describe.runIf(semver.gte(nodeVersion, '18.13.0'))('V2 functions API', () => {
     expect(files[0].runtimeVersion).toBeUndefined()
   })
 
-  test('Logs to systemlog', async () => {
-    const systemLog = vi.fn()
-
-    await zipFixture('v2-api', {
-      fixtureDir: FIXTURES_ESM_DIR,
-      opts: {
-        systemLog,
-      },
-    })
-
-    expect(systemLog).toHaveBeenCalledOnce()
-    expect(systemLog).toHaveBeenCalledWith('detected v2 function')
-  })
-
   test('Does not log to systemlog for v1', async () => {
     const systemLog = vi.fn()
 

--- a/tests/zip_function.test.ts
+++ b/tests/zip_function.test.ts
@@ -188,19 +188,6 @@ describe('zipFunction', () => {
       expect(result.entryFilename).toEqual('___netlify-entry-point.mjs')
     })
 
-    test('Logs to systemlog', async () => {
-      const { path: tmpDir } = await getTmpDir({ prefix: 'zip-it-test' })
-      const mainFile = join(FIXTURES_ESM_DIR, 'v2-api', 'function.js')
-      const systemLog = vi.fn()
-
-      await zipFunction(mainFile, tmpDir, {
-        systemLog,
-      })
-
-      expect(systemLog).toHaveBeenCalledOnce()
-      expect(systemLog).toHaveBeenCalledWith('detected v2 function')
-    })
-
     test('Does not log to systemlog for v1', async () => {
       const { path: tmpDir } = await getTmpDir({ prefix: 'zip-it-test' })
       const mainFile = join(FIXTURES_DIR, 'simple', 'function.js')


### PR DESCRIPTION
#### Summary

Cleaning up a system log line that I don't think is useful anymore, since the V2 detection mechanism has been proven to work and we have other ways of identifying the runtime version of a given function.